### PR TITLE
improve type safety and clarity of drag-and-drop

### DIFF
--- a/GM/LBoxTile.cpp
+++ b/GM/LBoxTile.cpp
@@ -140,15 +140,15 @@ BOOL CTileListBox::OnDragSetup(DragInfo* pDI)
     if (IsMultiSelect())
     {
         pDI->m_dragType = DRAG_TILELIST;
-        pDI->m_dwVal = (DWORD)GetMappedMultiSelectList();// TileID array
-        pDI->m_pObj = (void*)m_pDoc;
+        pDI->GetSubInfo<DRAG_TILELIST>().m_tileIDList = GetMappedMultiSelectList();// TileID array
+        pDI->GetSubInfo<DRAG_TILELIST>().m_gamDoc = m_pDoc;
         pDI->m_hcsrSuggest = g_res.hcrDragTile;
     }
     else
     {
         pDI->m_dragType = DRAG_TILE;
-        pDI->m_dwVal = (DWORD)GetCurMapItem();      // The TileID
-        pDI->m_pObj = (void*)m_pDoc;
+        pDI->GetSubInfo<DRAG_TILE>().m_tileID = GetCurMapItem();      // The TileID
+        pDI->GetSubInfo<DRAG_TILE>().m_gamDoc = m_pDoc;
         pDI->m_hcsrSuggest = g_res.hcrDragTile;
     }
     return TRUE;

--- a/GM/VwEdtbrd.cpp
+++ b/GM/VwEdtbrd.cpp
@@ -881,7 +881,7 @@ LRESULT CBrdEditView::OnDragTileItem(WPARAM wParam, LPARAM lParam)
 
     if (pdi->m_dragType != DRAG_TILE)
         return 0;               // Only tile drops allowed
-    if (pdi->m_pObj != (void*)GetDocument())
+    if (pdi->GetSubInfo<DRAG_TILE>().m_gamDoc != GetDocument())
         return 0;               // Only tiles from our document.
 
     if (wParam == phaseDragOver)
@@ -896,14 +896,14 @@ LRESULT CBrdEditView::OnDragTileItem(WPARAM wParam, LPARAM lParam)
         {
             case LAYER_BASE:
                 pDwg = m_pBoard->GetBaseDrawing(TRUE);
-                SetDrawingTile(pDwg, (TileID)pdi->m_dwVal, pnt, TRUE);
+                SetDrawingTile(pDwg, pdi->GetSubInfo<DRAG_TILE>().m_tileID, pnt, TRUE);
                 break;
             case LAYER_GRID:
-                SetCellTile((TileID)pdi->m_dwVal, pnt, TRUE);
+                SetCellTile(pdi->GetSubInfo<DRAG_TILE>().m_tileID, pnt, TRUE);
                 break;
             case LAYER_TOP:
                 pDwg = m_pBoard->GetTopDrawing(TRUE);
-                SetDrawingTile(pDwg, (TileID)pdi->m_dwVal, pnt, TRUE);
+                SetDrawingTile(pDwg, pdi->GetSubInfo<DRAG_TILE>().m_tileID, pnt, TRUE);
                 break;
             default: ;
         }

--- a/GM/VwPrjgbx.cpp
+++ b/GM/VwPrjgbx.cpp
@@ -428,7 +428,7 @@ LRESULT CGbxProjView::OnDragItem(WPARAM wParam, LPARAM lParam)
     if (pdi->m_dragType != DRAG_TILELIST)
         return 0;               // Only tile list drops allowed
 
-    if (pdi->m_pObj != (void*)pDoc)
+    if (pdi->GetSubInfo<DRAG_TILELIST>().m_gamDoc != pDoc)
         return 0;               // Only pieces from our document.
 
     CRect rct;
@@ -463,10 +463,10 @@ LRESULT CGbxProjView::OnDragItem(WPARAM wParam, LPARAM lParam)
                 nSel++;
         }
 
-        pTMgr->MoveTileIDsToTileSet(nGrpSel, *(CWordArray*)pdi->m_dwVal, nSel);
+        pTMgr->MoveTileIDsToTileSet(nGrpSel, *pdi->GetSubInfo<DRAG_TILELIST>().m_tileIDList, nSel);
         DoUpdateTileList();
         GetDocument()->NotifyTileDatabaseChange();
-        m_listTiles.SetCurSelsMapped(*(CWordArray*)pdi->m_dwVal);
+        m_listTiles.SetCurSelsMapped(*pdi->GetSubInfo<DRAG_TILELIST>().m_tileIDList);
         m_listTiles.ShowFirstSelection();
         pDoc->SetModifiedFlag();
     }

