### PR TITLE
Fix mdi vestiges

### DIFF
--- a/GM/Cbdesign.rc
+++ b/GM/Cbdesign.rc
@@ -241,10 +241,8 @@ BEGIN
     END
     POPUP "&Window"
     BEGIN
-        MENUITEM "&Cascade",                    ID_WINDOW_CASCADE
-        MENUITEM "&Tile Horizontally",          ID_WINDOW_TILE_HORZ
-        MENUITEM "&Tile Vertically",            ID_WINDOW_TILE_VERT
-        MENUITEM "&Arrange Icons",              ID_WINDOW_ARRANGE
+        MENUITEM "Split Tabs &Horizontally",    ID_WINDOW_TILE_HORZ
+        MENUITEM "Split Tabs &Vertically",      ID_WINDOW_TILE_VERT
         MENUITEM SEPARATOR
         MENUITEM "T&ool Palette",               ID_WINDOW_TOOLPAL
         MENUITEM "Co&lor Palette",              ID_WINDOW_COLORPAL
@@ -1259,10 +1257,8 @@ END
 STRINGTABLE
 BEGIN
     ID_WINDOW_NEW           "Open another window for the active document"
-    ID_WINDOW_ARRANGE       "Arrange icons at the bottom of the window"
-    ID_WINDOW_CASCADE       "Arrange windows so they overlap"
-    ID_WINDOW_TILE_HORZ     "Arrange windows as non-overlapping tiles"
-    ID_WINDOW_TILE_VERT     "Arrange windows as non-overlapping tiles"
+    ID_WINDOW_TILE_HORZ     "Split active tab into a new group horizontally"
+    ID_WINDOW_TILE_VERT     "Split active tab into a new group vertically"
     ID_WINDOW_SPLIT         "Split the active window into panes"
 END
 

--- a/GM/FrmMain.cpp
+++ b/GM/FrmMain.cpp
@@ -44,9 +44,9 @@ static char THIS_FILE[] = __FILE__;
 ///////////////////////////////////////////////////////////////////////
 // CMainFrame
 
-IMPLEMENT_DYNAMIC(CMainFrame, CMDIFrameWndEx)
+IMPLEMENT_DYNAMIC(CMainFrame, CMDIFrameWndExCb)
 
-BEGIN_MESSAGE_MAP(CMainFrame, CMDIFrameWndEx)
+BEGIN_MESSAGE_MAP(CMainFrame, CMDIFrameWndExCb)
     ON_WM_CREATE()
     ON_WM_CLOSE()
     ON_WM_PALETTECHANGED()

--- a/GM/FrmMain.cpp
+++ b/GM/FrmMain.cpp
@@ -107,7 +107,6 @@ static CRuntimeClass *tblBrd[] = { RUNTIME_CLASS(CBrdEditView), NULL };
 
 CMainFrame::CMainFrame()
 {
-    DockInit();
     m_bColorPalOn = TRUE;
     m_bTilePalOn = TRUE;
 }

--- a/GM/FrmMain.h
+++ b/GM/FrmMain.h
@@ -24,6 +24,8 @@
 #ifndef _FRMMAIN_H
 #define _FRMMAIN_H
 
+#include "LibMfc.h"
+
 #ifndef     _GMDOC_H
 #include    "gmdoc.h"
 #endif
@@ -40,7 +42,7 @@
 #include    "frmdocktile.h"
 #endif
 
