### PR TITLE
force a redraw to work around issue #23

### DIFF
--- a/GM/GmDoc.cpp
+++ b/GM/GmDoc.cpp
@@ -293,6 +293,8 @@ BOOL CGamDoc::CreateNewFrame(CDocTemplate* pTemplate, LPCSTR pszTitle,
     pNewFrame->SetWindowText(str);
     m_lpvCreateParam = lpvCreateParam;
     pTemplate->InitialUpdateFrame(pNewFrame, this);
+    // KLUDGE:  work around https://github.com/CyberBoardPBEM/cbwindows/issues/23
+    GetMainFrame()->RedrawWindow(NULL, NULL, RDW_ALLCHILDREN | RDW_INVALIDATE);
     m_lpvCreateParam = NULL;
     return TRUE;
 }


### PR DESCRIPTION
I still can't explain why CBDesign behaves this way, so here's a kludge to get around the problem.

Fixes #23