--- a/GP/LBoxSlct.cpp
+++ b/GP/LBoxSlct.cpp
@@ -60,6 +60,7 @@ CTileManager* CSelectListBox::GetTileManager()
 
 BOOL CSelectListBox::OnDragSetup(DragInfo* pDI)
 {
+    ASSERT(!"untested code");
     if (GetCount() <= 1)
         return FALSE;
 
@@ -69,9 +70,9 @@ BOOL CSelectListBox::OnDragSetup(DragInfo* pDI)
         m_multiSelList.Add(GetCurMapItem());
     }
     pDI->m_dragType = DRAG_SELECTVIEW;
-    pDI->m_dwVal = (DWORD)GetMappedMultiSelectList();
+    pDI->GetSubInfo<DRAG_SELECTVIEW>().m_ptrArray = GetMappedMultiSelectList();
         pDI->m_hcsrSuggest = g_res.hcrDragTile;
-    pDI->m_pObj = (void*)m_pDoc;
+    pDI->GetSubInfo<DRAG_SELECTVIEW>().m_gamDoc = m_pDoc;
     return TRUE;
 }
 
@@ -84,7 +85,7 @@ LRESULT CSelectListBox::OnDragItem(WPARAM wParam, LPARAM lParam)
     if (pdi->m_dragType != DRAG_SELECTVIEW)
         return 0;               // Only our drops allowed
 
-    if (pdi->m_pObj != (void*)m_pDoc)
+    if (pdi->GetSubInfo<DRAG_SELECTVIEW>().m_gamDoc != m_pDoc)
         return 0;               // Only pieces from our document.
 
     DoAutoScrollProcessing(pdi);

--- a/GP/LBoxTray.cpp
+++ b/GP/LBoxTray.cpp
@@ -306,15 +306,15 @@ BOOL CTrayListBox::OnDragSetup(DragInfo* pDI)
     if (IsMultiSelect())
     {
         pDI->m_dragType = DRAG_PIECELIST;
-        pDI->m_dwVal = (DWORD)GetMappedMultiSelectList();// PieceID array
-        pDI->m_pObj = (void*)m_pDoc;
+        pDI->GetSubInfo<DRAG_PIECELIST>().m_pieceIDList = GetMappedMultiSelectList();// PieceID array
+        pDI->GetSubInfo<DRAG_PIECELIST>().m_gamDoc = m_pDoc;
         pDI->m_hcsrSuggest = g_res.hcrDragTile;
     }
     else
     {
         pDI->m_dragType = DRAG_PIECE;
-        pDI->m_dwVal = (DWORD)GetCurMapItem();      // The PieceID
-        pDI->m_pObj = (void*)m_pDoc;
+        pDI->GetSubInfo<DRAG_PIECE>().m_pieceID = GetCurMapItem();      // The PieceID
+        pDI->GetSubInfo<DRAG_PIECE>().m_gamDoc = m_pDoc;
         pDI->m_hcsrSuggest = g_res.hcrDragTile;
     }
     return TRUE;

--- a/GP/PalTray.cpp
+++ b/GP/PalTray.cpp
@@ -555,12 +555,14 @@ LRESULT CTrayPalette::OnDragItem(WPARAM wParam, LPARAM lParam)
         pdi->m_dragType != DRAG_PIECELIST)
         return 0;                       // Only piece drops allowed
 
-    if (pdi->m_pObj != (void*)m_pDoc)
+    if (pdi->m_dragType == DRAG_PIECE && pdi->GetSubInfo<DRAG_PIECE>().m_gamDoc != m_pDoc ||
+        pdi->m_dragType == DRAG_SELECTLIST && pdi->GetSubInfo<DRAG_SELECTLIST>().m_gamDoc != m_pDoc ||
+        pdi->m_dragType == DRAG_PIECELIST && pdi->GetSubInfo<DRAG_PIECELIST>().m_gamDoc != m_pDoc)
         return 0;                       // Only pieces from our document.
 
     if (pdi->m_dragType == DRAG_SELECTLIST)
     {
-        if (!((CSelList*)(pdi->m_dwVal))->HasPieces())
+        if (!pdi->GetSubInfo<DRAG_SELECTLIST>().m_selectList->HasPieces())
             return 0;                   // Only piece drops allowed
     }
 