-class CMainFrame : public CMDIFrameWndEx
+class CMainFrame : public CMDIFrameWndExCb
 {
     DECLARE_DYNAMIC(CMainFrame)
 public:

--- a/GP/Cbplay.rc
+++ b/GP/Cbplay.rc
@@ -245,10 +245,8 @@ BEGIN
     END
     POPUP "&Window"
     BEGIN
-        MENUITEM "&Cascade",                    ID_WINDOW_CASCADE
-        MENUITEM "Tile &Horizontally",          ID_WINDOW_TILE_HORZ
-        MENUITEM "Tile &Vertically",            ID_WINDOW_TILE_VERT
-        MENUITEM "&Arrange Icons",              ID_WINDOW_ARRANGE
+        MENUITEM "Split Tabs &Horizontally",    ID_WINDOW_TILE_HORZ
+        MENUITEM "Split Tabs &Vertically",      ID_WINDOW_TILE_VERT
         MENUITEM SEPARATOR
         MENUITEM "Horizontal Split",            ID_VIEW_SPLITBOARDROWS
         MENUITEM "Vertical Split",              ID_VIEW_SPLITBOARDCOLS
@@ -413,10 +411,8 @@ BEGIN
     END
     POPUP "&Window"
     BEGIN
-        MENUITEM "&Cascade",                    ID_WINDOW_CASCADE
-        MENUITEM "&Tile Horizontally",          ID_WINDOW_TILE_HORZ
-        MENUITEM "&Tile Vertically",            ID_WINDOW_TILE_VERT
-        MENUITEM "&Arrange Icons",              ID_WINDOW_ARRANGE
+        MENUITEM "Split Tabs &Horizontally",    ID_WINDOW_TILE_HORZ
+        MENUITEM "Split Tabs &Vertically",      ID_WINDOW_TILE_VERT
         MENUITEM SEPARATOR
         MENUITEM "Horizontal Split",            ID_VIEW_SPLITBOARDROWS
         MENUITEM "Vertical Split",              ID_VIEW_SPLITBOARDCOLS
@@ -1555,10 +1551,8 @@ END
 STRINGTABLE
 BEGIN
     ID_WINDOW_NEW           "Open another window for the active document"
-    ID_WINDOW_ARRANGE       "Arrange icons at the bottom of the window"
-    ID_WINDOW_CASCADE       "Arrange windows so they overlap"
-    ID_WINDOW_TILE_HORZ     "Arrange windows as non-overlapping tiles"
-    ID_WINDOW_TILE_VERT     "Arrange windows as non-overlapping tiles"
+    ID_WINDOW_TILE_HORZ     "Split active tab into a new group horizontally"
+    ID_WINDOW_TILE_VERT     "Split active tab into a new group vertically"
     ID_WINDOW_SPLIT         "Split the active window into panes"
 END
 

--- a/GP/FrmMain.cpp
+++ b/GP/FrmMain.cpp
@@ -92,7 +92,6 @@ static char szSectControlBars[] = "ControlBars";
 
 CMainFrame::CMainFrame()
 {
-    DockInit();
     // TODO: add member initialization code here
 }
 

--- a/GP/FrmMain.cpp
+++ b/GP/FrmMain.cpp
@@ -33,7 +33,7 @@
 static char THIS_FILE[] = __FILE__;
 #endif
 
-IMPLEMENT_DYNAMIC(CMainFrame, CMDIFrameWndEx)
+IMPLEMENT_DYNAMIC(CMainFrame, CMDIFrameWndExCb)
 
 #ifdef _DEBUG
 #define new DEBUG_NEW
@@ -42,7 +42,7 @@ IMPLEMENT_DYNAMIC(CMainFrame, CMDIFrameWndEx)
 /////////////////////////////////////////////////////////////////////////////
 // CMainFrame
 
-BEGIN_MESSAGE_MAP(CMainFrame, CMDIFrameWndEx)
+BEGIN_MESSAGE_MAP(CMainFrame, CMDIFrameWndExCb)
     ON_WM_CREATE()
     ON_UPDATE_COMMAND_UI(ID_VIEW_SNAPGRID, OnUpdateDisable)
     ON_WM_HELPINFO()

--- a/GP/FrmMain.h
+++ b/GP/FrmMain.h
@@ -25,6 +25,8 @@
 #ifndef _FRMMAIN_H_
 #define _FRMMAIN_H_
 
+#include "LibMfc.h"
+
 #ifndef _FRMDOCKTRAY_H
 #include "FrmDockTray.h"
 #endif
@@ -37,7 +39,7 @@
 #include "PalReadMsg.h"
 #endif
 
-class CMainFrame : public CMDIFrameWndEx
+class CMainFrame : public CMDIFrameWndExCb
 {
     DECLARE_DYNAMIC(CMainFrame)
 public:

--- a/GShr/LibMfc.cpp
+++ b/GShr/LibMfc.cpp
@@ -426,12 +426,6 @@ namespace {
     }
 }
 
-void DockInit()
-{
-    CPaneDivider::m_pContainerManagerRTC = RUNTIME_CLASS(CPaneContainerManagerCb);
-    CPaneDivider::m_pSliderRTC = RUNTIME_CLASS(CPaneDividerCb);
-}
-
 IMPLEMENT_DYNAMIC(CMDIFrameWndExCb, CMDIFrameWndEx)
 
 BEGIN_MESSAGE_MAP(CMDIFrameWndExCb, CMDIFrameWndEx)
@@ -440,6 +434,12 @@ BEGIN_MESSAGE_MAP(CMDIFrameWndExCb, CMDIFrameWndEx)
     ON_COMMAND_EX(ID_WINDOW_TILE_HORZ, OnWindowTile)
     ON_COMMAND_EX(ID_WINDOW_TILE_VERT, OnWindowTile)
 END_MESSAGE_MAP()
+
+CMDIFrameWndExCb::CMDIFrameWndExCb()
+{
+    CPaneDivider::m_pContainerManagerRTC = RUNTIME_CLASS(CPaneContainerManagerCb);
+    CPaneDivider::m_pSliderRTC = RUNTIME_CLASS(CPaneDividerCb);
+}
 
 // KLUDGE:  dirty trick to get access to CMDIClientAreaWnd members
 class CMDIFrameWndExCb::CMDIClientAreaWndCb : public CMDIClientAreaWnd

--- a/GShr/LibMfc.cpp
+++ b/GShr/LibMfc.cpp
@@ -484,6 +484,7 @@ public:
         // show final state
         SetRedraw(TRUE);
         UpdateTabs(TRUE);
+        RedrawWindow(NULL, NULL, RDW_INVALIDATE | RDW_ALLCHILDREN);
 
         return TRUE;
     }

--- a/GShr/LibMfc.h
+++ b/GShr/LibMfc.h
@@ -57,8 +57,6 @@ UINT LocateSubMenuIndexOfMenuHavingStartingID(CMenu* pMenu, UINT nID);
 void CreateSequentialSubMenuIDs(CMenu& menu, UINT nBaseID, CStringArray& tblNames,
         CUIntArray* pTblSelections = NULL, UINT nBreaksAt = 20);
 
-void DockInit();
-
 /////////////////////////////////////////////////////////////////////////////
 // Extend CMDIFrameWndEx with message handlers to split tabs
 // into groups.
@@ -68,6 +66,8 @@ class CMDIFrameWndExCb : public CMDIFrameWndEx
     DECLARE_DYNAMIC(CMDIFrameWndExCb)
 
 protected:
+    CMDIFrameWndExCb();
+
     afx_msg void OnUpdateWindowTile(CCmdUI* pCmdUI);
     afx_msg BOOL OnWindowTile(UINT nID);
 

--- a/GShr/LibMfc.h
+++ b/GShr/LibMfc.h
@@ -59,5 +59,24 @@ void CreateSequentialSubMenuIDs(CMenu& menu, UINT nBaseID, CStringArray& tblName
 
 void DockInit();
 
+/////////////////////////////////////////////////////////////////////////////
+// Extend CMDIFrameWndEx with message handlers to split tabs
+// into groups.
+
+class CMDIFrameWndExCb : public CMDIFrameWndEx
+{
+    DECLARE_DYNAMIC(CMDIFrameWndExCb)
+
+protected:
+    afx_msg void OnUpdateWindowTile(CCmdUI* pCmdUI);
+    afx_msg BOOL OnWindowTile(UINT nID);
+
+    DECLARE_MESSAGE_MAP()
+
+    class CMDIClientAreaWndCb;
+    const CMDIClientAreaWndCb& GetMDIClient() const;
+    CMDIClientAreaWndCb& GetMDIClient();
+};
+
 #endif
 


### PR DESCRIPTION
Here's a suggestion for how to update the menus to reflect the change from MDI to tabbed windows.

Please note that this is a draft because 
1)  branch master currently has another pull request pending, so this should be rebased after that pull request is merged. 
2)  I don't know if we actually want the menu to enable splitting the tab groups
3)  I don't know if we want to use new menu ID values rather than reusing the old ones