@@ -596,20 +598,20 @@ LRESULT CTrayPalette::OnDragItem(WPARAM wParam, LPARAM lParam)
         if (pdi->m_dragType == DRAG_PIECE)
         {
             m_pDoc->AssignNewMoveGroup();
-            m_pDoc->PlacePieceInTray((PieceID)pdi->m_dwVal, pYGrp, nSel);
+            m_pDoc->PlacePieceInTray(pdi->GetSubInfo<DRAG_PIECE>().m_pieceID, pYGrp, nSel);
             // Select the last piece that was inserted
-            nSel = pYGrp->GetPieceIDIndex((PieceID)pdi->m_dwVal);
+            nSel = pYGrp->GetPieceIDIndex(pdi->GetSubInfo<DRAG_PIECE>().m_pieceID);
         }
         if (pdi->m_dragType == DRAG_PIECELIST)
         {
             m_pDoc->AssignNewMoveGroup();
-            nSel = m_pDoc->PlacePieceListInTray((CWordArray*)pdi->m_dwVal,
+            nSel = m_pDoc->PlacePieceListInTray(pdi->GetSubInfo<DRAG_PIECELIST>().m_pieceIDList,
                 pYGrp, nSel);
         }
         else        // DRAG_SELECTLIST
         {
             CPtrList m_listPtr;
-            CSelList* pSLst = (CSelList*)pdi->m_dwVal;
+            CSelList* pSLst = pdi->GetSubInfo<DRAG_SELECTLIST>().m_selectList;
             pSLst->LoadListWithObjectPtrs(&m_listPtr);
             pSLst->PurgeList(FALSE);
             m_pDoc->AssignNewMoveGroup();

--- a/GP/ToolPlay.cpp
+++ b/GP/ToolPlay.cpp
@@ -568,8 +568,8 @@ void CPSelectTool::KillScrollTimer(CPlayBoardView* pView)
 void CPSelectTool::DoDragDropStart(CPlayBoardView* pView)
 {
     m_di.m_dragType = DRAG_SELECTLIST;
-    m_di.m_dwVal = (DWORD)pView->GetSelectList();
-    m_di.m_pObj = (void*)pView->GetDocument();
+    m_di.GetSubInfo<DRAG_SELECTLIST>().m_selectList = pView->GetSelectList();
+    m_di.GetSubInfo<DRAG_SELECTLIST>().m_gamDoc = pView->GetDocument();
     m_di.m_hcsrSuggest = g_res.hcrDragTile;
 
     m_hLastWnd = NULL;

--- a/GP/VwPbrd.cpp
+++ b/GP/VwPbrd.cpp
@@ -528,7 +528,7 @@ LRESULT CPlayBoardView::OnDragItem(WPARAM wParam, LPARAM lParam)
 LRESULT CPlayBoardView::DoDragPiece(WPARAM wParam, DragInfo* pdi)
 {
     ASSERT(FALSE);      //!!!NOT USED???? //TODO: WHAT'S GOING ON HERE? 20200618
-    if (pdi->m_pObj != (void*)GetDocument())
+    if (pdi->GetSubInfo<DRAG_PIECE>().m_gamDoc != GetDocument())
         return 0;               // Only pieces from our document.
 
     if (wParam == phaseDragExit)
@@ -542,7 +542,7 @@ LRESULT CPlayBoardView::DoDragPiece(WPARAM wParam, DragInfo* pdi)
     {
         CPoint pnt = pdi->m_point;
         ClientToWorkspace(pnt);
-        AddPiece(pnt, (PieceID)pdi->m_dwVal);
+        AddPiece(pnt, pdi->GetSubInfo<DRAG_PIECE>().m_pieceID);
         DragKillAutoScroll();
     }
     return 0;
@@ -550,7 +550,7 @@ LRESULT CPlayBoardView::DoDragPiece(WPARAM wParam, DragInfo* pdi)
 
 LRESULT CPlayBoardView::DoDragPieceList(WPARAM wParam, DragInfo* pdi)
 {
-    if (pdi->m_pObj != (void*)GetDocument())
+    if (pdi->GetSubInfo<DRAG_PIECELIST>().m_gamDoc != GetDocument())
         return 0;               // Only pieces from our document.
 
     if (wParam == phaseDragExit)
@@ -564,7 +564,7 @@ LRESULT CPlayBoardView::DoDragPieceList(WPARAM wParam, DragInfo* pdi)
     {
         CGamDoc* pDoc = GetDocument();
         CPoint pnt = pdi->m_point;
-        CWordArray* pTbl = (CWordArray *)pdi->m_dwVal;
+        CWordArray* pTbl = pdi->GetSubInfo<DRAG_PIECELIST>().m_pieceIDList;
         ClientToWorkspace(pnt);
 
         // If the snap grid is on, adjust the point.
@@ -586,7 +586,7 @@ LRESULT CPlayBoardView::DoDragPieceList(WPARAM wParam, DragInfo* pdi)
         {
             CDrawList* pDwg = m_pPBoard->GetPieceList();
             CPtrList pceList;
-            pDwg->GetObjectListFromPieceIDTable((CWordArray *)pdi->m_dwVal, &pceList);
+            pDwg->GetObjectListFromPieceIDTable(pdi->GetSubInfo<DRAG_PIECELIST>().m_pieceIDList, &pceList);
             SelectAllObjectsInList(&pceList);   // Reselect pieces dropped on board
         }
 
@@ -599,8 +599,9 @@ LRESULT CPlayBoardView::DoDragPieceList(WPARAM wParam, DragInfo* pdi)
 
 LRESULT CPlayBoardView::DoDragMarker(WPARAM wParam, DragInfo* pdi)
 {
+    ASSERT(pdi->m_dragType == DRAG_MARKER);
     CGamDoc* pDoc = GetDocument();
-    if (pdi->m_pObj != (void*)pDoc)
+    if (pdi->GetSubInfo<DRAG_MARKER>().m_gamDoc != pDoc)
         return 0;               // Only markers from our document.
 
     if (wParam == phaseDragExit)
@@ -614,7 +615,7 @@ LRESULT CPlayBoardView::DoDragMarker(WPARAM wParam, DragInfo* pdi)
     {
         CMarkManager* pMMgr = pDoc->GetMarkManager();
         CPoint pnt = pdi->m_point;
-        MarkID mid = (MarkID)pdi->m_dwVal;
+        MarkID mid = pdi->GetSubInfo<DRAG_MARKER>().m_markID;
         ClientToWorkspace(pnt);
 
         // If Control is held and the marker tray is set to
@@ -718,12 +719,12 @@ NASTY_GOTO_TARGET:
 
 LRESULT CPlayBoardView::DoDragSelectList(WPARAM wParam, DragInfo* pdi)
 {
-    if (pdi->m_pObj != (void*)GetDocument())
+    if (pdi->GetSubInfo<DRAG_SELECTLIST>().m_gamDoc != GetDocument())
         return 0;               // Only pieces from our document.
 
     ClientToWorkspace(pdi->m_point);
 
-    CSelList *pSLst = (CSelList *)pdi->m_dwVal;
+    CSelList *pSLst = pdi->GetSubInfo<DRAG_SELECTLIST>().m_selectList;
     CDC *pDC = GetDC();
     OnPrepareScaledDC(pDC, TRUE);
 

--- a/GShr/LBoxGfx2.cpp
+++ b/GShr/LBoxGfx2.cpp
@@ -349,6 +349,7 @@ void CGrafixListBox2::OnLButtonUp(UINT nFlags, CPoint point)
     }
     if (m_bAllowDrag)
     {
+        ASSERT(!"unreachable code");
         BOOL bWasDragging = CWnd::GetCapture() == this;
         CListBox::OnLButtonUp(nFlags, point);
 
@@ -366,12 +367,16 @@ void CGrafixListBox2::OnLButtonUp(UINT nFlags, CPoint point)
             }
             else
             {
+                ASSERT(!"unreachable code");
+                ASSERT(!"what is m_dragType here?");
+#if 0
                 // The parent may want to override the value.
                 int nValueOverride = di.m_dwVal;
                 CWnd *pWnd = GetParent();
                 ASSERT(pWnd != NULL);
                 pWnd->SendMessage(WM_OVERRIDE_SELECTED_ITEM2, (WPARAM)&nValueOverride);
                 di.m_dwVal = nValueOverride;
+#endif
             }
 
             ReleaseCapture();
@@ -408,6 +413,7 @@ void CGrafixListBox2::OnMouseMove(UINT nFlags, CPoint point)
 
     if (m_bAllowDrag)
     {
+        ASSERT(!"unreachable code");
         if (CWnd::GetCapture() != this)
             return;
         // OK...We are dragging. Let's check if the cursor has been

--- a/GShr/LBoxGrfx.cpp
+++ b/GShr/LBoxGrfx.cpp
@@ -434,11 +434,11 @@ void CGrafixListBox::OnLButtonUp(UINT nFlags, CPoint point)
             else
             {
                 // The parent may want to override the value.
-                int nValueOverride = di.m_dwVal;
+                int nValueOverride = di.GetSubInfo<DRAG_MARKER>().m_markID;
                 CWnd *pWnd = GetParent();
                 ASSERT(pWnd != NULL);
                 pWnd->SendMessage(WM_OVERRIDE_SELECTED_ITEM, (WPARAM)&nValueOverride);
-                di.m_dwVal = nValueOverride;
+                di.GetSubInfo<DRAG_MARKER>().m_markID = nValueOverride;
             }
 
             ReleaseCapture();

--- a/GShr/LBoxGrfx.cpp
+++ b/GShr/LBoxGrfx.cpp
@@ -434,11 +434,26 @@ void CGrafixListBox::OnLButtonUp(UINT nFlags, CPoint point)
             else
             {
                 // The parent may want to override the value.
-                int nValueOverride = di.GetSubInfo<DRAG_MARKER>().m_markID;
-                CWnd *pWnd = GetParent();
-                ASSERT(pWnd != NULL);
-                pWnd->SendMessage(WM_OVERRIDE_SELECTED_ITEM, (WPARAM)&nValueOverride);
-                di.GetSubInfo<DRAG_MARKER>().m_markID = nValueOverride;
+                if (di.m_dragType == DRAG_MARKER)
+                {
+                    int nValueOverride = di.GetSubInfo<DRAG_MARKER>().m_markID;
+                    CWnd* pWnd = GetParent();
+                    ASSERT(pWnd != NULL);
+                    pWnd->SendMessage(WM_OVERRIDE_SELECTED_ITEM, (WPARAM)&nValueOverride);
+                    di.GetSubInfo<DRAG_MARKER>().m_markID = nValueOverride;
+                }
+                else if (di.m_dragType == DRAG_TILE)
+                {
+                    int nValueOverride = di.GetSubInfo<DRAG_TILE>().m_tileID;
+                    CWnd* pWnd = GetParent();
+                    ASSERT(pWnd != NULL);
+                    pWnd->SendMessage(WM_OVERRIDE_SELECTED_ITEM, (WPARAM)&nValueOverride);
+                    di.GetSubInfo<DRAG_TILE>().m_tileID = nValueOverride;
+                }
+                else
+                {
+                    ASSERT(!"unexpected dragType");
+                }
             }
 
             ReleaseCapture();

--- a/GShr/LBoxMark.cpp
+++ b/GShr/LBoxMark.cpp
@@ -217,8 +217,8 @@ BOOL CMarkListBox::OnDragSetup(DragInfo* pDI)
         return 0;                       // Drags not supported during play
 #endif
     pDI->m_dragType = DRAG_MARKER;
-    pDI->m_dwVal = (DWORD)GetCurMapItem();          // The MarkID
-    pDI->m_pObj = (void*)m_pDoc;
+    pDI->GetSubInfo<DRAG_MARKER>().m_markID = GetCurMapItem();          // The MarkID
+    pDI->GetSubInfo<DRAG_MARKER>().m_gamDoc = m_pDoc;
     pDI->m_hcsrSuggest = g_res.hcrDragTile;
     return TRUE;
 }

--- a/GShr/LBoxPiec.cpp
+++ b/GShr/LBoxPiec.cpp
@@ -166,8 +166,13 @@ void CPieceListBox::OnItemDraw(CDC* pDC, int nIndex, UINT nAction, UINT nState,
 BOOL CPieceListBox::OnDragSetup(DragInfo* pDI)
 {
     pDI->m_dragType = DRAG_PIECE;
-    pDI->m_dwVal = (DWORD)GetCurMapItem();          // The PieceID
+    pDI->GetSubInfo<DRAG_PIECE>().m_pieceID = GetCurMapItem();          // The PieceID
+    ASSERT(!"code look wrong, but I think this is unreachable");
+    /* this is the original code, but it looks wrong since
+        everything else seems to say DRAG_PIECE should have
+        m_pObj contain CGamDoc*
     pDI->m_pObj = (void*)m_pPMgr;
+    */
     pDI->m_hcsrSuggest = g_res.hcrDragTile;
     return TRUE;
 }


### PR DESCRIPTION
Here is some work to improve the type-safety and clarity of drag-and-drop code.  However, I admit it's only clearer if one is comfortable with templates.

Also, I believe the comments in DragDrop.h describing the drag-specific info did not always match the running code.  I have updated the comments to reflect my understanding of the actual code.  If the comments represent actual desired behavior, the comments will need to be reverted to the previous version, and the code modified to behave as desired.