### PR TITLE
Type safety for TileID/MarkID/PieceID (plus some other changes as a consequence)

### DIFF
--- a/GM/CBDsgn32.vcxproj
+++ b/GM/CBDsgn32.vcxproj
@@ -260,6 +260,7 @@ echo off
     <ClInclude Include="..\GShr\BrdCell.h" />
     <ClInclude Include="..\GShr\CDib.h" />
     <ClInclude Include="..\GShr\CellForm.h" />
+    <ClInclude Include="..\GShr\CyberBoard.h" />
     <ClInclude Include="ClipBrd.h" />
     <ClInclude Include="..\GShr\Ctl3d.h" />
     <ClInclude Include="..\GShr\DibApi.h" />

--- a/GM/CBDsgn32.vcxproj.filters
+++ b/GM/CBDsgn32.vcxproj.filters
@@ -502,6 +502,9 @@
     <ClInclude Include="..\GShr\WinTiny.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="..\GShr\CyberBoard.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <Image Include="res\BadColum.bmp">

--- a/GM/DlgBmask.cpp
+++ b/GM/DlgBmask.cpp
@@ -85,7 +85,7 @@ void CBoardMaskDialog::OnContextMenu(CWnd* pWnd, CPoint point)
 void CBoardMaskDialog::OnOK()
 {
     CDialog::OnOK();
-    m_nBrdNum = m_lboxBoard.GetCurSel();
+    m_nBrdNum = value_preserving_cast<size_t>(m_lboxBoard.GetCurSel());
 }
 
 BOOL CBoardMaskDialog::OnInitDialog()
@@ -94,8 +94,8 @@ BOOL CBoardMaskDialog::OnInitDialog()
 
     ASSERT(m_pBMgr);
 
-    for (int i = 0; i < m_pBMgr->GetNumBoards(); i++)
-        m_lboxBoard.AddString(m_pBMgr->GetBoard(i)->GetName());
+    for (size_t i = 0; i < m_pBMgr->GetNumBoards(); i++)
+        m_lboxBoard.AddString(m_pBMgr->GetBoard(i).GetName());
 
     m_lboxBoard.SetCurSel(0);
 

--- a/GM/DlgBmask.h
+++ b/GM/DlgBmask.h
@@ -39,7 +39,7 @@ public:
     CListBox    m_lboxBoard;
     //}}AFX_DATA
 
-    int m_nBrdNum;
+    size_t m_nBrdNum;
     CBoardManager* m_pBMgr;
 
 // Implementation

--- a/GM/DlgMedt.h
+++ b/GM/DlgMedt.h
@@ -54,7 +54,7 @@ public:
 
 // Implementation
 protected:
-    CWordArray      m_tbl;          // Need to use list box.
+    std::vector<MarkID> m_tbl;      // Need to use list box.
     CMarkManager*   m_pMMgr;
     CTileManager*   m_pTMgr;        // Set internally from m_pPMgr
     // --------- //

--- a/GM/DlgMnew.cpp
+++ b/GM/DlgMnew.cpp
@@ -102,14 +102,9 @@ void CMarkerCreateDialog::SetupTileListbox()
         return;
     }
 
-    CTileSet* pTSet = m_pTMgr->GetTileSet(nCurSel);
-    if (pTSet == NULL)
-    {
-        m_listTiles.SetItemMap(NULL);
-        return;
-    }
-    CWordArray* pLstMap = pTSet->GetTileIDTable();
-    m_listTiles.SetItemMap(pLstMap);
+    const CTileSet& pTSet = m_pTMgr->GetTileSet(value_preserving_cast<size_t>(nCurSel));
+    const std::vector<TileID>& pLstMap = pTSet.GetTileIDTable();
+    m_listTiles.SetItemMap(&pLstMap);
 }
 
 void CMarkerCreateDialog::SetupTileSetNames()
@@ -117,9 +112,9 @@ void CMarkerCreateDialog::SetupTileSetNames()
     ASSERT(m_pTMgr);
     m_comboTSet.ResetContent();
 
-    for (int i = 0; i < m_pTMgr->GetNumTileSets(); i++)
-        m_comboTSet.AddString(m_pTMgr->GetTileSet(i)->GetName());
-    if (m_pTMgr->GetNumTileSets() > 0)
+    for (size_t i = 0; i < m_pTMgr->GetNumTileSets(); i++)
+        m_comboTSet.AddString(m_pTMgr->GetTileSet(i).GetName());
+    if (!m_pTMgr->IsEmpty())
         m_comboTSet.SetCurSel(0);           // Select the first entry
 }
 
@@ -137,7 +132,7 @@ void CMarkerCreateDialog::CreateMarker()
     RefreshMarkerList();
 }
 
-TileID CMarkerCreateDialog::GetTileID()
+TileID CMarkerCreateDialog::GetTileID() const
 {
     int nCurSel = m_comboTSet.GetCurSel();
     if (nCurSel < 0)
@@ -147,24 +142,17 @@ TileID CMarkerCreateDialog::GetTileID()
     if (nCurTile < 0)
         return nullTid;
 
-    CTileSet* pTSet = m_pTMgr->GetTileSet(nCurSel);
-    if (pTSet == NULL)
-        return nullTid;
+    const CTileSet& pTSet = m_pTMgr->GetTileSet(value_preserving_cast<size_t>(nCurSel));
 
-    CWordArray* pLstMap = pTSet->GetTileIDTable();
-    return (TileID)pLstMap->GetAt(nCurTile);
+    const std::vector<TileID>& pLstMap = pTSet.GetTileIDTable();
+    return pLstMap.at(value_preserving_cast<size_t>(nCurTile));
 }
 
 void CMarkerCreateDialog::RefreshMarkerList()
 {
-    CMarkSet* pMSet = m_pMMgr->GetMarkSet(m_nMSet);
-    if (pMSet == NULL)
-    {
-        m_listMarks.SetItemMap(NULL);
-        return;
-    }
-    CWordArray* pLstMap = pMSet->GetMarkIDTable();
-    m_listMarks.SetItemMap(pLstMap);
+    CMarkSet& pMSet = m_pMMgr->GetMarkSet(m_nMSet);
+    const std::vector<MarkID>& pLstMap = pMSet.GetMarkIDTable();
+    m_listMarks.SetItemMap(&pLstMap);
 }
 
 /////////////////////////////////////////////////////////////////////////////

--- a/GM/DlgMnew.h
+++ b/GM/DlgMnew.h
@@ -51,7 +51,7 @@ public:
 
     // .. Caller must set these ..
     CGamDoc*        m_pDoc;
-    int             m_nMSet;
+    size_t          m_nMSet;
 
 // Implementation
 protected:
@@ -61,7 +61,7 @@ protected:
     void SetupTileListbox();
     void SetupTileSetNames();
     void CreateMarker();
-    TileID GetTileID();
+    TileID GetTileID() const;
     void RefreshMarkerList();
     // ------- //
     virtual void DoDataExchange(CDataExchange* pDX);    // DDX/DDV support

--- a/GM/DlgNtile.cpp
+++ b/GM/DlgNtile.cpp
@@ -101,8 +101,8 @@ BOOL CNewTileDialog::OnInitDialog()
 
     ASSERT(m_pBMgr != NULL);
 
-    for (int i = 0; i < m_pBMgr->GetNumBoards(); i++)
-        m_comboBoard.AddString(m_pBMgr->GetBoard(i)->GetName());
+    for (size_t i = 0; i < m_pBMgr->GetNumBoards(); i++)
+        m_comboBoard.AddString(m_pBMgr->GetBoard(i).GetName());
 
     m_comboBoard.SetCurSel(-1);
 
@@ -118,17 +118,16 @@ void CNewTileDialog::OnSelChangeBoardName()
     if (nBrd >= 0)
     {
         char szNum[40];
-        CBoard* pBoard = m_pBMgr->GetBoard(nBrd);
-        ASSERT(pBoard);
+        CBoard& pBoard = m_pBMgr->GetBoard(value_preserving_cast<size_t>(nBrd));
 
-        CSize size = pBoard->GetCellSize(fullScale);
+        CSize size = pBoard.GetCellSize(fullScale);
 
         itoa(size.cx, szNum, 10);
         m_editWidth.SetWindowText(szNum);
         itoa(size.cy, szNum, 10);
         m_editHeight.SetWindowText(szNum);
 
-        size = pBoard->GetCellSize(halfScale);
+        size = pBoard.GetCellSize(halfScale);
         m_nHalfWidth = size.cx;
         m_nHalfHeight = size.cy;
     }

--- a/GM/DlgPedt.h
+++ b/GM/DlgPedt.h
@@ -60,7 +60,7 @@ public:
 
 // Implementation
 protected:
-    CWordArray      m_tbl;          // Need to use list box.
+    std::vector<PieceID> m_tbl;     // Need to use list box.
     CTileManager*   m_pTMgr;        // Set internally from m_pDoc
     CPieceManager*  m_pPMgr;        // Set internally from m_pDoc
     // -------- //

--- a/GM/DlgPnew.h
+++ b/GM/DlgPnew.h
@@ -58,7 +58,7 @@ public:
 
     // ..Must be set by caller..
     CGamDoc*    m_pDoc;             // Pointer to document
-    int         m_nPSet;            // Number of piece set
+    size_t      m_nPSet;            // Number of piece set
 
 // Implementation
 protected:

--- a/GM/DlgTilsz.cpp
+++ b/GM/DlgTilsz.cpp
@@ -109,8 +109,8 @@ BOOL CResizeTileDialog::OnInitDialog()
 
     ASSERT(m_pBMgr != NULL);
 
-    for (int i = 0; i < m_pBMgr->GetNumBoards(); i++)
-        m_comboBrdName.AddString(m_pBMgr->GetBoard(i)->GetName());
+    for (size_t i = 0; i < m_pBMgr->GetNumBoards(); i++)
+        m_comboBrdName.AddString(m_pBMgr->GetBoard(i).GetName());
     m_comboBrdName.SetCurSel(-1);
 
     char szNum[40];
@@ -128,17 +128,16 @@ void CResizeTileDialog::OnSelchangeBrdName()
     if (nBrd >= 0)
     {
         char szNum[40];
-        CBoard* pBoard = m_pBMgr->GetBoard(nBrd);
-        ASSERT(pBoard);
+        CBoard& pBoard = m_pBMgr->GetBoard(value_preserving_cast<size_t>(nBrd));
 
-        CSize size = pBoard->GetCellSize(fullScale);
+        CSize size = pBoard.GetCellSize(fullScale);
 
         _itoa(size.cx, szNum, 10);
         m_editWidth.SetWindowText(szNum);
         _itoa(size.cy, szNum, 10);
         m_editHeight.SetWindowText(szNum);
 
-        size = pBoard->GetCellSize(halfScale);
+        size = pBoard.GetCellSize(halfScale);
         m_nHalfWidth = size.cx;
         m_nHalfHeight = size.cy;
     }

--- a/GM/LBoxTile.h
+++ b/GM/LBoxTile.h
@@ -43,7 +43,7 @@ class CGamDoc;
 
 /////////////////////////////////////////////////////////////////////////////
 
-class CTileListBox : public CGrafixListBox
+class CTileListBox : public CGrafixListBoxData<CGrafixListBox, TileID>
 {
 // Construction
 public:
@@ -65,10 +65,10 @@ protected:
     int         m_bDisplayIDs;     // Set to prop [Settings]:DisplayIDs
 
     // Overrides
-    virtual int OnItemHeight(int nIndex);
-    virtual void OnItemDraw(CDC* pDC, int nIndex, UINT nAction, UINT nState,
-        CRect rctItem);
-    virtual BOOL OnDragSetup(DragInfo* pDI);
+    virtual unsigned OnItemHeight(size_t nIndex) override;
+    virtual void OnItemDraw(CDC* pDC, size_t nIndex, UINT nAction, UINT nState,
+        CRect rctItem) override;
+    virtual BOOL OnDragSetup(DragInfo* pDI) override;
 
     //{{AFX_MSG(CTileListBox)
     //}}AFX_MSG

--- a/GM/PalTile.cpp
+++ b/GM/PalTile.cpp
@@ -136,7 +136,7 @@ TileID CTilePalette::GetCurrentTileID()
         return nullTid;
     if (m_listTile.GetCurSel() == LB_ERR)
         return nullTid;
-    return (TileID)m_listTile.GetCurMapItem();
+    return m_listTile.GetCurMapItem();
 }
 
 /////////////////////////////////////////////////////////////////////////////
@@ -173,8 +173,8 @@ void CTilePalette::LoadTileNameList()
     ASSERT(pTMgr != NULL);
 
     m_comboTGrp.ResetContent();
-    for (int i = 0; i < pTMgr->GetNumTileSets(); i++)
-        m_comboTGrp.AddString(pTMgr->GetTileSet(i)->GetName());
+    for (size_t i = 0; i < pTMgr->GetNumTileSets(); i++)
+        m_comboTGrp.AddString(pTMgr->GetTileSet(i).GetName());
     m_comboTGrp.SetCurSel(0);
     UpdateTileList();
 }
@@ -206,9 +206,8 @@ void CTilePalette::UpdateTileList()
         m_listTile.SetItemMap(NULL);
         return;
     }
-    CWordArray* pPieceTbl = pTMgr->GetTileSet(nSel)->GetTileIDTable();
-    ASSERT(pPieceTbl != NULL);
-    m_listTile.SetItemMap(pPieceTbl);
+    const std::vector<TileID>& pPieceTbl = pTMgr->GetTileSet(value_preserving_cast<size_t>(nSel)).GetTileIDTable();
+    m_listTile.SetItemMap(&pPieceTbl);
 }
 
 /////////////////////////////////////////////////////////////////////////////

--- a/GM/SelObjs.cpp
+++ b/GM/SelObjs.cpp
@@ -418,10 +418,10 @@ CRect CSelPoly::GetRect()
     int xmin = INT_MAX, xmax = INT_MIN, ymin = INT_MAX, ymax = INT_MIN;
     for (int i = 0; i < m_nPnts; i++)
     {
-        xmin = min(xmin, m_pPnts[i].x);
-        xmax = max(xmax, m_pPnts[i].x);
-        ymin = min(ymin, m_pPnts[i].y);
-        ymax = max(ymax, m_pPnts[i].y);
+        xmin = CB::min(xmin, m_pPnts[i].x);
+        xmax = CB::max(xmax, m_pPnts[i].x);
+        ymin = CB::min(ymin, m_pPnts[i].y);
+        ymax = CB::max(ymax, m_pPnts[i].y);
     }
     rct.SetRect(xmin, ymin, xmax, ymax);
     return rct;
@@ -668,10 +668,10 @@ void CSelList::Open()
 // Assumes RECTs are normalized!!
 void CbUnionRect(RECT* pRctDst, RECT* pRctSrc1, RECT* pRctSrc2)
 {
-    pRctDst->left = min(pRctSrc1->left, pRctSrc2->left);
-    pRctDst->top = min(pRctSrc1->top, pRctSrc2->top);
-    pRctDst->right = max(pRctSrc1->right, pRctSrc2->right);
-    pRctDst->bottom = max(pRctSrc1->bottom, pRctSrc2->bottom);
+    pRctDst->left = CB::min(pRctSrc1->left, pRctSrc2->left);
+    pRctDst->top = CB::min(pRctSrc1->top, pRctSrc2->top);
+    pRctDst->right = CB::max(pRctSrc1->right, pRctSrc2->right);
+    pRctDst->bottom = CB::max(pRctSrc1->bottom, pRctSrc2->bottom);
 }
 
 void CSelList::CalcEnclosingRect()

--- a/GM/StdAfx.h
+++ b/GM/StdAfx.h
@@ -55,8 +55,7 @@
 #include <dde.h>
 #include <math.h>
 
-// use explicitly sized ints for portable file format control
-#include <cstdint>
+#include "CyberBoard.h"
 
 #ifdef _UNICODE
 #if defined _M_IX86

--- a/GM/ToolImag.cpp
+++ b/GM/ToolImag.cpp
@@ -170,10 +170,10 @@ void CBitSelectTool::OnMouseMove(CBitEditView* pView, UINT nFlags, CPoint point)
     {
         pView->GetImagePixelLoc(point);
         // Make sure drag doesn't leave image.
-        point.x = max(point.x, m_rctBound.left);
-        point.y = max(point.y, m_rctBound.top);
-        point.x = min(point.x, m_rctBound.right);
-        point.y = min(point.y, m_rctBound.bottom);
+        point.x = CB::max(point.x, m_rctBound.left);
+        point.y = CB::max(point.y, m_rctBound.top);
+        point.x = CB::min(point.x, m_rctBound.right);
+        point.y = CB::min(point.y, m_rctBound.bottom);
 
         if (point == c_ptLast)
             return;

--- a/GM/VwBitedt.cpp
+++ b/GM/VwBitedt.cpp
@@ -611,10 +611,10 @@ void CBitEditView::GetImagePixelLocClamped(CPoint& point)
     point -= CSize(xBorder, yBorder);
     point.x = point.x / (int)m_nZoom;
     point.y = point.y / (int)m_nZoom;
-    point.x = max(point.x, 0);
-    point.x = min(point.x, m_size.cx - 1);
-    point.y = max(point.y, 0);
-    point.y = min(point.y, m_size.cy - 1);
+    point.x = CB::max(point.x, 0);
+    point.x = CB::min(point.x, m_size.cx - 1);
+    point.y = CB::max(point.y, 0);
+    point.y = CB::min(point.y, m_size.cy - 1);
 }
 
 void CBitEditView::InvalidateFocusBorder(BOOL bUpdate /* = FALSE */)
@@ -683,8 +683,8 @@ void CBitEditView::RecalcScrollLimits()
         CSize size = GetZoomedSize();
         SetScrollSizes(MM_TEXT, CSize(size.cx + 2 * xBorder,
             size.cy + 2 * yBorder),
-            CSize(max(size.cx/4, 16),
-            max(size.cy/4, 16)), CSize(4, 4));
+            CSize(CB::max(size.cx/4, 16),
+            CB::max(size.cy/4, 16)), CSize(4, 4));
     }
     else
         SetScrollSizes(MM_TEXT, CSize(100, 100));
@@ -725,7 +725,7 @@ int CBitEditView::CalcCaretHeight(int yLoc)
 {
     if (yLoc >= m_size.cy) return 0;
     int yEnd = yLoc + m_tmHeight;
-    yEnd = min(yEnd, m_size.cy);
+    yEnd = CB::min(yEnd, m_size.cy);
     return yEnd - yLoc;
 }
 
@@ -1152,13 +1152,12 @@ void CBitEditView::OnImageBoardMask()
 
     CBoardMaskDialog dlg;
     dlg.m_pBMgr = pBMgr;
-    if (dlg.DoModal() != IDOK || dlg.m_nBrdNum < 0)
+    if (dlg.DoModal() != IDOK || dlg.m_nBrdNum == Invalid_v<size_t>)
         return;
 
-    CBoard* pBoard = pBMgr->GetBoard(dlg.m_nBrdNum);
+    CBoard& pBoard = pBMgr->GetBoard(dlg.m_nBrdNum);
 
-    ASSERT(pBoard);
-    CCellForm* pcf = pBoard->GetBoardArray()->
+    CCellForm* pcf = pBoard.GetBoardArray()->
         GetCellForm(m_pSelView->GetCurrentScale());
     ASSERT(pcf);
 
@@ -1190,7 +1189,7 @@ void CBitEditView::OnImageBoardMask()
 void CBitEditView::OnUpdateImageBoardMask(CCmdUI* pCmdUI)
 {
     pCmdUI->Enable(m_pSelView->GetCurrentScale() != smallScale &&
-        GetDocument()->GetBoardManager()->GetNumBoards() > 0);
+        !GetDocument()->GetBoardManager()->IsEmpty());
 }
 
 void CBitEditView::OnUpdateViewZoomIn(CCmdUI* pCmdUI)

--- a/GM/VwEdtbrd.cpp
+++ b/GM/VwEdtbrd.cpp
@@ -181,7 +181,7 @@ void CBrdEditView::OnInitialUpdate()
 void CBrdEditView::OnUpdate(CView* pSender, LPARAM lHint, CObject* pHint)
 {
     WORD wHint = LOWORD(lHint);
-    TileID tid = (TileID)HIWORD(lHint);
+    TileID tid = static_cast<TileID>(HIWORD(lHint));
     if ((wHint == HINT_TILEMODIFIED && m_pBoard->IsTileInUse(tid)) ||
         wHint == HINT_TILEDELETED || wHint == HINT_TILESETDELETED)
     {
@@ -190,7 +190,7 @@ void CBrdEditView::OnUpdate(CView* pSender, LPARAM lHint, CObject* pHint)
     }
     else if (wHint == HINT_BOARDDELETED)
     {
-        if (((CGmBoxHint*)pHint)->m_pBoard == m_pBoard)
+        if (static_cast<CGmBoxHint*>(pHint)->GetArgs<HINT_BOARDDELETED>().m_pBoard == m_pBoard)
         {
             CFrameWnd* pFrm = GetParentFrame();
             ASSERT(pFrm != NULL);
@@ -199,7 +199,7 @@ void CBrdEditView::OnUpdate(CView* pSender, LPARAM lHint, CObject* pHint)
     }
     else if (wHint == HINT_BOARDPROPCHANGE)
     {
-        if (((CGmBoxHint*)pHint)->m_pBoard == m_pBoard)
+        if (static_cast<CGmBoxHint*>(pHint)->GetArgs<HINT_BOARDPROPCHANGE>().m_pBoard == m_pBoard)
         {
             SetScrollSizes(MM_TEXT, m_pBoard->GetSize(m_nZoom));
             Invalidate(FALSE);
@@ -561,7 +561,7 @@ void CBrdEditView::OnViewGridLines()
     EndWaitCursor();
 
     CGmBoxHint hint;
-    hint.m_pBoard = m_pBoard;
+    hint.GetArgs<HINT_BOARDPROPCHANGE>().m_pBoard = m_pBoard;
     GetDocument()->UpdateAllViews(this, HINT_BOARDPROPCHANGE, &hint);
 }
 
@@ -1550,7 +1550,7 @@ void CBrdEditView::OnUpdateToolsBrdSnapGrid(CCmdUI* pCmdUI)
 
 void CBrdEditView::OnToolsBrdProps()
 {
-    GetDocument()->DoBoardPropertyDialog(m_pBoard);
+    GetDocument()->DoBoardPropertyDialog(*m_pBoard);
 }
 
 static void SetObjVisibility(CDrawObj* pObj, DWORD dwUser)
@@ -2251,7 +2251,7 @@ BOOL CBrdEditView::DoMouseWheelFix(UINT fFlags, short zDelta, CPoint point)
             else
             {
                 nDisplacement = nToScroll * m_lineDev.cy;
-                nDisplacement = min(nDisplacement, m_pageDev.cy);
+                nDisplacement = CB::min(nDisplacement, m_pageDev.cy);
             }
             bResult = OnScrollBy(CSize(0, nDisplacement), TRUE);
         }
@@ -2266,7 +2266,7 @@ BOOL CBrdEditView::DoMouseWheelFix(UINT fFlags, short zDelta, CPoint point)
             else
             {
                 nDisplacement = nToScroll * m_lineDev.cx;
-                nDisplacement = min(nDisplacement, m_pageDev.cx);
+                nDisplacement = CB::min(nDisplacement, m_pageDev.cx);
             }
             bResult = OnScrollBy(CSize(nDisplacement, 0), TRUE);
         }

--- a/GM/VwPrjgbx.h
+++ b/GM/VwPrjgbx.h
@@ -46,7 +46,29 @@
 /////////////////////////////////////////////////////////////////////////////
 // CGbxProjView view
 
-class CGbxProjView : public CView
+/* KLUDGE:  CProjListBox<T> uses Invalid<T>, so Invalid<T>
+    must be explicit instantiated before using CProjListBox<T>.
+    However, explicit instantiation can't be done in class
+    definition.  Therefore, T must be declared in a separate
+    class definition.  */
+namespace CB { namespace Impl
+{
+    class CGbxProjViewBase
+    {
+    public:
+        // Project list box grouping order.
+        enum { grpDoc, grpBHdr, grpBrd, grpTHdr, grpTile, grpPHdr,
+            grpPce, grpMHdr, grpMark };
+    };
+
+    template<>
+    struct Invalid<decltype(CGbxProjViewBase::grpDoc)>
+    {
+        static constexpr decltype(CGbxProjViewBase::grpDoc) value = static_cast<decltype(CGbxProjViewBase::grpDoc)>(std::numeric_limits<std::underlying_type_t<decltype(CGbxProjViewBase::grpDoc)>>::max());
+    };
+}}
+
+class CGbxProjView : public CView, private CB::Impl::CGbxProjViewBase
 {
     DECLARE_DYNCREATE(CGbxProjView)
 protected:
@@ -54,14 +76,10 @@ protected:
 
 // Attributes
 public:
-    // Project list box grouping order.
-    enum { grpDoc, grpBHdr, grpBrd, grpTHdr, grpTile, grpPHdr,
-        grpPce, grpMHdr, grpMark };
-
     CGamDoc* GetDocument() { return (CGamDoc*)m_pDocument; }
 
     // Various controls...
-    CProjListBox    m_listProj;         // Main project box
+    CProjListBox<decltype(grpDoc)>    m_listProj;         // Main project box
 
     CEdit           m_editInfo;         // Used for various project info/help
     CTileListBox    m_listTiles;        // For viewing tiles

--- a/GM/VwTilesl.cpp
+++ b/GM/VwTilesl.cpp
@@ -121,7 +121,7 @@ void CTileSelView::OnInitialUpdate()
     m_pTileMgr = GetDocument()->GetTileManager();
     ASSERT(m_pTileMgr != NULL);
     CScrollView::OnInitialUpdate();
-    m_tid = (TileID)(DWORD)GetDocument()->GetCreateParameter();
+    m_tid = static_cast<TileID>(reinterpret_cast<uintptr_t>(GetDocument()->GetCreateParameter()));
     ASSERT(m_tid != nullTid);
 
     CTile tile;
@@ -159,7 +159,7 @@ void CTileSelView::OnUpdate(CView* pSender, LPARAM lHint, CObject* pHint)
 
     if (wHint == HINT_TILEDELETED)
     {
-        if ((TileID)HIWORD(lHint) == m_tid)
+        if (static_cast<TileID>(HIWORD(lHint)) == m_tid)
         {
             m_bNoUpdate = TRUE;
             CFrameWnd* pFrm = GetParentFrame();
@@ -297,7 +297,7 @@ void CTileSelView::UpdateDocumentTiles()
 
     // Finally handle various notifications
     pDoc->UpdateAllViews(this,
-        MAKELPARAM(HINT_TILEMODIFIED, m_tid), NULL);
+        MAKELPARAM(HINT_TILEMODIFIED, static_cast<WORD>(m_tid)), NULL);
     pDoc->SetModifiedFlag();
 }
 

--- a/GP/CBPlay32.vcxproj
+++ b/GP/CBPlay32.vcxproj
@@ -277,6 +277,7 @@ echo off
     <ResourceCompile Include="Cbplay.rc" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="..\GShr\CyberBoard.h" />
     <ClInclude Include="Arrows.h" />
     <ClInclude Include="..\GShr\Atom.h" />
     <ClInclude Include="..\GShr\BarCbDock.h" />

--- a/GP/Cbplay.rc
+++ b/GP/Cbplay.rc
@@ -1798,7 +1798,7 @@ BEGIN
     IDS_WARN_DISCARD_COMP_MOVE
                             "Are you sure you want to discard your compound move?"
     IDS_MSG_ROLLSET         "SET"
-    IDS_WARN_PIECESDELETED  "Pieces were defined in the current game that no longer exist in the GameBox file. A total of %d piece(s) have been removed from the game."
+    IDS_WARN_PIECESDELETED  "Pieces were defined in the current game that no longer exist in the GameBox file. A total of %zu piece(s) have been removed from the game."
     IDS_TIP_OBJTEXTCHG      "This object's text has changed"
     IDS_TIP_OBJLOCKED       "Objects have been locked on this playing board.\r\n\r\nLocked objects cannot be selected."
     IDS_TIP_OBJUNLOCKED     "Objects have been unlocked on this playing board."
@@ -1807,8 +1807,8 @@ BEGIN
     IDS_TIP_PREFIX_BACK     "Back: "
     IDS_TIP_LBOXITEM_MARKER "* "
     IDS_TIP_CLICK_MENU      "Click here for tray's menu"
-    IDS_TIP_TRAY_SHUFFLED   "%d pieces in this tray have been shuffled."
-    IDS_TIP_OBJS_SHUFFLED   "%d objects in this area of the board have been shuffled."
+    IDS_TIP_TRAY_SHUFFLED   "%zu pieces in this tray have been shuffled."
+    IDS_TIP_OBJS_SHUFFLED   "%zu objects in this area of the board have been shuffled."
     IDS_TIP_SELLIST_HELP    "Insert key = Selects only highlighted items.\r\nDelete key = Deselects all highlighted items."
 END
 

--- a/GP/Cbplay32.vcxproj.filters
+++ b/GP/Cbplay32.vcxproj.filters
@@ -619,6 +619,9 @@
     <ClInclude Include="WStateGp.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="..\GShr\CyberBoard.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <Image Include="res\BadColum.bmp">

--- a/GP/DlgItray.cpp
+++ b/GP/DlgItray.cpp
@@ -99,13 +99,13 @@ BOOL CImportTraysDlg::OnInitDialog()
     // already doesn't exist as a tray in the scenario, add it to the
     // listbox.
 
-    for (int nPSet = 0; nPSet < pPMgr->GetNumPieceSets(); nPSet++)
+    for (size_t nPSet = 0; nPSet < pPMgr->GetNumPieceSets(); nPSet++)
     {
-        CString strName = pPMgr->GetPieceSet(nPSet)->GetName();
-        int nTray;
+        CString strName = pPMgr->GetPieceSet(nPSet).GetName();
+        size_t nTray;
         for (nTray = 0; nTray < pYMgr->GetNumTraySets(); nTray++)
         {
-            if (strName.CompareNoCase(pYMgr->GetTraySet(nTray)->GetName()) == 0)
+            if (strName.CompareNoCase(pYMgr->GetTraySet(nTray).GetName()) == 0)
                 break;
         }
         if (nTray >= pYMgr->GetNumTraySets())
@@ -133,18 +133,18 @@ void CImportTraysDlg::OnOK()
         if (m_listGroups.GetCheck(i) > 0)
         {
             CString strTrayName;
-            int nPSet = (int)m_listGroups.GetItemData(i);
-            CPieceSet* pPSet = pPMgr->GetPieceSet(nPSet);
+            size_t nPSet = value_preserving_cast<size_t>(m_listGroups.GetItemData(i));
+            CPieceSet& pPSet = pPMgr->GetPieceSet(nPSet);
 
             // Create tray and add pieces...
-            int nTray = pYMgr->CreateTraySet(pPSet->GetName());
-            CTraySet* pYSet = pYMgr->GetTraySet(nTray);
+            size_t nTray = pYMgr->CreateTraySet(pPSet.GetName());
+            CTraySet& pYSet = pYMgr->GetTraySet(nTray);
 
             // Locate only those pieces that aren't currently being used.
-            CWordArray arrUnusedPieces;
-            pPTbl->LoadUnusedPieceList(&arrUnusedPieces, nPSet);
-            pPTbl->SetPieceListAsFrontUp(&arrUnusedPieces);
-            pYSet->AddPieceList(&arrUnusedPieces);
+            std::vector<PieceID> arrUnusedPieces;
+            pPTbl->LoadUnusedPieceList(arrUnusedPieces, nPSet);
+            pPTbl->SetPieceListAsFrontUp(arrUnusedPieces);
+            pYSet.AddPieceList(arrUnusedPieces);
         }
     }
     CDialog::OnOK();

--- a/GP/DlgSlbrd.h
+++ b/GP/DlgSlbrd.h
@@ -40,12 +40,12 @@ public:
     CCheckListBox   m_listBoards;
     //}}AFX_DATA
 
-    CWordArray  m_tblBrds;      // Table of board serial numbers
+    std::vector<BoardID> m_tblBrds;      // Table of board serial numbers
     CBoardManager* m_pBMgr;     // Pointer to gamebox board manager.
 
 // Implementation
 protected:
-    int FindSerialNumberListIndex(int nSerial);
+    int FindSerialNumberListIndex(BoardID nSerial) const;
 
     virtual void DoDataExchange(CDataExchange* pDX);    // DDX/DDV support
 

--- a/GP/DlgSpece.h
+++ b/GP/DlgSpece.h
@@ -56,8 +56,8 @@ protected:
     CPieceTable*    m_pPTbl;        // Loaded using doc pointer
     CTrayManager*   m_pYMgr;        // Loaded using doc pointer
 
-    CWordArray      m_tblPiece;
-    CWordArray      m_tblTray;
+    std::vector<PieceID> m_tblPiece;
+    std::vector<PieceID> m_tblTray;
 
     // -------- //
     void LoadPieceNameList();

--- a/GP/DlgYnew.cpp
+++ b/GP/DlgYnew.cpp
@@ -72,8 +72,8 @@ void CTrayNewDialog::OnOK()
         m_editName.SetFocus();
         return;
     }
-    int nSel = m_pYMgr->FindTrayByName(m_strName);
-    if (nSel != -1)
+    size_t nSel = m_pYMgr->FindTrayByName(m_strName);
+    if (nSel != Invalid_v<size_t>)
     {
         AfxMessageBox(IDS_ERR_TRAYNAMEUSED, MB_OK | MB_ICONINFORMATION);
         m_editName.SetFocus();

--- a/GP/DlgYprop.cpp
+++ b/GP/DlgYprop.cpp
@@ -44,7 +44,7 @@ CTrayPropDialog::CTrayPropDialog(CWnd* pParent /*=NULL*/)
     m_nVizOpts = -1;
     m_bRandomSel = FALSE;
     //}}AFX_DATA_INIT
-    m_nYSel = -1;
+    m_nYSel = Invalid_v<size_t>;
     m_nOwnerSel = -1;
     m_bNonOwnerAccess = FALSE;
     m_pPlayerMgr = NULL;
@@ -134,8 +134,8 @@ void CTrayPropDialog::OnOK()
         m_editName.SetFocus();
         return;
     }
-    int nSel = m_pYMgr->FindTrayByName(m_strName);
-    if (nSel != -1 && nSel != m_nYSel)
+    size_t nSel = m_pYMgr->FindTrayByName(m_strName);
+    if (nSel != Invalid_v<size_t> && nSel != m_nYSel)
     {
         AfxMessageBox(IDS_ERR_TRAYNAMEUSED, MB_OK | MB_ICONINFORMATION);
         m_editName.SetFocus();
@@ -160,9 +160,9 @@ BOOL CTrayPropDialog::OnInitDialog()
 {
     CDialog::OnInitDialog();
     ASSERT(m_pYMgr);
-    ASSERT(m_nYSel != -1);
+    ASSERT(m_nYSel != Invalid_v<size_t>);
 
-    m_editName.SetWindowText(m_pYMgr->GetTraySet(m_nYSel)->GetName());
+    m_editName.SetWindowText(m_pYMgr->GetTraySet(m_nYSel).GetName());
     if (m_pPlayerMgr == NULL)
     {
         m_comboOwners.EnableWindow(FALSE);

--- a/GP/DlgYprop.h
+++ b/GP/DlgYprop.h
@@ -49,7 +49,7 @@ public:
     BOOL    m_bRandomSel;
     //}}AFX_DATA
 
-    int             m_nYSel;
+    size_t          m_nYSel;
     int             m_nOwnerSel;    // -1 = no owner, 0 = first player, ....
     BOOL            m_bNonOwnerAccess;
     BOOL            m_bEnforceVizForOwnerToo;

--- a/GP/FileLib.cpp
+++ b/GP/FileLib.cpp
@@ -78,7 +78,7 @@ BOOL CopyOpenFiles(CFile* pSrcFile, CFile* pDestFile, DWORD dwLen)
         pszBfr = new char[COPY_BFR_LEN];
         while (TRUE)
         {
-            UINT nRead = (UINT)min(dwLen, (DWORD)COPY_BFR_LEN);
+            UINT nRead = value_preserving_cast<UINT>(CB::min(dwLen, COPY_BFR_LEN));
             pSrcFile->Read(pszBfr, nRead);
             pDestFile->Write(pszBfr, nRead);
             dwLen -= nRead;

--- a/GP/GamDoc5.cpp
+++ b/GP/GamDoc5.cpp
@@ -292,7 +292,7 @@ CRollState* CGamDoc::GetDieRollState()
 // coordinates. If either of the coordinates are -1, the center of
 // the view receives the tip.
 
-void CGamDoc::EventShowBoardNotification(int nBrdSerNum, CPoint pntTipLoc, CString strMsg)
+void CGamDoc::EventShowBoardNotification(BoardID nBrdSerNum, CPoint pntTipLoc, CString strMsg)
 {
     if (IsQuietPlayback()) return;
 
@@ -302,16 +302,16 @@ void CGamDoc::EventShowBoardNotification(int nBrdSerNum, CPoint pntTipLoc, CStri
 
     if (pntTipLoc.x == -1 || pntTipLoc.y == -1)
     {
-        EnsureBoardVisible(pPBoard);
-        pView = (CPlayBoardView*)FindPBoardView(pPBoard);
+        EnsureBoardVisible(*pPBoard);
+        pView = (CPlayBoardView*)FindPBoardView(*pPBoard);
         CRect rct;
         pView->GetClientRect(rct);
         pntTipLoc = rct.CenterPoint();
     }
     else
     {
-        EnsureBoardLocationVisible(pPBoard, pntTipLoc);
-        pView = (CPlayBoardView*)FindPBoardView(pPBoard);
+        EnsureBoardLocationVisible(*pPBoard, pntTipLoc);
+        pView = (CPlayBoardView*)FindPBoardView(*pPBoard);
         pView->WorkspaceToClient(pntTipLoc);
     }
     pView->SetNotificationTip(pntTipLoc, strMsg);
@@ -322,11 +322,11 @@ void CGamDoc::EventShowBoardNotification(int nBrdSerNum, CPoint pntTipLoc, CStri
 // If the piece id is null or not found in the tray, the center of the
 // listbox receives the tip.
 
-void CGamDoc::EventShowTrayNotification(int nTrayNum, PieceID pid, CString strMsg)
+void CGamDoc::EventShowTrayNotification(size_t nTrayNum, PieceID pid, CString strMsg)
 {
     if (IsQuietPlayback()) return;
 
-    CTraySet* pYGrp = GetTrayManager()->GetTraySet(nTrayNum);
+    CTraySet& pYGrp = GetTrayManager()->GetTraySet(nTrayNum);
     SelectTrayItem(pYGrp, pid, strMsg);
 }
 

--- a/GP/GamState.cpp
+++ b/GP/GamState.cpp
@@ -45,7 +45,6 @@ CGameState::CGameState()
 {
     m_pDoc = NULL;
     m_pPBMgr = NULL;
-    m_pYMgr = NULL;
     m_pPTbl = NULL;
 }
 
@@ -53,7 +52,6 @@ CGameState::CGameState(CGamDoc* pDoc)
 {
     m_pDoc = pDoc;
     m_pPBMgr = NULL;
-    m_pYMgr = NULL;
     m_pPTbl = NULL;
 }
 
@@ -61,15 +59,14 @@ BOOL CGameState::CompareState()
 {
     ASSERT(m_pDoc != NULL);
     ASSERT(m_pPBMgr != NULL);
-    ASSERT(m_pYMgr != NULL);
     ASSERT(m_pPTbl != NULL);
     // Compare the string tables
 
     // Compare the piece tables
-    if (!m_pDoc->GetPieceTable()->Compare(m_pPTbl))
+    if (!m_pDoc->GetPieceTable()->Compare(*m_pPTbl))
         return FALSE;
     // Compare the play boards
-    if (!m_pDoc->GetPBoardManager()->Compare(m_pPBMgr))
+    if (!m_pDoc->GetPBoardManager()->Compare(*m_pPBMgr))
         return FALSE;
     // Compare the trays
     if (!m_pDoc->GetTrayManager()->Compare(m_pYMgr))
@@ -101,15 +98,14 @@ BOOL CGameState::RestoreState()
 {
     ASSERT(m_pDoc != NULL);
     ASSERT(m_pPBMgr != NULL);
-    ASSERT(m_pYMgr != NULL);
     ASSERT(m_pPTbl != NULL);
 
     TRY
     {
         m_pDoc->GetGameStringMap()->Clone(&m_mapString);
-        m_pDoc->GetPBoardManager()->Restore(m_pDoc, m_pPBMgr);
+        m_pDoc->GetPBoardManager()->Restore(m_pDoc, *m_pPBMgr);
         m_pDoc->GetTrayManager()->Restore(m_pDoc, m_pYMgr);
-        m_pDoc->GetPieceTable()->Restore(m_pDoc, m_pPTbl);
+        m_pDoc->GetPieceTable()->Restore(m_pDoc, *m_pPTbl);
     }
     CATCH_ALL(e)
     {
@@ -125,8 +121,7 @@ void CGameState::Clear()
 
     if (m_pPBMgr != NULL) delete m_pPBMgr;
     m_pPBMgr = NULL;
-    if (m_pYMgr != NULL) delete m_pYMgr;
-    m_pYMgr = NULL;
+    m_pYMgr.Clear();
     if (m_pPTbl != NULL) delete m_pPTbl;
     m_pPTbl = NULL;
 }
@@ -142,14 +137,13 @@ void CGameState::Serialize(CArchive& ar)
         Clear();
 
         m_pPBMgr = new CPBoardManager;
-        m_pYMgr = new CTrayManager;
         m_pPTbl = new CPieceTable;
 
         if (CGamDoc::GetLoadingVersion() >= NumVersion(2, 0))
             m_mapString.Serialize(ar);                  // V2.0
     }
     m_pPBMgr->Serialize(ar);
-    m_pYMgr->Serialize(ar);
+    m_pYMgr.Serialize(ar);
     m_pPTbl->Serialize(ar);
 }
 

--- a/GP/GamState.h
+++ b/GP/GamState.h
@@ -67,7 +67,7 @@ protected:
     // --------- //
     CGameElementStringMap m_mapString; // Text set by player
     CPBoardManager* m_pPBMgr;   // Playing boards in use.
-    CTrayManager*   m_pYMgr;    // Content of trays manager
+    CTrayManager    m_pYMgr;    // Content of trays manager
     CPieceTable*    m_pPTbl;    // The playing piece table.
 };
 

--- a/GP/GeoBoard.h
+++ b/GP/GeoBoard.h
@@ -30,19 +30,16 @@
 class CBoard;
 class CGamDoc;
 
-// The starting serial number for geomorpically created boards.
-const int GEO_BOARD_SERNUM_BASE = 1000;
-
 /////////////////////////////////////////////////////////////////////////////
 
 struct CGeoBoardElement
 {
-    int m_nBoardSerialNum;
+    BoardID m_nBoardSerialNum;
 
 public:
     CGeoBoardElement();
     CGeoBoardElement(CGeoBoardElement& geo);
-    CGeoBoardElement(int nBoardSerialNum);
+    CGeoBoardElement(BoardID nBoardSerialNum);
 
 public:
     void Serialize(CArchive& ar);
@@ -60,8 +57,8 @@ public:
 public:
     void SetName(LPCTSTR pszName) { m_strName = pszName; }
 
-    void SetSerialNumber(int nBoardSerialNumber) { m_nSerialNum = nBoardSerialNumber; }
-    int  GetSerialNumber() { return m_nSerialNum; }
+    void SetSerialNumber(BoardID nBoardSerialNumber) { m_nSerialNum = nBoardSerialNumber; }
+    BoardID GetSerialNumber() const { return m_nSerialNum; }
 
     void SetBoardRowCount(int nBoardRowCount) { m_nBoardRowCount = nBoardRowCount; }
     void SetBoardColCount(int nBoardColCount) { m_nBoardColCount = nBoardColCount; }
@@ -73,14 +70,14 @@ public:
 public:
     CBoard* CreateBoard(CGamDoc* pDoc);
 
-    int  AddElement(int nBoardSerialNum);
+    int  AddElement(BoardID nBoardSerialNum);
 
     void Serialize(CArchive& ar);
 
 // Implementation - methods
 protected:
-    CBoard* GetBoard(int nBoardRow, int nBoardCol);
-    CBoard* CloneBoard(CBoard* pOrigBoard);
+    CBoard& GetBoard(int nBoardRow, int nBoardCol);
+    CBoard* CloneBoard(CBoard& pOrigBoard);
     void    ComputeNewBoardDimensions(int& rnRows, int& rnCols);
     CPoint  ComputeGraphicalOffset(int nBoardRow, int nBoardCol);
     void    ComputeCellOffset(int nBoardRow, int nBoardCol, int& rnCellRow, int& rnCellCol);
@@ -91,12 +88,12 @@ protected:
                 CBoardArray* pBARight, int nRowLeft, int nColLeft, int nRowRight, int nColRight);
     void    CombineTopAndBottom(CBitmap& bmap, TileScale eScale, CBoardArray* pBATop,
                 CBoardArray* pBABottom, int nRowTop, int nColTop, int nRowBottom, int nColBottom);
-    int     GetSpecialTileSet();
+    size_t  GetSpecialTileSet();
 
 // Implementation - vars
 protected:
     CString m_strName;                  // The board's name
-    int     m_nSerialNum;               // The issued serial number
+    BoardID m_nSerialNum;               // The issued serial number
 
     int     m_nBoardRowCount;           // Number of boards vertically
     int     m_nBoardColCount;           // Number of boards horizontally

--- a/GP/Gp.h
+++ b/GP/Gp.h
@@ -48,7 +48,7 @@
 
 #define WM_ROTATEPIECE_DELTA    (WM_USER + 210) // WPARAM = (int)relative rotation delta
 #define WM_CENTERBOARDONPOINT   (WM_USER + 211) // WPARAM = POINT* in board coords
-#define WM_SHOWPLAYINGBOARD     (WM_USER + 212) // WPARAM = Playing Board Index
+#define WM_SHOWPLAYINGBOARD     (WM_USER + 212) // WPARAM = size_t Playing Board Index
 #define WM_WINSTATE_RESTORE     (WM_USER + 213) // No Args. Posted to project window
 #define WM_SELECT_BOARD_OBJLIST (WM_USER + 214) // WPARAM = CPlayBoard*, LPARAM = CPtrList*
 

--- a/GP/LBoxSlct.h
+++ b/GP/LBoxSlct.h
@@ -54,7 +54,7 @@ public:
 
 // Attributes
 public:
-    virtual CTileManager* GetTileManager();
+    virtual CTileManager* GetTileManager() override;
 
 // Operations
 public:
@@ -65,22 +65,22 @@ protected:
     CGamDoc*    m_pDoc;
 
     // Misc
-    TileID CSelectListBox::GetTileID(BOOL bActiveIfApplies, int nIndex);
+    TileID GetTileID(BOOL bActiveIfApplies, size_t nIndex);
     void GetTileRectsForTwoSidedView(int nLBoxIndex, CRect& rctLeft, CRect& rctRight);
 
     // Overrides
-    virtual int OnItemHeight(int nIndex);
-    virtual void OnItemDraw(CDC* pDC, int nIndex, UINT nAction, UINT nState,
-        CRect rctItem);
-    virtual BOOL OnDragSetup(DragInfo* pDI);
+    virtual unsigned OnItemHeight(size_t nIndex) override;
+    virtual void OnItemDraw(CDC* pDC, size_t nIndex, UINT nAction, UINT nState,
+        CRect rctItem) override;
+    virtual BOOL OnDragSetup(DragInfo* pDI) override;
 
-    virtual void OnGetItemDebugString(int nIndex, CString& str);
+    virtual void OnGetItemDebugString(size_t nItem, CString& str) override;
 
     // Tool tip processing
-    virtual BOOL OnIsToolTipsEnabled();
-    virtual int  OnGetHitItemCodeAtPoint(CPoint point, CRect& rct);
-    virtual void OnGetTipTextForItemCode(int nItemCode, CString& strTip, CString& strTitle);
-    virtual BOOL OnDoesItemHaveTipText(int nItem);
+    virtual BOOL OnIsToolTipsEnabled() override;
+    virtual int  OnGetHitItemCodeAtPoint(CPoint point, CRect& rct) override;
+    virtual void OnGetTipTextForItemCode(int nItemCode, CString& strTip, CString& strTitle) override;
+    virtual BOOL OnDoesItemHaveTipText(size_t nItem) override;
 
     //{{AFX_MSG(CSelectListBox)
     afx_msg LRESULT OnDragItem(WPARAM wParam, LPARAM lParam);

--- a/GP/LBoxTray.h
+++ b/GP/LBoxTray.h
@@ -44,7 +44,7 @@ enum  TrayViz;
 
 /////////////////////////////////////////////////////////////////////////////
 
-class CTrayListBox : public CTileBaseListBox
+class CTrayListBox : public CGrafixListBoxData<CTileBaseListBox, PieceID>
 {
 // Construction
 public:
@@ -52,7 +52,7 @@ public:
 
 // Attributes
 public:
-    virtual CTileManager* GetTileManager();
+    virtual CTileManager* GetTileManager() override;
 
     TrayViz GetTrayContentVisibility() { return m_eTrayViz; }
 
@@ -61,7 +61,7 @@ public:
 // Operations
 public:
     void DeselectAll();
-    int  SelectTrayPiece(PieceID pid);
+    size_t SelectTrayPiece(PieceID pid);
     void ShowListIndex(int nPos);
 
     void SetDocument(CGamDoc *pDoc);
@@ -74,7 +74,7 @@ public:
 
 // Implementation
 protected:
-    void GetPieceTileIDs(int nIndex, TileID& tid1, TileID& tid2);
+    void GetPieceTileIDs(size_t nIndex, TileID& tid1, TileID& tid2);
 
 // Implementation
 protected:
@@ -85,16 +85,16 @@ protected:
     BOOL        m_bAllowTips;
 
     // Overrides
-    virtual int OnItemHeight(int nIndex);
-    virtual void OnItemDraw(CDC* pDC, int nIndex, UINT nAction, UINT nState,
-        CRect rctItem);
-    virtual BOOL OnDragSetup(DragInfo* pDI);
+    virtual unsigned OnItemHeight(size_t nIndex) override;
+    virtual void OnItemDraw(CDC* pDC, size_t nIndex, UINT nAction, UINT nState,
+        CRect rctItem) override;
+    virtual BOOL OnDragSetup(DragInfo* pDI) override;
 
     // Tool tip processing
-    virtual BOOL OnIsToolTipsEnabled();
-    virtual int  OnGetHitItemCodeAtPoint(CPoint point, CRect& rct);
-    virtual void OnGetTipTextForItemCode(int nItemCode, CString& strTip, CString& strTitle);
-    virtual BOOL OnDoesItemHaveTipText(int nItem);
+    virtual BOOL OnIsToolTipsEnabled() override;
+    virtual int  OnGetHitItemCodeAtPoint(CPoint point, CRect& rct) override;
+    virtual void OnGetTipTextForItemCode(int nItemCode, CString& strTip, CString& strTitle) override;
+    virtual BOOL OnDoesItemHaveTipText(size_t nItem) override;
 
     // Misc
 

--- a/GP/MapFace.h
+++ b/GP/MapFace.h
@@ -53,10 +53,10 @@ typedef DWORD ElementState;
 const DWORD MARKER_ELEMENT_FLAG = 0x80000000L; // Top set if a marker, else a piece
 
 inline ElementState MakePieceState(PieceID pid, WORD nFacingDegCW, BYTE nSide)
-    { return ((DWORD)pid << 12) | ((DWORD)nSide << 9) | (nFacingDegCW & 0x1FF); }
+    { return ((DWORD)static_cast<WORD>(pid) << 12) | ((DWORD)nSide << 9) | (nFacingDegCW & 0x1FF); }
 
 inline ElementState MakeMarkerState(MarkID mid, WORD nFacingDegCW)
-    { return ((DWORD)mid << 12) | (nFacingDegCW & 0x1FF) | MARKER_ELEMENT_FLAG; }
+    { return ((DWORD)static_cast<WORD>(mid) << 12) | (nFacingDegCW & 0x1FF) | MARKER_ELEMENT_FLAG; }
 
 inline int GetElementFacingAngle(ElementState elem)
 {
@@ -70,7 +70,7 @@ inline int GetElementFacingAngle(ElementState elem)
 class CTileFacingMap : public CMap< ElementState, ElementState, TileID, TileID >
 {
     CTileManager*   m_pTMgr;
-    int             m_nTileSet;         // Our private tile set
+    size_t          m_nTileSet;         // Our private tile set
 public:
     CTileFacingMap() { m_pTMgr = NULL; }
     CTileFacingMap(CTileManager* pTileMgr) { m_pTMgr = NULL; SetTileManager(pTileMgr); }

--- a/GP/MoveMgr.cpp
+++ b/GP/MoveMgr.cpp
@@ -67,7 +67,7 @@ void CMoveRecord::Serialize(CArchive& ar)
 /////////////////////////////////////////////////////////////////////
 // CBoardPieceMove methods....
 
-CBoardPieceMove::CBoardPieceMove(int nBrdSerNum, PieceID pid, CPoint pnt,
+CBoardPieceMove::CBoardPieceMove(BoardID nBrdSerNum, PieceID pid, CPoint pnt,
     PlacePos ePos)
 {
     m_eType = mrecPMove;
@@ -83,7 +83,7 @@ BOOL CBoardPieceMove::ValidatePieces(CGamDoc* pDoc)
 #ifdef _DEBUG
     BOOL bUsed = pDoc->GetPieceTable()->IsPieceUsed(m_pid);
     if (!bUsed)
-        TRACE1("CBoardPieceMove::ValidatePieces - Piece %u not in piece table.\n", m_pid);
+        TRACE1("CBoardPieceMove::ValidatePieces - Piece %u not in piece table.\n", value_preserving_cast<UINT>(static_cast<WORD>(m_pid)));
     return bUsed;
 #else
     return pDoc->GetPieceTable()->IsPieceUsed(m_pid);
@@ -100,7 +100,7 @@ void CBoardPieceMove::DoMoveSetup(CGamDoc* pDoc, int nMoveWithinGroup)
     {
         CRect rct = pObj->GetRect();
         CPoint ptCtr = GetMidRect(rct);
-        pDoc->EnsureBoardLocationVisible(pPBoard, ptCtr);
+        pDoc->EnsureBoardLocationVisible(*pPBoard, ptCtr);
         CPlayBoard* pPBrdDest = pDoc->GetPBoardManager()->
             GetPBoardBySerial(m_nBrdNum);
         ASSERT(pPBrdDest);
@@ -108,7 +108,7 @@ void CBoardPieceMove::DoMoveSetup(CGamDoc* pDoc, int nMoveWithinGroup)
             pObj->GetRect().Size());
     }
     else
-        pDoc->SelectTrayItem(pTray, m_pid);
+        pDoc->SelectTrayItem(*pTray, m_pid);
 }
 
 void CBoardPieceMove::DoMove(CGamDoc* pDoc, int nMoveWithinGroup)
@@ -121,7 +121,7 @@ void CBoardPieceMove::DoMove(CGamDoc* pDoc, int nMoveWithinGroup)
         GetPBoardBySerial(m_nBrdNum);
     ASSERT(pPBrdDest);
 
-    pDoc->EnsureBoardLocationVisible(pPBrdDest, m_ptCtr);
+    pDoc->EnsureBoardLocationVisible(*pPBrdDest, m_ptCtr);
 
     if (pDoc->FindPieceCurrentLocation(m_pid, pTrayFrom, pPBrdFrom, &pObj))
     {
@@ -138,7 +138,7 @@ void CBoardPieceMove::DoMove(CGamDoc* pDoc, int nMoveWithinGroup)
         CPoint ptCtr = GetMidRect(rct);
         pDoc->IndicateBoardPiece(pPBrdDest, ptCtr, rct.Size());
     }
-    pDoc->SelectObjectOnBoard(pPBrdDest, pObj);
+    pDoc->SelectObjectOnBoard(*pPBrdDest, pObj);
 }
 
 void CBoardPieceMove::DoMoveCleanup(CGamDoc* pDoc, int nMoveWithinGroup)
@@ -150,18 +150,17 @@ void CBoardPieceMove::Serialize(CArchive& ar)
     CMoveRecord::Serialize(ar);
     if (ar.IsStoring())
     {
-        ar << (WORD)m_pid;
-        ar << (short)m_nBrdNum;
+        ar << m_pid;
+        ar << m_nBrdNum;
         ar << (short)m_ePos;
         ar << (short)m_ptCtr.x;
         ar << (short)m_ptCtr.y;
     }
     else
     {
-        WORD wTmp;
         short sTmp;
-        ar >> wTmp; m_pid = (int)wTmp;
-        ar >> sTmp; m_nBrdNum = (int)sTmp;
+        ar >> m_pid;
+        ar >> m_nBrdNum;
         ar >> sTmp; m_ePos = (PlacePos)sTmp;
         ar >> sTmp; m_ptCtr.x = sTmp;
         ar >> sTmp; m_ptCtr.y = sTmp;
@@ -173,7 +172,7 @@ void CBoardPieceMove::DumpToTextFile(CFile& file)
 {
     char szBfr[256];
     wsprintf(szBfr, "    board = %d, pos = %d, pid = %d, @(%d, %d)\r\n",
-        m_nBrdNum, m_ePos, m_pid, m_ptCtr.x, m_ptCtr.y);
+        value_preserving_cast<int>(static_cast<WORD>(m_nBrdNum)), m_ePos, value_preserving_cast<int>(static_cast<WORD>(m_pid)), m_ptCtr.x, m_ptCtr.y);
     file.Write(szBfr, lstrlen(szBfr));
 }
 #endif
@@ -181,7 +180,7 @@ void CBoardPieceMove::DumpToTextFile(CFile& file)
 /////////////////////////////////////////////////////////////////////
 // CTrayPieceMove methods....
 
-CTrayPieceMove::CTrayPieceMove(int nTrayNum, PieceID pid, int nPos)
+CTrayPieceMove::CTrayPieceMove(size_t nTrayNum, PieceID pid, size_t nPos)
 {
     m_eType = mrecTMove;
     // ------- //
@@ -195,7 +194,7 @@ BOOL CTrayPieceMove::ValidatePieces(CGamDoc* pDoc)
 #ifdef _DEBUG
     BOOL bUsed = pDoc->GetPieceTable()->IsPieceUsed(m_pid);
     if (!bUsed)
-        TRACE1("CTrayPieceMove::ValidatePieces - Piece %u not in piece table.\n", m_pid);
+        TRACE1("CTrayPieceMove::ValidatePieces - Piece %u not in piece table.\n", value_preserving_cast<UINT>(static_cast<WORD>(m_pid)));
     return bUsed;
 #else
     return pDoc->GetPieceTable()->IsPieceUsed(m_pid);
@@ -212,22 +211,22 @@ void CTrayPieceMove::DoMoveSetup(CGamDoc* pDoc, int nMoveWithinGroup)
     {
         CRect rct = pObj->GetRect();
         CPoint ptCtr = GetMidRect(rct);
-        pDoc->EnsureBoardLocationVisible(pPBoard, ptCtr);
+        pDoc->EnsureBoardLocationVisible(*pPBoard, ptCtr);
         pDoc->IndicateBoardPiece(pPBoard, ptCtr, rct.Size());
     }
     else
-        pDoc->SelectTrayItem(pTray, m_pid);
+        pDoc->SelectTrayItem(*pTray, m_pid);
 }
 
 void CTrayPieceMove::DoMove(CGamDoc* pDoc, int nMoveWithinGroup)
 {
-    CTraySet* pYGrp = pDoc->GetTrayManager()->GetTraySet(m_nTrayNum);
+    CTraySet& pYGrp = pDoc->GetTrayManager()->GetTraySet(m_nTrayNum);
     pDoc->PlacePieceInTray(m_pid, pYGrp, m_nPos);
 }
 
 void CTrayPieceMove::DoMoveCleanup(CGamDoc* pDoc, int nMoveWithinGroup)
 {
-    CTraySet* pYGrp = pDoc->GetTrayManager()->GetTraySet(m_nTrayNum);
+    CTraySet& pYGrp = pDoc->GetTrayManager()->GetTraySet(m_nTrayNum);
     pDoc->SelectTrayItem(pYGrp, m_pid);
 }
 
@@ -236,17 +235,18 @@ void CTrayPieceMove::Serialize(CArchive& ar)
     CMoveRecord::Serialize(ar);
     if (ar.IsStoring())
     {
-        ar << (WORD)m_pid;
-        ar << (short)m_nTrayNum;
-        ar << (short)m_nPos;
+        ar << m_pid;
+        ar << value_preserving_cast<int16_t>(m_nTrayNum);
+        ASSERT(m_nPos == Invalid_v<size_t> ||
+                m_nPos < size_t(int16_t(-1)));
+        ar << (m_nPos == Invalid_v<size_t> ? int16_t(-1) : value_preserving_cast<int16_t>(m_nPos));
     }
     else
     {
-        WORD wTmp;
-        short sTmp;
-        ar >> wTmp; m_pid = (int)wTmp;
-        ar >> sTmp; m_nTrayNum = (int)sTmp;
-        ar >> sTmp; m_nPos = (int)sTmp;
+        int16_t sTmp;
+        ar >> m_pid;
+        ar >> sTmp; m_nTrayNum = value_preserving_cast<size_t>(sTmp);
+        ar >> sTmp; m_nPos = sTmp == int16_t(-1) ? Invalid_v<size_t> : value_preserving_cast<size_t>(sTmp);
     }
 }
 
@@ -254,8 +254,8 @@ void CTrayPieceMove::Serialize(CArchive& ar)
 void CTrayPieceMove::DumpToTextFile(CFile& file)
 {
     char szBfr[256];
-    wsprintf(szBfr, "    tray = %d, nPos = %d, pid = %d\r\n",
-        m_nTrayNum, m_nPos, m_pid);
+    wsprintf(szBfr, "    tray = %zu, nPos = %zu, pid = %u\r\n",
+        m_nTrayNum, m_nPos, static_cast<WORD>(m_pid));
     file.Write(szBfr, lstrlen(szBfr));
 }
 #endif
@@ -268,7 +268,7 @@ BOOL CPieceSetSide::ValidatePieces(CGamDoc* pDoc)
 #ifdef _DEBUG
     BOOL bUsed = pDoc->GetPieceTable()->IsPieceUsed(m_pid);
     if (!bUsed)
-        TRACE1("CPieceSetSide::ValidatePieces - Piece %u not in piece table.\n", m_pid);
+        TRACE1("CPieceSetSide::ValidatePieces - Piece %u not in piece table.\n", value_preserving_cast<UINT>(static_cast<WORD>(m_pid)));
     return bUsed;
 #else
     return pDoc->GetPieceTable()->IsPieceUsed(m_pid);
@@ -307,12 +307,12 @@ void CPieceSetSide::DoMoveSetup(CGamDoc* pDoc, int nMoveWithinGroup)
     {
         CRect rct = pObj->GetRect();
         CPoint ptCtr = GetMidRect(rct);
-        pDoc->EnsureBoardLocationVisible(pPBoard, ptCtr);
+        pDoc->EnsureBoardLocationVisible(*pPBoard, ptCtr);
         pDoc->IndicateBoardPiece(pPBoard, ptCtr, rct.Size());
-        pDoc->SelectObjectOnBoard(pPBoard, pObj);
+        pDoc->SelectObjectOnBoard(*pPBoard, pObj);
     }
     else
-        pDoc->SelectTrayItem(pTray, m_pid);
+        pDoc->SelectTrayItem(*pTray, m_pid);
 }
 
 void CPieceSetSide::DoMove(CGamDoc* pDoc, int nMoveWithinGroup)
@@ -332,13 +332,12 @@ void CPieceSetSide::Serialize(CArchive& ar)
     CMoveRecord::Serialize(ar);
     if (ar.IsStoring())
     {
-        ar << (WORD)m_pid;
+        ar << m_pid;
         ar << (BYTE)m_bTopUp;
     }
     else
     {
-        WORD wTmp;
-        ar >> wTmp; m_pid = (PieceID)wTmp;
+        ar >> m_pid;
         BYTE cTmp;
         ar >> cTmp; m_bTopUp = (BOOL)cTmp;
     }
@@ -349,7 +348,7 @@ void CPieceSetSide::DumpToTextFile(CFile& file)
 {
     char szBfr[256];
     wsprintf(szBfr, "    Piece %d is set to %s visible.\r\n",
-        m_pid, m_bTopUp ? "top" : "bottom");
+        value_preserving_cast<int>(static_cast<WORD>(m_pid)), m_bTopUp ? "top" : "bottom");
     file.Write(szBfr, lstrlen(szBfr));
 }
 #endif
@@ -362,7 +361,7 @@ BOOL CPieceSetFacing::ValidatePieces(CGamDoc* pDoc)
 #ifdef _DEBUG
     BOOL bUsed = pDoc->GetPieceTable()->IsPieceUsed(m_pid);
     if (!bUsed)
-        TRACE1("CPieceSetFacing::ValidatePieces - Piece %u not in piece table.\n", m_pid);
+        TRACE1("CPieceSetFacing::ValidatePieces - Piece %u not in piece table.\n", value_preserving_cast<UINT>(static_cast<WORD>(m_pid)));
     return bUsed;
 #else
     return pDoc->GetPieceTable()->IsPieceUsed(m_pid);
@@ -379,12 +378,12 @@ void CPieceSetFacing::DoMoveSetup(CGamDoc* pDoc, int nMoveWithinGroup)
     {
         CRect rct = pObj->GetRect();
         CPoint ptCtr = GetMidRect(rct);
-        pDoc->EnsureBoardLocationVisible(pPBoard, ptCtr);
+        pDoc->EnsureBoardLocationVisible(*pPBoard, ptCtr);
         pDoc->IndicateBoardPiece(pPBoard, ptCtr, rct.Size());
-        pDoc->SelectObjectOnBoard(pPBoard, pObj);
+        pDoc->SelectObjectOnBoard(*pPBoard, pObj);
     }
     else
-        pDoc->SelectTrayItem(pTray, m_pid);
+        pDoc->SelectTrayItem(*pTray, m_pid);
 }
 
 void CPieceSetFacing::DoMove(CGamDoc* pDoc, int nMoveWithinGroup)
@@ -404,13 +403,13 @@ void CPieceSetFacing::Serialize(CArchive& ar)
     CMoveRecord::Serialize(ar);
     if (ar.IsStoring())
     {
-        ar << (WORD)m_pid;
+        ar << m_pid;
         ar << (WORD)m_nFacingDegCW;
     }
     else
     {
         WORD wTmp;
-        ar >> wTmp; m_pid = (PieceID)wTmp;
+        ar >> m_pid;
         if (CGamDoc::GetLoadingVersion() < NumVersion(2, 90))   //Ver2.90
         {
             BYTE cTmp;
@@ -429,7 +428,7 @@ void CPieceSetFacing::Serialize(CArchive& ar)
 void CPieceSetFacing::DumpToTextFile(CFile& file)
 {
     char szBfr[256];
-    wsprintf(szBfr, "    Piece %d is rotated %d degrees.\r\n", m_pid, m_nFacingDegCW);
+    wsprintf(szBfr, "    Piece %d is rotated %d degrees.\r\n", value_preserving_cast<int>(static_cast<WORD>(m_pid)), m_nFacingDegCW);
     file.Write(szBfr, lstrlen(szBfr));
 }
 #endif
@@ -442,7 +441,7 @@ BOOL CPieceSetOwnership::ValidatePieces(CGamDoc* pDoc)
 #ifdef _DEBUG
     BOOL bUsed = pDoc->GetPieceTable()->IsPieceUsed(m_pid);
     if (!bUsed)
-        TRACE1("CPieceSetOwnership::ValidatePieces - Piece %u not in piece table.\n", m_pid);
+        TRACE1("CPieceSetOwnership::ValidatePieces - Piece %u not in piece table.\n", value_preserving_cast<UINT>(static_cast<WORD>(m_pid)));
     return bUsed;
 #else
     return pDoc->GetPieceTable()->IsPieceUsed(m_pid);
@@ -459,12 +458,12 @@ void CPieceSetOwnership::DoMove(CGamDoc* pDoc, int nMoveWithinGroup)
     {
         CRect rct = pObj->GetRect();
         CPoint ptCtr = GetMidRect(rct);
-        pDoc->EnsureBoardLocationVisible(pPBoard, ptCtr);
+        pDoc->EnsureBoardLocationVisible(*pPBoard, ptCtr);
         pDoc->IndicateBoardPiece(pPBoard, ptCtr, rct.Size());
-        pDoc->SelectObjectOnBoard(pPBoard, pObj);
+        pDoc->SelectObjectOnBoard(*pPBoard, pObj);
     }
     else
-        pDoc->SelectTrayItem(pTray, m_pid);
+        pDoc->SelectTrayItem(*pTray, m_pid);
     pDoc->SetPieceOwnership(m_pid, m_dwOwnerMask);
 }
 
@@ -473,13 +472,13 @@ void CPieceSetOwnership::Serialize(CArchive& ar)
     CMoveRecord::Serialize(ar);
     if (ar.IsStoring())
     {
-        ar << (WORD)m_pid;
+        ar << m_pid;
         ar << m_dwOwnerMask;
     }
     else
     {
         WORD wTmp;
-        ar >> wTmp; m_pid = (PieceID)wTmp;
+        ar >> m_pid;
         if (CGamDoc::GetLoadingVersion() < NumVersion(3, 10))
         {
             ar >> wTmp;
@@ -495,7 +494,7 @@ void CPieceSetOwnership::DumpToTextFile(CFile& file)
 {
     char szBfr[256];
     wsprintf(szBfr, "    Piece %d has ownership changed to 0x%X.\r\n",
-        m_pid, m_dwOwnerMask);
+        value_preserving_cast<int>(static_cast<WORD>(m_pid)), m_dwOwnerMask);
     file.Write(szBfr, lstrlen(szBfr));
 }
 #endif
@@ -520,9 +519,9 @@ void CMarkerSetFacing::DoMoveSetup(CGamDoc* pDoc, int nMoveWithinGroup)
     {
         CRect rct = pObj->GetRect();
         CPoint ptCtr = GetMidRect(rct);
-        pDoc->EnsureBoardLocationVisible(pPBoard, ptCtr);
+        pDoc->EnsureBoardLocationVisible(*pPBoard, ptCtr);
         pDoc->IndicateBoardPiece(pPBoard, ptCtr, rct.Size());
-        pDoc->SelectObjectOnBoard(pPBoard, pObj);
+        pDoc->SelectObjectOnBoard(*pPBoard, pObj);
     }
     else
         ASSERT(FALSE);          // SHOULDN'T HAPPEN
@@ -545,15 +544,15 @@ void CMarkerSetFacing::Serialize(CArchive& ar)              // VER2.0 is first t
     if (ar.IsStoring())
     {
         ar << m_dwObjID;
-        ar << (WORD)m_mid;
-        ar << (WORD)m_nFacingDegCW;
+        ar << m_mid;
+        ar << value_preserving_cast<WORD>(m_nFacingDegCW);
     }
     else
     {
         ar >> m_dwObjID;
         WORD wTmp;
-        ar >> wTmp; m_mid = (PieceID)wTmp;
-        ar >> wTmp; m_nFacingDegCW = (int)wTmp;
+        ar >> m_mid;
+        ar >> wTmp; m_nFacingDegCW = value_preserving_cast<int>(wTmp);
         if (CGamDoc::GetLoadingVersion() < NumVersion(2, 90))   //Ver2.90
             m_nFacingDegCW *= 5;                                // Convert old values to degrees
     }
@@ -564,7 +563,7 @@ void CMarkerSetFacing::DumpToTextFile(CFile& file)
 {
     char szBfr[256];
     wsprintf(szBfr, "    Marker dwObjID = %lX, mid = %d is rotated %d degrees.\r\n",
-        m_dwObjID, m_mid, m_nFacingDegCW);
+        m_dwObjID, value_preserving_cast<int>(static_cast<WORD>(m_mid)), m_nFacingDegCW);
     file.Write(szBfr, lstrlen(szBfr));
 }
 #endif
@@ -572,7 +571,7 @@ void CMarkerSetFacing::DumpToTextFile(CFile& file)
 /////////////////////////////////////////////////////////////////////
 // CBoardMarkerMove methods....
 
-CBoardMarkerMove::CBoardMarkerMove(int nBrdSerNum, ObjectID dwObjID, MarkID mid,
+CBoardMarkerMove::CBoardMarkerMove(BoardID nBrdSerNum, ObjectID dwObjID, MarkID mid,
     CPoint pnt, PlacePos ePos)
 {
     m_eType = mrecMMove;
@@ -593,7 +592,7 @@ void CBoardMarkerMove::DoMoveSetup(CGamDoc* pDoc, int nMoveWithinGroup)
     {
         CRect rct = pObj->GetRect();
         CPoint ptCtr = GetMidRect(rct);
-        pDoc->EnsureBoardLocationVisible(pPBoard, ptCtr);
+        pDoc->EnsureBoardLocationVisible(*pPBoard, ptCtr);
         CPlayBoard* pPBrdDest = pDoc->GetPBoardManager()->
             GetPBoardBySerial(m_nBrdNum);
         ASSERT(pPBrdDest != NULL);
@@ -610,7 +609,7 @@ void CBoardMarkerMove::DoMove(CGamDoc* pDoc, int nMoveWithinGroup)
         GetPBoardBySerial(m_nBrdNum);
     ASSERT(pPBrdDest != NULL);
 
-    pDoc->EnsureBoardLocationVisible(pPBrdDest, m_ptCtr);
+    pDoc->EnsureBoardLocationVisible(*pPBrdDest, m_ptCtr);
 
     CDrawObj* pObj;
     CPlayBoard* pPBrdFrom = pDoc->FindObjectOnBoard(m_dwObjID, &pObj);
@@ -637,20 +636,19 @@ void CBoardMarkerMove::Serialize(CArchive& ar)
     CMoveRecord::Serialize(ar);
     if (ar.IsStoring())
     {
-        ar << (WORD)m_mid;
+        ar << m_mid;
         ar << m_dwObjID;
-        ar << (short)m_nBrdNum;
+        ar << m_nBrdNum;
         ar << (short)m_ePos;
         ar << (short)m_ptCtr.x;
         ar << (short)m_ptCtr.y;
     }
     else
     {
-        WORD wTmp;
         short sTmp;
-        ar >> wTmp; m_mid = (int)wTmp;
+        ar >> m_mid;
         ar >> m_dwObjID;
-        ar >> sTmp; m_nBrdNum = (int)sTmp;
+        ar >> m_nBrdNum;
         ar >> sTmp; m_ePos = (PlacePos)sTmp;
         ar >> sTmp; m_ptCtr.x = sTmp;
         ar >> sTmp; m_ptCtr.y = sTmp;
@@ -662,7 +660,7 @@ void CBoardMarkerMove::DumpToTextFile(CFile& file)
 {
     char szBfr[256];
     wsprintf(szBfr, "    board = %d, pos = %d, dwObjID = %lX, mid = %d, @(%d, %d)\r\n",
-        m_nBrdNum, m_ePos, m_dwObjID, m_mid, m_ptCtr.x, m_ptCtr.y);
+        value_preserving_cast<int>(static_cast<WORD>(m_nBrdNum)), m_ePos, m_dwObjID, value_preserving_cast<int>(static_cast<WORD>(m_mid)), m_ptCtr.x, m_ptCtr.y);
     file.Write(szBfr, lstrlen(szBfr));
 }
 #endif
@@ -685,7 +683,7 @@ void CObjectDelete::DoMoveSetup(CGamDoc* pDoc, int nMoveWithinGroup)
     {
         CRect rct = pObj->GetRect();
         CPoint ptCtr = GetMidRect(rct);
-        pDoc->EnsureBoardLocationVisible(pPBoard, ptCtr);
+        pDoc->EnsureBoardLocationVisible(*pPBoard, ptCtr);
         pDoc->IndicateBoardPiece(pPBoard, ptCtr, pObj->GetRect().Size());
     }
 }
@@ -778,7 +776,7 @@ void CObjectSetText::DoMove(CGamDoc* pDoc, int nMoveWithinGroup)
                 pTray, pPBoard, &pPObj))
             pObj = pPObj;
         else
-            pDoc->SelectTrayItem(pTray, GetPieceIDFromElement(m_elem), IDS_TIP_OBJTEXTCHG);
+            pDoc->SelectTrayItem(*pTray, GetPieceIDFromElement(m_elem), IDS_TIP_OBJTEXTCHG);
     }
     else
         pPBoard = pDoc->FindObjectOnBoard(static_cast<ObjectID>(m_elem), &pObj);
@@ -787,12 +785,12 @@ void CObjectSetText::DoMove(CGamDoc* pDoc, int nMoveWithinGroup)
     {
         CRect rct = pObj->GetRect();
         CPoint ptCtr = GetMidRect(rct);
-        pDoc->EnsureBoardLocationVisible(pPBoard, ptCtr);
+        pDoc->EnsureBoardLocationVisible(*pPBoard, ptCtr);
         pDoc->IndicateBoardPiece(pPBoard, ptCtr, pObj->GetRect().Size());
 
         // Show a balloon tip so person knows what happened
         if (nMoveWithinGroup == 0)
-            pDoc->IndicateTextTipOnBoard(pPBoard, ptCtr, IDS_TIP_OBJTEXTCHG);
+            pDoc->IndicateTextTipOnBoard(*pPBoard, ptCtr, IDS_TIP_OBJTEXTCHG);
     }
 }
 
@@ -881,7 +879,7 @@ void CObjectLockdown::DoMoveSetup(CGamDoc* pDoc, int nMoveWithinGroup)
 
         CRect rct = pObj->GetRect();
         CPoint ptCtr = GetMidRect(rct);
-        pDoc->EnsureBoardLocationVisible(pPBoard, ptCtr);
+        pDoc->EnsureBoardLocationVisible(*pPBoard, ptCtr);
         pDoc->IndicateBoardPiece(pPBoard, ptCtr, pObj->GetRect().Size());
     }
 }
@@ -909,10 +907,10 @@ void CObjectLockdown::DoMove(CGamDoc* pDoc, int nMoveWithinGroup)
 
         CRect rct = pObj->GetRect();
         CPoint ptCtr = GetMidRect(rct);
-        pDoc->EnsureBoardLocationVisible(pPBoard, ptCtr);
+        pDoc->EnsureBoardLocationVisible(*pPBoard, ptCtr);
 
         // Show a balloon tip so person knows what happened
-        pDoc->IndicateTextTipOnBoard(pPBoard, ptCtr,
+        pDoc->IndicateTextTipOnBoard(*pPBoard, ptCtr,
             m_bLockState ? IDS_TIP_OBJLOCKED : IDS_TIP_OBJUNLOCKED);
     }
 }
@@ -1024,11 +1022,10 @@ void CMovePlotList::Serialize(CArchive& ar)
 {
     CMoveRecord::Serialize(ar);
     if (ar.IsStoring())
-        ar << (short)m_nBrdNum;
+        ar << m_nBrdNum;
     else
     {
-        short sTmp;
-        ar >> sTmp; m_nBrdNum = (int)sTmp;
+        ar >> m_nBrdNum;
     }
     m_tblPlot.Serialize(ar);
 }
@@ -1068,23 +1065,33 @@ void CMessageRcd::DumpToTextFile(CFile& file)
 
 /////////////////////////////////////////////////////////////////////
 
-CEventMessageRcd::CEventMessageRcd(CString strMsg, BOOL bIsBoardEvent,
-    int nID, int nVal1, int nVal2 /* = 0 */)
+CEventMessageRcd::CEventMessageRcd(CString strMsg,
+    BoardID nBoard, int x, int y)
 {
     m_eType = mrecEvtMsg;
-    m_bIsBoardEvent = bIsBoardEvent;
-    m_nID = nID;
-    m_nVal1 = nVal1;
-    m_nVal2 = nVal2;
+    m_bIsBoardEvent = TRUE;
+    m_nBoard = nBoard;
+    m_x = x;
+    m_y = y;
+    m_strMsg = strMsg;
+}
+
+CEventMessageRcd::CEventMessageRcd(CString strMsg,
+    size_t nTray, PieceID pieceID)
+{
+    m_eType = mrecEvtMsg;
+    m_bIsBoardEvent = FALSE;
+    m_nTray = nTray;
+    m_pieceID = pieceID;
     m_strMsg = strMsg;
 }
 
 void CEventMessageRcd::DoMoveCleanup(CGamDoc* pDoc, int nMoveWithinGroup)
 {
     if (m_bIsBoardEvent)        // Board event message
-        pDoc->EventShowBoardNotification(m_nID, CPoint(m_nVal1, m_nVal2), m_strMsg);
+        pDoc->EventShowBoardNotification(m_nBoard, CPoint(m_x, m_y), m_strMsg);
     else                        // Tray event message
-        pDoc->EventShowTrayNotification(m_nID, (PieceID)m_nVal1, m_strMsg);
+        pDoc->EventShowTrayNotification(m_nTray, m_pieceID, m_strMsg);
 }
 
 void CEventMessageRcd::Serialize(CArchive& ar)
@@ -1093,9 +1100,18 @@ void CEventMessageRcd::Serialize(CArchive& ar)
     if (ar.IsStoring())
     {
         ar << (WORD)m_bIsBoardEvent;
-        ar << (WORD)m_nID;
-        ar << (DWORD)m_nVal1;
-        ar << (DWORD)m_nVal2;
+        if (m_bIsBoardEvent)
+        {
+            ar << m_nBoard;
+            ar << value_preserving_cast<DWORD>(m_x);
+            ar << value_preserving_cast<DWORD>(m_y);
+        }
+        else
+        {
+            ar << value_preserving_cast<WORD>(m_nTray);
+            ar << value_preserving_cast<DWORD>(static_cast<WORD>(m_pieceID));
+            ar << (DWORD)0;
+        }
         ar << m_strMsg;
     }
     else
@@ -1103,9 +1119,18 @@ void CEventMessageRcd::Serialize(CArchive& ar)
         WORD wTmp;
         DWORD dwTmp;
         ar >> wTmp; m_bIsBoardEvent = (int)wTmp;
-        ar >> wTmp; m_nID = (int)wTmp;
-        ar >> dwTmp; m_nVal1 = (int)dwTmp;
-        ar >> dwTmp; m_nVal2 = (int)dwTmp;
+        if (m_bIsBoardEvent)
+        {
+            ar >> m_nBoard;
+            ar >> dwTmp; m_x = value_preserving_cast<int>(dwTmp);
+            ar >> dwTmp; m_y = value_preserving_cast<int>(dwTmp);
+        }
+        else
+        {
+            ar >> wTmp; m_nTray = value_preserving_cast<size_t>(wTmp);
+            ar >> dwTmp; m_pieceID = static_cast<PieceID>(dwTmp);
+            ar >> dwTmp;
+        }
         ar >> m_strMsg;
     }
 }
@@ -1114,8 +1139,16 @@ void CEventMessageRcd::Serialize(CArchive& ar)
 void CEventMessageRcd::DumpToTextFile(CFile& file)
 {
     char szBfr[256];
-    wsprintf(szBfr, "    BoardEvt = %s, nID = %d, nVal1 = %d, nVal2 = %d\r\n",
-             (LPCTSTR)(m_bIsBoardEvent ? "TRUE" : "FALSE"), m_nID, m_nVal1, m_nVal2);
+    if (m_bIsBoardEvent)
+    {
+        wsprintf(szBfr, "    BoardEvt = %s, nBoard = %d, (x, y) = (%d, %d)\r\n",
+                 (LPCTSTR)(m_bIsBoardEvent ? "TRUE" : "FALSE"), value_preserving_cast<int>(static_cast<WORD>(m_nBoard)), m_x, m_y);
+    }
+    else
+    {
+        wsprintf(szBfr, "    BoardEvt = %s, nTray = %zu, pieceID = %d\r\n",
+                 (LPCTSTR)(m_bIsBoardEvent ? "TRUE" : "FALSE"), m_nTray, value_preserving_cast<int>(static_cast<WORD>(m_pieceID)));
+    }
     file.Write(szBfr, lstrlen(szBfr));
 }
 #endif

--- a/GP/MoveMgr.h
+++ b/GP/MoveMgr.h
@@ -78,7 +78,7 @@ class CBoardPieceMove : public CMoveRecord
 {
 public:
     CBoardPieceMove() { m_eType = mrecPMove; }
-    CBoardPieceMove(int nBrdSerNum, PieceID pid, CPoint pnt, PlacePos ePos);
+    CBoardPieceMove(BoardID nBrdSerNum, PieceID pid, CPoint pnt, PlacePos ePos);
 
     virtual void DoMoveSetup(CGamDoc* pDoc, int nMoveWithinGroup);
     virtual void DoMove(CGamDoc* pDoc, int nMoveWithinGroup);
@@ -94,7 +94,7 @@ public:
 protected:
     CPoint      m_ptCtr;
     PieceID     m_pid;
-    int         m_nBrdNum;
+    BoardID     m_nBrdNum;
     PlacePos    m_ePos;
 };
 
@@ -104,7 +104,7 @@ class CTrayPieceMove : public CMoveRecord
 {
 public:
     CTrayPieceMove() { m_eType = mrecTMove; }
-    CTrayPieceMove(int nTrayNum, PieceID pid, int nPos);
+    CTrayPieceMove(size_t nTrayNum, PieceID pid, size_t nPos);
 
     virtual void DoMoveSetup(CGamDoc* pDoc, int nMoveWithinGroup);
     virtual void DoMove(CGamDoc* pDoc, int nMoveWithinGroup);
@@ -119,8 +119,8 @@ public:
 #endif
 protected:
     PieceID     m_pid;
-    int         m_nTrayNum;
-    int         m_nPos;
+    size_t      m_nTrayNum;
+    size_t      m_nPos;
 };
 
 ///////////////////////////////////////////////////////////////////////
@@ -225,7 +225,7 @@ class CBoardMarkerMove : public CMoveRecord
 {
 public:
     CBoardMarkerMove() { m_eType = mrecMMove; }
-    CBoardMarkerMove(int nBrdSerNum, ObjectID dwObjID, MarkID mid,
+    CBoardMarkerMove(BoardID nBrdSerNum, ObjectID dwObjID, MarkID mid,
         CPoint pnt, PlacePos ePos);
 
     virtual void DoMoveSetup(CGamDoc* pDoc, int nMoveWithinGroup);
@@ -240,7 +240,7 @@ protected:
     CPoint      m_ptCtr;
     ObjectID    m_dwObjID;
     MarkID      m_mid;
-    int         m_nBrdNum;
+    BoardID     m_nBrdNum;
     PlacePos    m_ePos;
 };
 
@@ -343,7 +343,7 @@ class CMovePlotList : public CMoveRecord
 {
 public:
     CMovePlotList() { m_eType = mrecMPlot; }
-    CMovePlotList(int nBrdSerNum, CDrawList* pDwg)
+    CMovePlotList(BoardID nBrdSerNum, CDrawList* pDwg)
         { m_eType = mrecMPlot; m_nBrdNum = nBrdSerNum; SavePlotList(pDwg); }
 
     void SavePlotList(CDrawList* pDwg);
@@ -357,7 +357,7 @@ public:
     virtual void DumpToTextFile(CFile& file);
 #endif
 protected:
-    int         m_nBrdNum;
+    BoardID     m_nBrdNum;
     CDWordArray m_tblPlot;
 };
 
@@ -387,8 +387,10 @@ class CEventMessageRcd : public CMoveRecord
 {
 public:
     CEventMessageRcd() { m_eType = mrecEvtMsg; }
-    CEventMessageRcd(CString strMsg, BOOL bIsBoardEvent,
-        int nID, int nVal1, int nVal2 = 0);
+    CEventMessageRcd(CString strMsg,
+        BoardID nBoard, int x, int y);
+    CEventMessageRcd(CString strMsg,
+        size_t nTray, PieceID pid);
 
     virtual void DoMoveCleanup(CGamDoc* pDoc, int nMoveWithinGroup);
 
@@ -399,9 +401,20 @@ public:
 #endif
 protected:
     BOOL    m_bIsBoardEvent;        // If TRUE, message relates to board
-    int     m_nID;                  // Serial num of board or tray number
-    int     m_nVal1;                // X coord if board, tray item index if tray
-    int     m_nVal2;                // Y coord if board, 0 if tray
+    union
+    {
+        struct
+        {
+            BoardID m_nBoard;
+            int     m_x;
+            int     m_y;
+        };
+        struct
+        {
+            size_t  m_nTray;
+            PieceID m_pieceID;
+        };
+    };
     CString m_strMsg;               // The message text
 };
 

--- a/GP/PPieces.h
+++ b/GP/PPieces.h
@@ -71,9 +71,9 @@ public:
     BOOL IsOwned()              { return m_dwOwnerMask != 0; }
     BOOL IsOwnedBy(DWORD dwMask)  { return (BOOL)(m_dwOwnerMask & dwMask); }
 
-    BOOL operator != (Piece& pce)
+    BOOL operator != (const Piece& pce) const
         { return m_nSide != pce.m_nSide || m_nFacing != pce.m_nFacing; }
-    BOOL operator == (Piece& pce)
+    BOOL operator == (const Piece& pce) const
         { return m_nSide == pce.m_nSide && m_nFacing == pce.m_nFacing; }
 
     void Serialize(CArchive& ar);
@@ -95,7 +95,7 @@ class CPieceTable
 {
 public:
     CPieceTable();
-    ~CPieceTable();
+    ~CPieceTable() = default;
 
 // Attributes
 public:
@@ -105,12 +105,12 @@ public:
 
 // Operations
 public:
-    void LoadUnusedPieceList(CWordArray *pPTbl, int nPieceSet,
+    void LoadUnusedPieceList(std::vector<PieceID>& pPTbl, size_t nPieceSet,
         BOOL bClear = TRUE);
-    void LoadUnusedPieceList(CWordArray *pPTbl, CPieceSet* pPceSet,
+    void LoadUnusedPieceList(std::vector<PieceID>& pPTbl, const CPieceSet& pPceSet,
         BOOL bClear = TRUE);
-    void SetPieceListAsUnused(CWordArray *pPTbl);
-    void SetPieceListAsFrontUp(CWordArray *pPTbl);
+    void SetPieceListAsUnused(const std::vector<PieceID>& pPTbl);
+    void SetPieceListAsFrontUp(const std::vector<PieceID>& pPTbl);
 
     void FlipPieceOver(PieceID pid);
 
@@ -137,7 +137,7 @@ public:
     TileID GetInactiveTileID(PieceID pid, BOOL bWithFacing = FALSE);
 
     CSize GetPieceSize(PieceID pid, BOOL bWithFacing = FALSE);
-    CSize GetStackedSize(CWordArray* pTbl, int xDelta, int yDelta, BOOL bWithFacing = FALSE);
+    CSize GetStackedSize(const std::vector<PieceID>& pTbl, int xDelta, int yDelta, BOOL bWithFacing = FALSE);
 
     void CreatePlayingPieceTable();
     void SetPiece(PieceID pid, int nSide = 0, int nFacing = 0);
@@ -147,9 +147,9 @@ public:
 
     void Clear();
 
-    CPieceTable* Clone(CGamDoc *pDoc);
-    void Restore(CGamDoc *pDoc, CPieceTable* pTbl);
-    BOOL Compare(CPieceTable* pTbl);
+    CPieceTable* Clone(CGamDoc *pDoc) const;
+    void Restore(CGamDoc *pDoc, const CPieceTable& pTbl);
+    BOOL Compare(const CPieceTable& pTbl) const;
 
     void Serialize(CArchive& ar);
 
@@ -159,8 +159,9 @@ public:
 
 // Implementation
 protected:
-    Piece*      m_pPieceTbl;        // Global def'ed
-    UINT        m_nTblSize;         // Number of alloc'ed ents in Piece table
+    XxxxIDTable<PieceID, Piece,
+                maxPieces, pieceTblBaseSize, pieceTblIncrSize,
+                true> m_pPieceTbl;
 
     WORD        m_wReserved1;       // For future need (set to 0)
     WORD        m_wReserved2;       // For future need (set to 0)
@@ -170,11 +171,11 @@ protected:
     CPieceManager* m_pPMgr;         // To get access to piece defs.
     CGamDoc*       m_pDoc;          // Used for serialize fixups
     // ------- //
-    Piece* GetPiece(PieceID pid);
-    PieceDef* GetPieceDef(PieceID pid);
-    void GetPieceDefinitionPair(PieceID pid, Piece*& pPce, PieceDef*& pDef);
+    Piece& GetPiece(PieceID pid);
+    const PieceDef& GetPieceDef(PieceID pid) const;
+    void GetPieceDefinitionPair(PieceID pid, Piece*& pPce, const PieceDef*& pDef);
 
-    TileID GetFacedTileID(PieceID pid, TileID tidBase, int nFacing, int nSide);
+    TileID GetFacedTileID(PieceID pid, TileID tidBase, int nFacing, int nSide) const;
 };
 
 #endif

--- a/GP/PalMark.h
+++ b/GP/PalMark.h
@@ -55,7 +55,7 @@ public:
 
 // Operations
 public:
-    int  GetSelectedMarkerGroup();
+    size_t GetSelectedMarkerGroup();
 
     void UpdatePaletteContents();
 
@@ -80,7 +80,7 @@ protected:
     // when only single entry should be shown in the Tray listbox.
     // This is pretty much a hack but is was easier than reworking
     // CGrafixListBox to support this oddball situation.
-    CWordArray  m_dummyArray;
+    std::vector<MarkID> m_dummyArray;
 
     // Enclosed controls....
     CComboBox   m_comboMGrp;
@@ -89,7 +89,7 @@ protected:
     void LoadMarkerNameList();
     void UpdateMarkerList();
 
-    int  FindMarkerGroupIndex(int nGroupNum);
+    int  FindMarkerGroupIndex(size_t nGroupNum);
 
     // Some temporary vars used during windows position restoration.
     // They are loaded during the de-serialization process.

--- a/GP/PalTray.h
+++ b/GP/PalTray.h
@@ -67,10 +67,10 @@ public:
 // Operations
 public:
     void DeselectAll();
-    void SelectTrayPiece(int nGroup, PieceID pid, LPCTSTR pszNotificationTip = NULL);
-    void ShowTrayIndex(int nGroup, int nPos);
+    void SelectTrayPiece(size_t nGroup, PieceID pid, LPCTSTR pszNotificationTip = NULL);
+    void ShowTrayIndex(size_t nGroup, int nPos);
 
-    void UpdatePaletteContents(CTraySet* pTray = NULL);
+    void UpdatePaletteContents(const CTraySet* pTray = NULL);
     void Serialize(CArchive &ar);
 
 // Implementation - vars
@@ -88,7 +88,7 @@ protected:
     // when only single entry should be shown in the Tray listbox.
     // This is pretty much a hack but is was easier than reworking
     // CGrafixListBox to support this oddball situation.
-    CWordArray  m_dummyArray;
+    std::vector<PieceID> m_dummyArray;
 
     // Enclosed controls....
     CComboBox    m_comboYGrp;
@@ -98,8 +98,8 @@ protected:
 
     void LoadTrayNameList();
     void UpdateTrayList();
-    int  GetSelectedTray();
-    int  FindTrayIndex(int nTrayNum);
+    size_t GetSelectedTray();
+    int  FindTrayIndex(size_t nTrayNum);
 
     // Some temporary vars used during windows position restoration.
     // They are loaded during the de-serialization process.

--- a/GP/SelOPlay.h
+++ b/GP/SelOPlay.h
@@ -191,7 +191,7 @@ public:
     BOOL IsMultipleSelects() const { return GetCount() > 1; }
     BOOL IsSingleSelect() const { return GetCount() == 1; }
     BOOL IsAnySelects() const { return GetCount() > 0; }
-    BOOL IsObjectSelected(CDrawObj* pObj) const;
+    BOOL IsObjectSelected(const CDrawObj* pObj) const;
     BOOL HasPieces() const;
     BOOL HasOwnedPieces() const;
     BOOL HasNonOwnedPieces() const;
@@ -222,11 +222,11 @@ public:
     // -------- //
     void LoadListWithObjectPtrs(CPtrList* pList, BOOL bPiecesOnly = FALSE,
         BOOL bVisualOrder = FALSE);
-    void LoadTableWithPieceIDs(CWordArray* pTbl, BOOL bVisualOrder = TRUE);
-    void LoadTableWithObjectPtrs(CPtrArray* pTbl, BOOL bVisualOrder = TRUE);
+    void LoadTableWithPieceIDs(std::vector<PieceID>& pTbl, BOOL bVisualOrder = TRUE);
+    void LoadTableWithObjectPtrs(std::vector<CDrawObj*>& pTbl, BOOL bVisualOrder = TRUE);
     // -------- //
     enum LoadFilter { LF_NOTOWNED, LF_OWNED, LF_BOTH };
-    void LoadTableWithOwnerStatePieceIDs(CWordArray* pTbl, LoadFilter eWantOwned, BOOL bVisualOrder = TRUE);
+    void LoadTableWithOwnerStatePieceIDs(std::vector<PieceID>& pTbl, LoadFilter eWantOwned, BOOL bVisualOrder = TRUE);
     // -------- //
     void InvalidateListHandles(BOOL bUpdate = FALSE);
     void InvalidateList(BOOL bUpdate = FALSE);

--- a/GP/StdAfx.h
+++ b/GP/StdAfx.h
@@ -55,8 +55,7 @@
 #include <dde.h>
 #include <math.h>
 
-// use explicitly sized ints for portable file format control
-#include <cstdint>
+#include "CyberBoard.h"
 
 #ifdef _UNICODE
 #if defined _M_IX86

--- a/GP/VwPbrd.h
+++ b/GP/VwPbrd.h
@@ -83,8 +83,8 @@ public:
     void SelectAllUnderPoint(CPoint point);
     CDrawObj* ObjectHitTest(CPoint point);
     void SelectAllObjectsInList(CPtrList* pLst);
-    void SelectAllObjectsInTable(CPtrArray* pTbl);
-    void SelectMarkersInGroup(UINT nGroup);
+    void SelectAllObjectsInTable(const std::vector<CDrawObj*>& pTbl);
+    void SelectMarkersInGroup(size_t nGroup);
     void SelectAllMarkers();
 
     // TEMP FOR NOW!

--- a/GP/VwPbrd1.cpp
+++ b/GP/VwPbrd1.cpp
@@ -345,13 +345,13 @@ void CPlayBoardView::SelectAllObjectsInList(CPtrList* pLst)
         NotifySelectListChange();
 }
 
-void CPlayBoardView::SelectAllObjectsInTable(CPtrArray* pTbl)
+void CPlayBoardView::SelectAllObjectsInTable(const std::vector<CDrawObj*>& pTbl)
 {
     BOOL bPieceSelected = FALSE;
 
-    for (int i = 0; i < pTbl->GetSize(); i++)
+    for (size_t i = 0; i < pTbl.size(); i++)
     {
-        CDrawObj* pObj = (CDrawObj*)pTbl->GetAt(i);
+        CDrawObj* pObj = pTbl.at(i);
         ASSERT(pObj != NULL);
         if (!m_selList.IsObjectSelected(pObj))
         {
@@ -391,7 +391,7 @@ void CPlayBoardView::SelectAllMarkers()
 
 //////////////////////////////////////////////////////////////////////
 
-void CPlayBoardView::SelectMarkersInGroup(UINT nGroup)
+void CPlayBoardView::SelectMarkersInGroup(size_t nGroup)
 {
     CDrawList* pDwg = m_pPBoard->GetPieceList();
     ASSERT(pDwg);

--- a/GP/VwPrjga1.cpp
+++ b/GP/VwPrjga1.cpp
@@ -90,7 +90,7 @@ void CGamProjView::DoBoardProperty()
     int nSel = m_listProj.GetCurSel();
     ASSERT(nSel >= 0);
     ASSERT(m_listProj.GetItemGroupCode(nSel) == grpBrd);
-    int nBrd = m_listProj.GetItemSourceCode(nSel);
+    size_t nBrd = m_listProj.GetItemSourceCode(nSel);
     pDoc->DoBoardProperties(nBrd);
 }
 
@@ -100,9 +100,9 @@ void CGamProjView::DoBoardView()
     int nSel = m_listProj.GetCurSel();
     ASSERT(nSel >= 0);
     ASSERT(m_listProj.GetItemGroupCode(nSel) == grpBrd);
-    int nBrd = m_listProj.GetItemSourceCode(nSel);
+    size_t nBrd = m_listProj.GetItemSourceCode(nSel);
 
-    CPlayBoard* pPBoard = pDoc->GetPBoardManager()->GetPBoard(nBrd);
+    CPlayBoard& pPBoard = pDoc->GetPBoardManager()->GetPBoard(nBrd);
     CView* pView = pDoc->FindPBoardView(pPBoard);
     if (pView != NULL)
     {
@@ -115,7 +115,7 @@ void CGamProjView::DoBoardView()
     {
         CString strTitle;
         m_listProj.GetItemText(nSel, strTitle);
-        pDoc->CreateNewFrame(GetApp()->m_pBrdViewTmpl, strTitle, pPBoard);
+        pDoc->CreateNewFrame(GetApp()->m_pBrdViewTmpl, strTitle, &pPBoard);
     }
 }
 
@@ -187,7 +187,7 @@ void CGamProjView::DoHistoryReplay()
     }
     ASSERT(nSel >= 0);
     ASSERT(m_listProj.GetItemGroupCode(nSel) == grpHist);
-    int nHist = m_listProj.GetItemSourceCode(nSel);
+    size_t nHist = m_listProj.GetItemSourceCode(nSel);
     m_listProj.MarkGroupItem(grpHist, nHist);   // Pre mark line
     if (!pDoc->LoadAndActivateHistory(nHist))
     {
@@ -218,7 +218,7 @@ void CGamProjView::DoHistoryExport()
     int nSel = m_listProj.GetCurSel();
     ASSERT(nSel >= 0);
     ASSERT(m_listProj.GetItemGroupCode(nSel) == grpHist);
-    int nHist = m_listProj.GetItemSourceCode(nSel);
+    size_t nHist = m_listProj.GetItemSourceCode(nSel);
     pDoc->SaveHistoryMovesInFile(nHist);
 }
 
@@ -245,12 +245,12 @@ void CGamProjView::DoUpdateHistoryInfo()
     int nSel = m_listProj.GetCurSel();
     ASSERT(nSel >= 0);
     ASSERT(m_listProj.GetItemGroupCode(nSel) == grpHist);
-    int nHist = m_listProj.GetItemSourceCode(nSel);
+    size_t nHist = m_listProj.GetItemSourceCode(nSel);
     CHistoryTable* pHistTbl = pDoc->GetHistoryTable();
     ASSERT(pHistTbl);
-    CHistRecord* pHRec = pHistTbl->GetHistRecord(nHist);
+    CHistRecord& pHRec = pHistTbl->GetHistRecord(nHist);
 
-    m_editInfo.SetWindowText(pHRec->m_strDescr);
+    m_editInfo.SetWindowText(pHRec.m_strDescr);
 }
 
 

--- a/GP/VwPrjgam.cpp
+++ b/GP/VwPrjgam.cpp
@@ -148,7 +148,7 @@ int CGamProjView::OnCreate(LPCREATESTRUCT lpCreateStruct)
     // Save for list box construction...
     int xProjListRight = posBtn.x + (7 * sizeBtn.cx) / 2;
 
-    xProjListRight = max(xProjListRight, PROJ_LIST_WIDTH);
+    xProjListRight = CB::max(xProjListRight, PROJ_LIST_WIDTH);
 
     // The project list box.
     CRect rctList(XBORDER, YBORDER, xProjListRight, YBORDER);
@@ -181,14 +181,14 @@ void CGamProjView::OnInitialUpdate()
     // is disabled.
     if (!pDoc->m_bSaveWindowPositions)
     {
-        for (int i = 0; i < pPBMgr->GetNumPBoards(); i++)
+        for (size_t i = 0; i < pPBMgr->GetNumPBoards(); i++)
         {
-            CPlayBoard* pPBoard = pPBMgr->GetPBoard(i);
-            if (pPBoard->m_bOpenBoardOnLoad)
+            CPlayBoard& pPBoard = pPBMgr->GetPBoard(i);
+            if (pPBoard.m_bOpenBoardOnLoad)
             {
                 // Defer opening the view until our view init
                 // in done.
-                PostMessage(WM_SHOWPLAYINGBOARD, (WPARAM)i);
+                PostMessage(WM_SHOWPLAYINGBOARD, value_preserving_cast<WPARAM>(i));
             }
         }
     }
@@ -427,25 +427,25 @@ void CGamProjView::DoUpdateProjectList(BOOL bUpdateItem /* = TRUE */)
 
     CPBoardManager* pPBMgr = pDoc->GetPBoardManager();
     ASSERT(pPBMgr);
-    for (int i = 0; i < pPBMgr->GetNumPBoards(); i++)
+    for (size_t i = 0; i < pPBMgr->GetNumPBoards(); i++)
     {
         static int bDisplayIDs = -1;
         if (bDisplayIDs == -1)
         {
             bDisplayIDs = GetApp()->GetProfileInt("Settings", "DisplayIDs", 0);
         }
-        CPlayBoard* pPBoard = pPBMgr->GetPBoard(i);
-        str = pPBoard->GetBoard()->GetName();
+        CPlayBoard& pPBoard = pPBMgr->GetPBoard(i);
+        str = pPBoard.GetBoard()->GetName();
         if (bDisplayIDs)
         {
             CString strTmp = str;
             str.Format("[%d] %s",
-                pPBMgr->GetPBoard(i)->GetBoard()->GetSerialNumber(), (LPCTSTR)strTmp);
+                static_cast<WORD>(pPBMgr->GetPBoard(i).GetBoard()->GetSerialNumber()), (LPCTSTR)strTmp);
         }
-        if (pPBoard->IsOwned())
+        if (pPBoard.IsOwned())
         {
             CString strOwner = pDoc->GetPlayerManager()->GetPlayerUsingMask(
-                pPBoard->GetOwnerMask()).m_strName;
+                pPBoard.GetOwnerMask()).m_strName;
             CString strOwnedBy;
             strOwnedBy.Format(IDS_TIP_OWNED_BY_PROJ, strOwner);
             str += strOwnedBy;
@@ -494,13 +494,13 @@ void CGamProjView::DoUpdateProjectList(BOOL bUpdateItem /* = TRUE */)
     {
         CString strTimeFmt;
         strTimeFmt.LoadString(IDS_GAME_USA_TIMEFMT);
-        for (int i = 0; i < pHTbl->GetNumHistRecords(); i++)
+        for (size_t i = 0; i < pHTbl->GetNumHistRecords(); i++)
         {
-            CHistRecord* pRcd = pHTbl->GetHistRecord(i);
-            CString str = pRcd->m_timeAbsorbed.Format(strTimeFmt);
+            CHistRecord& pRcd = pHTbl->GetHistRecord(i);
+            CString str = pRcd.m_timeAbsorbed.Format(strTimeFmt);
             str += " - ";
-            str += pRcd->m_strTitle;
-            m_listProj.AddSeqItem(grpHist, str, i, i);
+            str += pRcd.m_strTitle;
+            m_listProj.AddSeqItem(grpHist, str, value_preserving_cast<int>(i), i);
             if (pDoc->IsPlayingHistory() &&
                 pDoc->GetCurrentHistoryRecNum() == i)
             {
@@ -767,11 +767,10 @@ void CGamProjView::OnUpdateProjItemExport(CCmdUI* pCmdUI)
 LRESULT CGamProjView::OnMessageShowPlayingBoard(WPARAM wParam, LPARAM)
 {
     CGamDoc* pDoc = GetDocument();
-    CPlayBoard* pPBoard = pDoc->GetPBoardManager()->GetPBoard((int)wParam);
-    ASSERT(pPBoard != NULL);
-    ASSERT(pPBoard->m_bOpenBoardOnLoad);
+    CPlayBoard& pPBoard = pDoc->GetPBoardManager()->GetPBoard(value_preserving_cast<size_t>(wParam));
+    ASSERT(pPBoard.m_bOpenBoardOnLoad);
     pDoc->CreateNewFrame(GetApp()->m_pBrdViewTmpl,
-        pPBoard->GetBoard()->GetName(), pPBoard);
+        pPBoard.GetBoard()->GetName(), &pPBoard);
     return (LRESULT)0;
 }
 

--- a/GP/VwPrjgam.h
+++ b/GP/VwPrjgam.h
@@ -38,7 +38,29 @@
 /////////////////////////////////////////////////////////////////////////////
 // CGamProjView view
 
-class CGamProjView : public CView
+/* KLUDGE:  CProjListBox<T> uses Invalid<T>, so Invalid<T>
+    must be explicit instantiated before using CProjListBox<T>.
+    However, explicit instantiation can't be done in class
+    definition.  Therefore, T must be declared in a separate
+    class definition.  */
+namespace CB { namespace Impl
+{
+    class CGamProjViewBase
+    {
+    public:
+        // Project list box grouping order.
+        enum { grpDoc, grpBrdHdr, grpBrd, grpHistHdr, grpCurHist, grpCurPlay,
+            grpHistPlay, grpHist };
+    };
+
+    template<>
+    struct Invalid<decltype(CGamProjViewBase::grpDoc)>
+    {
+        static constexpr decltype(CGamProjViewBase::grpDoc) value = static_cast<decltype(CGamProjViewBase::grpDoc)>(std::numeric_limits<std::underlying_type_t<decltype(CGamProjViewBase::grpDoc)>>::max());
+    };
+}}
+
+class CGamProjView : public CView, private CB::Impl::CGamProjViewBase
 {
     DECLARE_DYNCREATE(CGamProjView)
 protected:
@@ -46,14 +68,10 @@ protected:
 
 // Attributes
 public:
-    // Project list box grouping order.
-    enum { grpDoc, grpBrdHdr, grpBrd, grpHistHdr, grpCurHist, grpCurPlay,
-        grpHistPlay, grpHist };
-
     CGamDoc* GetDocument() { return (CGamDoc*)m_pDocument; }
 
     // Various controls...
-    CProjListBox    m_listProj;         // Main project box
+    CProjListBox<decltype(grpDoc)>    m_listProj;         // Main project box
 
     CEdit           m_editInfo;         // Used for various project info/help
 
@@ -139,6 +157,7 @@ protected:
 
     DECLARE_MESSAGE_MAP()
 };
+
 
 /////////////////////////////////////////////////////////////////////////////
 

--- a/GP/VwPrjgs1.cpp
+++ b/GP/VwPrjgs1.cpp
@@ -83,7 +83,7 @@ void CGsnProjView::DoBoardProperty()
     int nSel = m_listProj.GetCurSel();
     ASSERT(nSel >= 0);
     ASSERT(m_listProj.GetItemGroupCode(nSel) == grpBrd);
-    int nBrd = m_listProj.GetItemSourceCode(nSel);
+    size_t nBrd = m_listProj.GetItemSourceCode(nSel);
     pDoc->DoBoardProperties(nBrd);
 }
 
@@ -93,9 +93,9 @@ void CGsnProjView::DoBoardView()
     int nSel = m_listProj.GetCurSel();
     ASSERT(nSel >= 0);
     ASSERT(m_listProj.GetItemGroupCode(nSel) == grpBrd);
-    int nBrd = m_listProj.GetItemSourceCode(nSel);
+    size_t nBrd = m_listProj.GetItemSourceCode(nSel);
 
-    CPlayBoard* pPBoard = pDoc->GetPBoardManager()->GetPBoard(nBrd);
+    CPlayBoard& pPBoard = pDoc->GetPBoardManager()->GetPBoard(nBrd);
     CView* pView = pDoc->FindPBoardView(pPBoard);
     if (pView != NULL)
     {
@@ -108,7 +108,7 @@ void CGsnProjView::DoBoardView()
     {
         CString strTitle;
         m_listProj.GetItemText(nSel, strTitle);
-        pDoc->CreateNewFrame(GetApp()->m_pBrdViewTmpl, strTitle, pPBoard);
+        pDoc->CreateNewFrame(GetApp()->m_pBrdViewTmpl, strTitle, &pPBoard);
     }
 }
 
@@ -119,7 +119,7 @@ void CGsnProjView::DoBoardRemove()
     int nSel = m_listProj.GetCurSel();
     ASSERT(nSel >= 0);
     ASSERT(m_listProj.GetItemGroupCode(nSel) == grpBrd);
-    int nBrd = m_listProj.GetItemSourceCode(nSel);
+    size_t nBrd = m_listProj.GetItemSourceCode(nSel);
 
     pDoc->GetPBoardManager()->DeletePBoard(nBrd);
     pDoc->SetModifiedFlag(TRUE);
@@ -150,7 +150,7 @@ void CGsnProjView::DoTrayProperty()
     int nSel = m_listProj.GetCurSel();
     ASSERT(nSel >= 0);
     ASSERT(m_listProj.GetItemGroupCode(nSel) == grpTray);
-    int nGrp = m_listProj.GetItemSourceCode(nSel);
+    size_t nGrp = m_listProj.GetItemSourceCode(nSel);
 
 
     CTrayPropDialog dlg;
@@ -158,25 +158,25 @@ void CGsnProjView::DoTrayProperty()
     dlg.m_pYMgr = pDoc->GetTrayManager();
     dlg.m_pPlayerMgr = pDoc->GetPlayerManager();
 
-    CTraySet* pYGrp = pDoc->GetTrayManager()->GetTraySet(nGrp);
-    dlg.m_bRandomSel = pYGrp->IsRandomPiecePull();
-    dlg.SetTrayViz(pYGrp->GetTrayContentVisibility());
-    dlg.m_nOwnerSel = CPlayerManager::GetPlayerNumFromMask(pYGrp->GetOwnerMask());
-    dlg.m_bNonOwnerAccess = pYGrp->IsNonOwnerAccessAllowed();
-    dlg.m_bEnforceVizForOwnerToo = pYGrp->IsEnforcingVisibilityForOwnerToo();
+    CTraySet& pYGrp = pDoc->GetTrayManager()->GetTraySet(nGrp);
+    dlg.m_bRandomSel = pYGrp.IsRandomPiecePull();
+    dlg.SetTrayViz(pYGrp.GetTrayContentVisibility());
+    dlg.m_nOwnerSel = CPlayerManager::GetPlayerNumFromMask(pYGrp.GetOwnerMask());
+    dlg.m_bNonOwnerAccess = pYGrp.IsNonOwnerAccessAllowed();
+    dlg.m_bEnforceVizForOwnerToo = pYGrp.IsEnforcingVisibilityForOwnerToo();
 
     if (dlg.DoModal() == IDOK)
     {
-        pYGrp->SetName(dlg.m_strName);
+        pYGrp.SetName(dlg.m_strName);
 
-        pYGrp->SetRandPiecePull(dlg.m_bRandomSel);
-        pYGrp->SetTrayContentVisibility(dlg.GetTrayViz());
+        pYGrp.SetRandPiecePull(dlg.m_bRandomSel);
+        pYGrp.SetTrayContentVisibility(dlg.GetTrayViz());
         if (dlg.m_pPlayerMgr != NULL)
         {
-            pYGrp->SetOwnerMask(CPlayerManager::GetMaskFromPlayerNum(dlg.m_nOwnerSel));
-            pYGrp->PropagateOwnerMaskToAllPieces(pDoc);
-            pYGrp->SetNonOwnerAccess(dlg.m_bNonOwnerAccess);
-            pYGrp->SetEnforceVisibilityForOwnerToo(dlg.m_bEnforceVizForOwnerToo);
+            pYGrp.SetOwnerMask(CPlayerManager::GetMaskFromPlayerNum(dlg.m_nOwnerSel));
+            pYGrp.PropagateOwnerMaskToAllPieces(pDoc);
+            pYGrp.SetNonOwnerAccess(dlg.m_bNonOwnerAccess);
+            pYGrp.SetEnforceVisibilityForOwnerToo(dlg.m_bEnforceVizForOwnerToo);
         }
 
         CGamDocHint hint;
@@ -192,12 +192,12 @@ void CGsnProjView::DoTrayEdit()
     int nSel = m_listProj.GetCurSel();
     ASSERT(nSel >= 0);
     ASSERT(m_listProj.GetItemGroupCode(nSel) == grpTray);
-    int nGrp = m_listProj.GetItemSourceCode(nSel);
+    size_t nGrp = m_listProj.GetItemSourceCode(nSel);
     CTrayManager* pYMgr = pDoc->GetTrayManager();
 
     CSetPiecesDialog dlg;
     dlg.m_pDoc = pDoc;
-    dlg.m_nYSel = nGrp;
+    dlg.m_nYSel = value_preserving_cast<int>(nGrp);
 
     m_listTrays.SetItemMap(NULL);       // Clear this since repaint may fail...
     pDoc->CloseTrayPalettes();          // ...Ditto that for tray palettes
@@ -220,16 +220,16 @@ void CGsnProjView::DoTrayDelete()
     int nSel = m_listProj.GetCurSel();
     ASSERT(nSel >= 0);
     ASSERT(m_listProj.GetItemGroupCode(nSel) == grpTray);
-    int nGrp = m_listProj.GetItemSourceCode(nSel);
+    size_t nGrp = m_listProj.GetItemSourceCode(nSel);
 
-    if (!pYMgr->GetTraySet(nGrp)->IsEmpty())
+    if (!pYMgr->GetTraySet(nGrp).IsEmpty())
     {
         if (AfxMessageBox(IDS_ERR_TRAYHASPIECES,
                 MB_OKCANCEL | MB_ICONEXCLAMATION) != IDOK)
             return;
         // Mark those pieces as unused.
         pPTbl->SetPieceListAsUnused(
-            pYMgr->GetTraySet(nGrp)->GetPieceIDTable());
+            pYMgr->GetTraySet(nGrp).GetPieceIDTable());
     }
     pYMgr->DeleteTraySet(nGrp);
     CGamDocHint hint;
@@ -250,16 +250,11 @@ void CGsnProjView::DoUpdateTrayList()
     int nSel = m_listProj.GetCurSel();
     ASSERT(nSel >= 0);
     ASSERT(m_listProj.GetItemGroupCode(nSel) == grpTray);
-    int nGrp = m_listProj.GetItemSourceCode(nSel);
+    size_t nGrp = m_listProj.GetItemSourceCode(nSel);
 
-    CTraySet* pYGrp = pDoc->GetTrayManager()->GetTraySet(nGrp);
-    if (pYGrp == NULL)
-    {
-        m_listTrays.SetItemMap(NULL);
-        return;
-    }
-    CWordArray* pLstMap = pYGrp->GetPieceIDTable();
-    m_listTrays.SetItemMap(pLstMap);
+    CTraySet& pYGrp = pDoc->GetTrayManager()->GetTraySet(nGrp);
+    const std::vector<PieceID>& pLstMap = pYGrp.GetPieceIDTable();
+    m_listTrays.SetItemMap(&pLstMap);
 }
 
 

--- a/GP/VwPrjgsn.cpp
+++ b/GP/VwPrjgsn.cpp
@@ -142,7 +142,7 @@ int CGsnProjView::OnCreate(LPCREATESTRUCT lpCreateStruct)
 
     int xProjListRight = posBtn.x - 1;  // Save for list box construction
 
-    xProjListRight = max(xProjListRight, PROJ_LIST_WIDTH);
+    xProjListRight = CB::max(xProjListRight, PROJ_LIST_WIDTH);
 
     // The project list box.
     CRect rctList(XBORDER, YBORDER, xProjListRight, YBORDER);
@@ -179,14 +179,14 @@ void CGsnProjView::OnInitialUpdate()
     // is disabled.
     if (!pDoc->m_bSaveWindowPositions)
     {
-        for (int i = 0; i < pPBMgr->GetNumPBoards(); i++)
+        for (size_t i = 0; i < pPBMgr->GetNumPBoards(); i++)
         {
-            CPlayBoard* pPBoard = pPBMgr->GetPBoard(i);
-            if (pPBoard->m_bOpenBoardOnLoad)
+            CPlayBoard& pPBoard = pPBMgr->GetPBoard(i);
+            if (pPBoard.m_bOpenBoardOnLoad)
             {
                 // Defer opening the view until our view init
                 // in done.
-                PostMessage(WM_SHOWPLAYINGBOARD, (WPARAM)i);
+                PostMessage(WM_SHOWPLAYINGBOARD, value_preserving_cast<WPARAM>(i));
             }
         }
     }
@@ -425,20 +425,20 @@ void CGsnProjView::DoUpdateProjectList(BOOL bUpdateItem /* = TRUE */)
 
     CPBoardManager* pPBMgr = pDoc->GetPBoardManager();
     ASSERT(pPBMgr);
-    for (int i = 0; i < pPBMgr->GetNumPBoards(); i++)
+    for (size_t i = 0; i < pPBMgr->GetNumPBoards(); i++)
     {
-        CPlayBoard* pPBoard = pPBMgr->GetPBoard(i);
-        str = pPBoard->GetBoard()->GetName();
+        CPlayBoard& pPBoard = pPBMgr->GetPBoard(i);
+        str = pPBoard.GetBoard()->GetName();
         if (bDisplayIDs)
         {
             CString strTmp = str;
             str.Format("[%d] %s",
-                pPBoard->GetBoard()->GetSerialNumber(), (LPCTSTR)strTmp);
+                static_cast<WORD>(pPBoard.GetBoard()->GetSerialNumber()), (LPCTSTR)strTmp);
         }
-        if (pPBoard->IsOwned())
+        if (pPBoard.IsOwned())
         {
             CString strOwner = pDoc->GetPlayerManager()->GetPlayerUsingMask(
-                pPBoard->GetOwnerMask()).m_strName;
+                pPBoard.GetOwnerMask()).m_strName;
             CString strOwnedBy;
             strOwnedBy.Format(IDS_TIP_OWNED_BY_PROJ, strOwner);
             str += strOwnedBy;
@@ -452,19 +452,19 @@ void CGsnProjView::DoUpdateProjectList(BOOL bUpdateItem /* = TRUE */)
 
     CTrayManager* pYMgr = pDoc->GetTrayManager();
     ASSERT(pYMgr);
-    for (int i = 0; i < pYMgr->GetNumTraySets(); i++)
+    for (size_t i = 0; i < pYMgr->GetNumTraySets(); i++)
     {
-        CTraySet* pYSet = pYMgr->GetTraySet(i);
-        str = pYSet->GetName();
+        CTraySet& pYSet = pYMgr->GetTraySet(i);
+        str = pYSet.GetName();
         if (bDisplayIDs)
         {
             CString strTmp = str;
-            str.Format("[%d] %s", i, (LPCTSTR)strTmp);
+            str.Format("[%zu] %s", i, (LPCTSTR)strTmp);
         }
-        if (pYSet->IsOwned())
+        if (pYSet.IsOwned())
         {
             CString strOwner = pDoc->GetPlayerManager()->GetPlayerUsingMask(
-                pYSet->GetOwnerMask()).m_strName;
+                pYSet.GetOwnerMask()).m_strName;
             CString strOwnedBy;
             strOwnedBy.Format(IDS_TIP_OWNED_BY_PROJ, strOwner);
             str += strOwnedBy;
@@ -752,11 +752,10 @@ void CGsnProjView::OnUpdateProjItemView(CCmdUI* pCmdUI)
 LRESULT CGsnProjView::OnMessageShowPlayingBoard(WPARAM wParam, LPARAM)
 {
     CGamDoc* pDoc = GetDocument();
-    CPlayBoard* pPBoard = pDoc->GetPBoardManager()->GetPBoard((int)wParam);
-    ASSERT(pPBoard != NULL);
-    ASSERT(pPBoard->m_bOpenBoardOnLoad);
+    CPlayBoard& pPBoard = pDoc->GetPBoardManager()->GetPBoard(value_preserving_cast<size_t>(wParam));
+    ASSERT(pPBoard.m_bOpenBoardOnLoad);
     pDoc->CreateNewFrame(GetApp()->m_pBrdViewTmpl,
-        pPBoard->GetBoard()->GetName(), pPBoard);
+        pPBoard.GetBoard()->GetName(), &pPBoard);
     return (LRESULT)0;
 }
 

--- a/GP/VwPrjgsn.h
+++ b/GP/VwPrjgsn.h
@@ -38,7 +38,28 @@
 /////////////////////////////////////////////////////////////////////////////
 // CGsnProjView view
 
-class CGsnProjView : public CView
+/* KLUDGE:  CProjListBox<T> uses Invalid<T>, so Invalid<T>
+    must be explicit instantiated before using CProjListBox<T>.
+    However, explicit instantiation can't be done in class
+    definition.  Therefore, T must be declared in a separate
+    class definition.  */
+namespace CB { namespace Impl
+{
+    class CGsnProjViewBase
+    {
+    public:
+        // Project list box grouping order.
+        enum { grpDoc, grpBrdHdr, grpBrd, grpTrayHdr, grpTray };
+    };
+
+    template<>
+    struct Invalid<decltype(CGsnProjViewBase::grpDoc)>
+    {
+        static constexpr decltype(CGsnProjViewBase::grpDoc) value = static_cast<decltype(CGsnProjViewBase::grpDoc)>(std::numeric_limits<std::underlying_type_t<decltype(CGsnProjViewBase::grpDoc)>>::max());
+    };
+}}
+
+class CGsnProjView : public CView, private CB::Impl::CGsnProjViewBase
 {
     DECLARE_DYNCREATE(CGsnProjView)
 protected:
@@ -46,13 +67,10 @@ protected:
 
 // Attributes
 public:
-    // Project list box grouping order.
-    enum { grpDoc, grpBrdHdr, grpBrd, grpTrayHdr, grpTray };
-
     CGamDoc* GetDocument() { return (CGamDoc*)m_pDocument; }
 
     // Various controls...
-    CProjListBox    m_listProj;         // Main project box
+    CProjListBox<decltype(grpDoc)>    m_listProj;         // Main project box
 
     CEdit           m_editInfo;         // Used for various project info/help
     CTrayListBox    m_listTrays;        // For viewing tray contents

--- a/GP/VwSelpce.cpp
+++ b/GP/VwSelpce.cpp
@@ -138,17 +138,17 @@ void CSelectedPieceView::OnUpdate(CView* pSender, LPARAM lHint, CObject* pHint)
         if (!pSLst->HasPieces() && !pSLst->HasMarkers())
         {
             m_listSel.SetItemMap(NULL);
-            m_tblSel.RemoveAll();
+            m_tblSel.clear();
             return;
         }
-        pSLst->LoadTableWithObjectPtrs(&m_tblSel);
+        pSLst->LoadTableWithObjectPtrs(m_tblSel);
 
         m_listSel.SetItemMap(&m_tblSel);
     }
     else if (lHint == HINT_GAMESTATEUSED)
     {
         m_listSel.SetItemMap(NULL);
-        m_tblSel.RemoveAll();
+        m_tblSel.clear();
         return;
     }
 }
@@ -237,12 +237,12 @@ void CSelectedPieceView::ModifySelectionsBasedOnListItems(BOOL bRemoveSelectedIt
         if (bRemoveSelectedItems && nSelItem == tblListBoxSel.GetSize())
         {
             // Not a listbox selection so add it to new select list.
-            listDObj.AddTail(m_listSel.MapIndexToItem(nItem));
+            listDObj.AddTail(m_listSel.MapIndexToItem(value_preserving_cast<size_t>(nItem)));
         }
         else if (!bRemoveSelectedItems && nSelItem < tblListBoxSel.GetSize())
         {
             // It is a listbox selection so add it to new select list.
-            listDObj.AddTail(m_listSel.MapIndexToItem(nItem));
+            listDObj.AddTail(m_listSel.MapIndexToItem(value_preserving_cast<size_t>(nItem)));
         }
     }
     CPlayBoardFrame* pFrame = (CPlayBoardFrame*)GetParentFrame();

--- a/GP/VwSelpce.h
+++ b/GP/VwSelpce.h
@@ -49,7 +49,7 @@ protected:
     CPlayBoard*     m_pPBoard;      // Board that contains selections
 
     CSelectListBox  m_listSel;
-    CPtrArray       m_tblSel;
+    std::vector<CDrawObj*> m_tblSel;
     CToolTipCtrl    m_toolTip;
 
 // Implementation

--- a/GP/WStateGp.cpp
+++ b/GP/WStateGp.cpp
@@ -47,13 +47,13 @@ CWnd* CGpWinStateMgr::OnGetFrameForWinStateElement(CWinStateElement* pWse)
     else if (pWse->m_wUserCode1 == gpFrmPlayBoard)
     {
         // The second user code is the board's serial number.
-        CPlayBoard* pPBoard = pDoc->GetPBoardManager()->GetPBoardBySerial(pWse->m_wUserCode2);
+        CPlayBoard& pPBoard = CheckedDeref(pDoc->GetPBoardManager()->GetPBoardBySerial(static_cast<BoardID>(pWse->m_wUserCode2)));
         CView* pView = pDoc->FindPBoardView(pPBoard);
         if (pView == NULL)
         {
             // No frame open for board. Create it.
             pDoc->CreateNewFrame(GetApp()->m_pBrdViewTmpl,
-                pPBoard->GetBoard()->GetName(), pPBoard);
+                pPBoard.GetBoard()->GetName(), &pPBoard);
             // Try to locate it again
             pView = pDoc->FindPBoardView(pPBoard);
         }
@@ -71,7 +71,7 @@ void CGpWinStateMgr::OnAnnotateWinStateElement(CWinStateElement *pWse, CWnd *pWn
     {
         CPlayBoardFrame* pFrame = (CPlayBoardFrame*)pWnd;
         pWse->m_wUserCode1 = gpFrmPlayBoard;
-        pWse->m_wUserCode2 = pFrame->m_pPBoard->GetSerialNumber();
+        pWse->m_wUserCode2 = static_cast<WORD>(pFrame->m_pPBoard->GetSerialNumber());
     }
 }
 

--- a/GShr/BrdCell.cpp
+++ b/GShr/BrdCell.cpp
@@ -95,8 +95,8 @@ void CBoardArray::ReshapeBoard(int nRows, int nCols, int nParm1, int nParm2,
     for (int i = 0; i < nRows * nCols; i++)
         pMap[i].Clear();
 
-    int maxRows = min(m_nRows, nRows);
-    int maxCols = min(m_nCols, nCols);
+    int maxRows = CB::min(m_nRows, nRows);
+    int maxCols = CB::min(m_nCols, nCols);
 
     for (int r = 0; r < maxRows; r++)
     {
@@ -151,14 +151,14 @@ void CBoardArray::GenerateCellDefs(CellFormType eType, int nParm1, int nParm2,
     cfFull.CreateCell(eType, nParm1, nParm2, nStagger);
     int nHalfP1 = (nParm1 / 2) + ((nParm1 & 1) != 0 ? 1 : 0);
     int nHalfP2 = (nParm2 / 2) + ((nParm2 & 1) != 0 ? 1 : 0);
-    cfHalf.CreateCell(eType, max(2, nHalfP1), max(2, nHalfP2 ), nStagger);
+    cfHalf.CreateCell(eType, CB::max(2, nHalfP1), CB::max(2, nHalfP2 ), nStagger);
 
     // Attempt to compute 1/8 scale. Rounds up to get dimensions.
     // Minimum cell size is two pixels.
     int nSmallP1 = (nParm1 / 8) + ((nParm1 % 8) != 0 ? 1 : 0);
     int nSmallP2 = (nParm2 / 8) + ((nParm2 % 8) != 0 ? 1 : 0);
-    nSmallP1 = max(nSmallP1, 2);
-    nSmallP2 = max(nSmallP2, 2);
+    nSmallP1 = CB::max(nSmallP1, 2);
+    nSmallP2 = CB::max(nSmallP2, 2);
 
     // Hexagonal grids are shown as brick grids in small scale.
     if (eType == cformHexFlat)

--- a/GShr/BrdCell.h
+++ b/GShr/BrdCell.h
@@ -104,8 +104,8 @@ public:
     void SetTileManager(CTileManager *pTsa) { m_pTsa = pTsa; }
     CTileManager *GetTileManager() { return m_pTsa; }
     // ------ //
-    int GetRows() { return m_nRows; }
-    int GetCols() { return m_nCols; }
+    int GetRows() const { return m_nRows; }
+    int GetCols() const { return m_nCols; }
     int GetWidth(TileScale eScale);     // Board's pixel width
     int GetHeight(TileScale eScale);    // Board's pixel height
     CSize GetSize(TileScale eScale);    // Board's pixel size

--- a/GShr/CalcLib.cpp
+++ b/GShr/CalcLib.cpp
@@ -197,11 +197,11 @@ BOOL StrDecimalChecked(const char **psp, int *pnVal, int *pnScale)
 // ----------------------------------------------- //
 // Helper for calculation allocation increments.
 
-UINT CalcAllocSize(UINT uiDesired, UINT uiBaseSize, UINT uiExtendSize)
+size_t CalcAllocSize(size_t uiDesired, size_t uiBaseSize, size_t uiExtendSize)
 {
     if (uiDesired < uiBaseSize)
         return uiBaseSize;
-    UINT uiVal = uiExtendSize * ((uiDesired - uiBaseSize) / uiExtendSize) +
+    size_t uiVal = uiExtendSize * ((uiDesired - uiBaseSize) / uiExtendSize) +
         uiBaseSize;
     if (uiVal < uiDesired)
         uiVal += uiExtendSize;

--- a/GShr/CellForm.cpp
+++ b/GShr/CellForm.cpp
@@ -446,8 +446,8 @@ void CCellForm::GetCellNumberStr(CellNumStyle eStyle, int row, int col,
         case cns0101ByRows:
             _itoa(row, szNum1, 10);
             _itoa(col, szNum2, 10);
-            nTmp = max(strlen(szNum1), strlen(szNum2));
-            nTmp = max(nTmp, 2);            // Make sure at least 2 digits
+            nTmp = CB::max(strlen(szNum1), strlen(szNum2));
+            nTmp = CB::max(nTmp, 2);            // Make sure at least 2 digits
             StrLeadZeros(szNum1, nTmp);
             StrLeadZeros(szNum2, nTmp);
             str = szNum1;

--- a/GShr/CyberBoard.h
+++ b/GShr/CyberBoard.h
@@ -1,0 +1,552 @@
+// CyberBoard.h
+//
+// Copyright (c) 2020 By Bill Su, All Rights Reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+#ifndef _CYBERBOARD_H
+#define _CYBERBOARD_H
+
+// use explicitly sized ints for portable file format control
+#include <cinttypes>
+#include <limits>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <WinExt.h>
+
+#if defined(max)
+    #undef max
+#endif
+#if defined(min)
+    #undef min
+#endif
+
+/////////////////////////////////////////////////////////////////////////////
+
+/* Invalid_v<T> is used as the "no-value" value for type T.
+    It will probably be set to std::numeric_limits<T>::max(). */
+
+/* N.B.:  semantically, std::optional<T> is a better way to
+    represent the absence of a T, but T values sometimes get used
+    in C-style functions, so std::optional<T> is unavailable */
+
+/* KLUDGE:  bool handles uintptr_t being same type as size_t.
+    Code using Invalid<> should never specify second template
+    argument; let its default value be used.
+
+    Additional notes:
+    In this code, size_t is used all over because that's the index
+    type for std::vector.  (I am too lazy to use std::vector::size_type.)
+    The original code frequently used -1 to indicate "no-value" for an
+    index parameter.  I wanted to use std::numeric_limits<size_t>::max()
+    for this purpose, but that was too long, so I declared a
+    constexpr Invalid_size_t or something like that.  However, I
+    found a spot in the code where uintptr_t seems more
+    appropriate.  I could have declared Invalid_uintptr_t, but I
+    felt like a situation like this cried out for using template
+    Invalid.  The problem is that both size_t and uintptr_t are
+    specified by the MSVC compiler as typedefs to the same C++
+    fundamental type.  That means that attempting to explicitly
+    instantiate Invalid<size_t> and Invalid<uintptr_t> is viewed
+    by the compiler as conflicting instantiations.  To get
+    around this problem, I added a second default template
+    argument to Invalid<>, and have the default value be
+    different for size_t and uintptr_t.  By making that second
+    argument different, the compiler sees them as separate
+    instantiations, and is satisfied.  */
+template<typename T, bool = true>
+struct Invalid
+{
+};
+
+template<>
+struct Invalid<uintptr_t>
+{
+    static constexpr uintptr_t value = std::numeric_limits<uintptr_t>::max();
+};
+
+// this explicit instantiation is only relevant if size_t != uintptr_t
+template<>
+struct Invalid<size_t, !std::is_same_v<size_t, uintptr_t>>
+{
+    static constexpr size_t value = std::numeric_limits<size_t>::max();
+};
+
+// convenience helper
+template<typename T>
+constexpr T Invalid_v = Invalid<T>::value;
+
+/////////////////////////////////////////////////////////////////////////////
+
+template<typename T>
+T& CheckedDeref(T* p)
+{
+    ASSERT(p);
+    if (!p) {
+        AfxThrowInvalidArgException();
+    }
+    return *p;
+}
+
+/////////////////////////////////////////////////////////////////////////////
+
+/* test whether DEST can represent the exact value of src,
+    not just the bit pattern
+    (e.g., sint8_t can't represent 130) */
+
+template<typename DEST, typename SRC>
+struct is_always_value_preserving
+{
+    static_assert(std::is_integral_v<DEST>,
+                    "only integral types supported");
+    static constexpr bool value = std::is_integral_v<DEST> &&
+                                    std::is_integral_v<SRC> &&
+                                    std::is_signed_v<DEST> == std::is_signed_v<SRC> &&
+                                    sizeof(DEST) >= sizeof(SRC);
+};
+
+// convenience helper
+template<typename DEST, typename SRC>
+constexpr bool is_always_value_preserving_v = is_always_value_preserving<DEST, SRC>::value;
+
+template<typename DEST, typename SRC>
+constexpr std::enable_if_t<is_always_value_preserving_v<DEST, SRC>, bool> is_value_preserving(SRC /*src*/)
+{
+    return true;
+}
+
+template<typename DEST, typename SRC>
+constexpr std::enable_if_t<!is_always_value_preserving_v<DEST, SRC>, bool> is_value_preserving(SRC src)
+{
+    if (std::is_signed_v<SRC> &&
+        std::is_unsigned_v<DEST> &&
+        src < SRC(0))
+    {
+        return false;
+    }
+    else if (std::is_unsigned_v<SRC> &&
+        std::is_signed_v<DEST> &&
+        static_cast<DEST>(src) < DEST(0))
+    {
+        return false;
+    }
+    else if (static_cast<SRC>(static_cast<DEST>(src)) != src)
+    {
+        return false;
+    }
+    else
+    {
+        return true;
+    }
+}
+
+/////////////////////////////////////////////////////////////////////////////
+
+// TODO:  when drop MFC THROW/AfxThrow, use std::bad_cast
+class CBadCastException : public CException
+{
+};
+
+inline void __declspec(noreturn) CbThrowBadCastException()
+{
+    ASSERT(!"bad cast");
+    THROW(new CBadCastException());
+}
+
+/////////////////////////////////////////////////////////////////////////////
+
+// exception if DEST can't represent src
+template<typename DEST, typename SRC>
+constexpr std::enable_if_t<is_always_value_preserving_v<DEST, SRC>, DEST> value_preserving_cast(SRC src)
+{
+    return static_cast<DEST>(src);
+}
+
+template<typename DEST, typename SRC>
+constexpr std::enable_if_t<!is_always_value_preserving_v<DEST, SRC>, DEST> value_preserving_cast(SRC src)
+{
+    if (!is_value_preserving<DEST>(src))
+    {
+        CbThrowBadCastException();
+    }
+    return static_cast<DEST>(src);
+}
+
+/////////////////////////////////////////////////////////////////////////////
+
+namespace CB
+{
+    /* defining Invalid<> required removing the MS min/max
+        macros.  On the other hand, std::min/max don't allow
+        different argument types.  So provide our own min/max,
+        and check for value preservation while we're at it. */
+    template<typename LEFT, typename RIGHT>
+    std::common_type_t<LEFT, RIGHT> max(LEFT left, RIGHT right)
+    {
+        typedef std::common_type_t<LEFT, RIGHT> CommonType;
+        static_assert(is_always_value_preserving_v<CommonType, LEFT> &&
+                        is_always_value_preserving_v<CommonType, RIGHT>,
+                        "unsafe conversion not supported");
+        CommonType left2(static_cast<CommonType>(left));
+        CommonType right2(static_cast<CommonType>(right));
+        return !(left2 < right2) ? left2 : right2;
+    }
+
+    template<typename LEFT, typename RIGHT>
+    std::common_type_t<LEFT, RIGHT> min(LEFT left, RIGHT right)
+    {
+        typedef std::common_type_t<LEFT, RIGHT> CommonType;
+        static_assert(is_always_value_preserving_v<CommonType, LEFT> &&
+                        is_always_value_preserving_v<CommonType, RIGHT>,
+                        "unsafe conversion not supported");
+        CommonType left2(static_cast<CommonType>(left));
+        CommonType right2(static_cast<CommonType>(right));
+        return left2 < right2 ? left2 : right2;
+    }
+}
+
+/////////////////////////////////////////////////////////////////////////////
+
+template<char PREFIX_>
+class XxxxID
+{
+public:
+    static constexpr char PREFIX = PREFIX_;
+
+    XxxxID() = default;
+    // goal is 32bit ids, but currently ids are 16 bit
+    explicit constexpr XxxxID(uint32_t i) : id(value_preserving_cast<uint16_t>(i)) {}
+
+    template<typename T>
+    explicit constexpr XxxxID(T i) : XxxxID(value_preserving_cast<uint32_t>(i)) { static_assert(std::is_integral_v<T>, "id must be an integer"); }
+
+    ~XxxxID() = default;
+
+    explicit constexpr operator WORD() const { return id; }
+
+    bool operator==(const XxxxID& rhs) const { return id == rhs.id; }
+    bool operator!=(const XxxxID& rhs) const { return !operator==(rhs); }
+
+private:
+    uint16_t id;
+};
+
+template<char PREFIX>
+CArchive& operator<<(CArchive& ar, const XxxxID<PREFIX>& oid)
+{
+    if (!ar.IsStoring())
+    {
+        AfxThrowArchiveException(CArchiveException::readOnly);
+    }
+    static_assert(sizeof(uint16_t) == sizeof(oid), "wrong serialize type");
+    return ar << reinterpret_cast<const uint16_t&>(oid);
+}
+
+template<char PREFIX>
+CArchive& operator>>(CArchive& ar, XxxxID<PREFIX>& oid)
+{
+    if (ar.IsStoring())
+    {
+        AfxThrowArchiveException(CArchiveException::writeOnly);
+    }
+    static_assert(sizeof(uint16_t) == sizeof(oid), "wrong serialize type");
+    return ar >> reinterpret_cast<uint16_t&>(oid);
+}
+
+// KLUDGE:  use unique_ptr since CWordArray doesn't have move operators
+template<char PREFIX>
+std::unique_ptr<const CWordArray> ToCWordArray(const std::vector<XxxxID<PREFIX>>& v)
+{
+    std::unique_ptr<CWordArray> retval(new CWordArray);
+    retval->SetSize(value_preserving_cast<INT_PTR>(v.size()));
+    for (INT_PTR i = 0; i < retval->GetSize(); ++i)
+    {
+        (*retval)[i] = static_cast<WORD>(v[value_preserving_cast<size_t>(i)]);
+    }
+    return retval;
+}
+
+template<typename T>
+std::vector<T> ToVector(const CWordArray& a)
+{
+    static_assert(std::is_same_v<T, XxxxID<T::PREFIX>>, "requires XxxxID<>");
+    std::vector<T> retval;
+    retval.resize(value_preserving_cast<size_t>(a.GetSize()));
+    for (INT_PTR i = 0; i < a.GetSize(); ++i)
+    {
+        retval[value_preserving_cast<size_t>(i)] = static_cast<T>(a[i]);
+    }
+    return retval;
+}
+
+template<char PREFIX>
+CArchive& operator<<(CArchive& ar, const std::vector<XxxxID<PREFIX>>& v)
+{
+    if (!ar.IsStoring())
+    {
+        AfxThrowArchiveException(CArchiveException::readOnly);
+    }
+    // KLUDGE:  current file format uses MFC CWordArray
+    const_cast<CWordArray*>(ToCWordArray(v).get())->Serialize(ar);
+    return ar;
+}
+
+template<char PREFIX>
+CArchive& operator>>(CArchive& ar, std::vector<XxxxID<PREFIX>>& v)
+{
+    if (ar.IsStoring())
+    {
+        AfxThrowArchiveException(CArchiveException::writeOnly);
+    }
+    // KLUDGE:  current file format uses MFC CWordArray
+    CWordArray temp;
+    temp.Serialize(ar);
+    v = ToVector<XxxxID<PREFIX>>(temp);
+    return ar;
+}
+
+template<typename DEST, char PREFIX>
+constexpr std::enable_if_t<is_always_value_preserving_v<DEST, WORD>, DEST> value_preserving_cast(XxxxID<PREFIX> src)
+{
+    return static_cast<DEST>(static_cast<WORD>(src));
+}
+
+template<typename DEST, char PREFIX>
+constexpr std::enable_if_t<!is_always_value_preserving_v<DEST, WORD>, DEST> value_preserving_cast(XxxxID<PREFIX> src)
+{
+    if (!is_value_preserving<DEST>(static_cast<WORD>(src)))
+    {
+        CbThrowBadCastException();
+    }
+    return static_cast<DEST>(static_cast<WORD>(src));
+}
+
+/////////////////////////////////////////////////////////////////////////////
+
+/* Factor some repetitive code for tables indexed by ID values
+    into a new XxxxIDTable<>. */
+template<typename KEY, typename ELEMENT,
+        size_t maxSize, size_t baseSize, size_t incrSize,
+        bool saveInGPlay>
+class XxxxIDTable
+{
+    static_assert(std::is_same_v<KEY, XxxxID<KEY::PREFIX>>, "requires XxxxID<>");
+    /* data is stored in memory that may be realloc()'ed, so data must be memcpy()'able
+        (if ELEMENT is not trivially copyable, use std::vector) */
+    static_assert(std::is_trivially_copyable_v<ELEMENT>, "ELEMENT must be trivially copyable");
+public:
+    XxxxIDTable() noexcept
+    {
+        m_pTbl = NULL;
+        m_nTblSize = 0;
+    }
+
+    XxxxIDTable(const XxxxIDTable& other) :
+        XxxxIDTable()
+    {
+        *this = other;
+    }
+
+    XxxxIDTable& operator=(const XxxxIDTable& other)
+    {
+        ResizeTable(other.GetSize(), nullptr);
+        /* ELEMENT is trivially copyable, so this is safe
+            (and more efficient than for loop with assignments) */
+        memcpy(m_pTbl, other.m_pTbl, GetSize()*sizeof(ELEMENT));
+        return *this;
+    }
+
+    XxxxIDTable(XxxxIDTable&& other) noexcept
+    {
+        m_pTbl = other.m_pTbl;
+        m_nTblSize = other.m_pTbl;
+        other.m_pTbl = NULL;
+        other.m_pTbl = 0;
+    }
+
+    XxxxIDTable& operator=(XxxxIDTable&& other) noexcept
+    {
+        if (m_pTbl != NULL) free(m_pTbl);
+        m_pTbl = other.m_pTbl;
+        m_nTblSize = other.m_pTbl;
+        other.m_pTbl = NULL;
+        other.m_pTbl = 0;
+    }
+
+    ~XxxxIDTable()
+    {
+        Clear();
+    }
+
+    bool operator==(nullptr_t) const { return Empty(); }
+    bool operator!=(nullptr_t) const { return !operator==(nullptr); }
+    bool Empty() const { return !m_pTbl; }
+    size_t GetSize() const { return m_nTblSize; }
+    bool Valid(KEY tid) const { return static_cast<WORD>(tid) < m_nTblSize; }
+
+    const ELEMENT& operator[](KEY tid) const { return m_pTbl[static_cast<WORD>(tid)]; }
+    ELEMENT& operator[](KEY tid) { return const_cast<ELEMENT&>(std::as_const(*this)[tid]); }
+
+    void Clear()
+    {
+        if (m_pTbl != NULL) free(m_pTbl);
+        m_pTbl = NULL;
+        m_nTblSize = 0;
+    }
+
+    /* WARNING:  will need to be generalized if an ELEMENT
+        without IsEmpty() wants to use this */
+    KEY CreateIDEntry(void (ELEMENT::*initializer)())
+    {
+        // Allocate from empty entry if possible
+        for (size_t i = 0; i < m_nTblSize; i++)
+        {
+            if (m_pTbl[i].IsEmpty())
+                return static_cast<KEY>(i);
+        }
+        // Get TileID from end of table.
+        if (m_nTblSize >= maxSize)
+        {
+            AfxThrowMemoryException();
+        }
+        KEY newXid = static_cast<KEY>(m_nTblSize);
+        ResizeTable(m_nTblSize + 1, initializer);
+        return newXid;
+    }
+
+    void ResizeTable(size_t nEntsNeeded, void (ELEMENT::*initializer)())
+    {
+        if (nEntsNeeded == 0)
+        {
+            Clear();
+            return;
+        }
+
+        size_t nNewSize = CalcAllocSize(nEntsNeeded, baseSize, incrSize);
+        if (m_pTbl != NULL)
+        {
+            ELEMENT* pNewTbl = (ELEMENT*)realloc(
+                m_pTbl, nNewSize * sizeof(ELEMENT));
+            if (pNewTbl == NULL)
+                AfxThrowMemoryException();
+            m_pTbl = pNewTbl;
+        }
+        else
+        {
+            m_pTbl = (ELEMENT*)malloc(nNewSize * sizeof(ELEMENT));
+            if (m_pTbl == NULL)
+                AfxThrowMemoryException();
+        }
+        if (initializer)
+        {
+            for (size_t i = m_nTblSize; i < nNewSize; i++)
+                (m_pTbl[i].*initializer)();
+        }
+        m_nTblSize = nNewSize;
+    }
+
+    void Serialize(CArchive& ar)
+    {
+        if (ar.IsStoring())
+        {
+            constexpr bool inGplay =
+#ifdef GPLAY
+                true
+#else
+                false
+#endif
+                ;
+            if (!inGplay || saveInGPlay)
+            {
+                ar << value_preserving_cast<WORD>(m_nTblSize);
+                for (size_t i = 0; i < m_nTblSize; i++)
+                    m_pTbl[i].Serialize(ar);
+            }
+        }
+        else
+        {
+            WORD wTmp;
+            ar >> wTmp;
+            if (wTmp > 0)
+            {
+                ResizeTable(value_preserving_cast<size_t>(wTmp), nullptr);
+                for (size_t i = 0; i < wTmp; i++)
+                    m_pTbl[i].Serialize(ar);
+            }
+        }
+    }
+
+private:
+    ELEMENT*    m_pTbl;         // Global def'ed
+    size_t      m_nTblSize;     // Number of alloc'ed ents in tile table
+};
+
+template<typename KEY, typename ELEMENT,
+        size_t maxSize, size_t baseSize, size_t incrSize,
+        bool saveInGPlay>
+CArchive& operator<<(CArchive& ar, const XxxxIDTable<KEY, ELEMENT, maxSize, baseSize, incrSize, saveInGPlay>& v)
+{
+    if (!ar.IsStoring())
+    {
+        AfxThrowArchiveException(CArchiveException::readOnly);
+    }
+    const_cast<XxxxIDTable<KEY, ELEMENT, maxSize, baseSize, incrSize, saveInGPlay>&>(v).Serialize(ar);
+    return ar;
+}
+
+template<typename KEY, typename ELEMENT,
+        size_t maxSize, size_t baseSize, size_t incrSize,
+        bool saveInGPlay>
+CArchive& operator>>(CArchive& ar, XxxxIDTable<KEY, ELEMENT, maxSize, baseSize, incrSize, saveInGPlay>& v)
+{
+    if (ar.IsStoring())
+    {
+        AfxThrowArchiveException(CArchiveException::writeOnly);
+    }
+    v.Serialize(ar);
+    return ar;
+}
+
+/////////////////////////////////////////////////////////////////////////////
+
+inline CArchive& operator<<(CArchive& ar, const std::string& s)
+{
+    CString cs = s.c_str();
+    ar << cs;
+    return ar;
+}
+
+inline CArchive& operator>>(CArchive& ar, std::string& s)
+{
+    CString cs;
+    ar >> cs;
+    s = cs;
+    return ar;
+}
+
+/////////////////////////////////////////////////////////////////////////////
+
+static_assert(std::is_same_v<std::vector<int>::size_type, size_t>, "std::vector index is not size_t");
+static_assert(std::is_same_v<std::vector<int>::iterator::difference_type, ptrdiff_t>, "std::vector iterator offset is not ptrdiff_t");
+#endif

--- a/GShr/DragDrop.h
+++ b/GShr/DragDrop.h
@@ -28,6 +28,7 @@
 #include "Tile.h"
 #include "Pieces.h"
 #include "Marks.h"
+class CDrawObj;
 class CSelList;
 
 ////////////////////////////////////////////////////////////////
@@ -55,14 +56,16 @@ const   WORD    phaseDragDrop  = 3;
 
 enum DragType
 {
-    DRAG_TILE,              // pObj = CGamDoc*, dwItem = TileID
-    DRAG_TILELIST,          // pObj = CGamDoc*, dwItem = CWordArray*
-    DRAG_MGRTILE,           // pObj = CTileManager*, dwItem = TileID
-    DRAG_PIECE,             // pObj = CGamDoc*, dwItem = PieceID
-    DRAG_PIECELIST,         // pObj = CGamDoc*, dwItem = CWordArray*
-    DRAG_MARKER,            // pObj = CGamDoc*, dwItem = MarkID
-    DRAG_SELECTLIST,        // pObj = CGamDoc*, dwItem = CSelList*
-    DRAG_SELECTVIEW         // pObj = CGamDoc*, dwItem = CPtrArray*
+    DRAG_TILE,
+    DRAG_TILELIST,
+    DRAG_MGRTILE,
+    DRAG_PIECE,
+    DRAG_PIECELIST,
+    DRAG_MARKER,
+    DRAG_SELECTLIST,
+    DRAG_SELECTVIEW,
+
+    DRAG_INVALID = -1,
 };
 
 struct DragInfo
@@ -86,7 +89,7 @@ struct DragInfo
     template<>
     struct SubInfo<DRAG_TILELIST>
     {
-        CWordArray* m_tileIDList;
+        const std::vector<TileID>* m_tileIDList;
         CGamDoc* m_gamDoc;
     };
     template<>
@@ -104,7 +107,7 @@ struct DragInfo
     template<>
     struct SubInfo<DRAG_PIECELIST>
     {
-        CWordArray* m_pieceIDList;
+        const std::vector<PieceID>* m_pieceIDList;
         CGamDoc* m_gamDoc;
     };
     template<>
@@ -122,7 +125,7 @@ struct DragInfo
     template<>
     struct SubInfo<DRAG_SELECTVIEW>
     {
-        CPtrArray* m_ptrArray;
+        std::vector<CDrawObj*>* m_ptrArray;
         CGamDoc* m_gamDoc;
     };
     // TODO:  when upgrade to c++ 17, use std::variant

--- a/GShr/GMisc.h
+++ b/GShr/GMisc.h
@@ -57,7 +57,7 @@ CPoint RotatePointAroundPoint(CPoint pntOrigin, CPoint pntXlate, int nAngleDeg);
 int GridizeClosest1000(int nVal, int nMultiple, int nOffset);
 int GridizeClosest(int nVal, int nMultiple, int nOffset);
 BOOL StrDecimalChecked(const char **psp, int *pnVal, int *pnScale);
-UINT CalcAllocSize(UINT uiDesired, UINT uiBaseSize, UINT uiExtendSize);
+size_t CalcAllocSize(size_t uiDesired, size_t uiBaseSize, size_t uiExtendSize);
 void ScalePoint(POINT& pnt, const CSize& numSize, const CSize& denSize);
 void ScaleRect(RECT& rct, const CSize& numSize, const CSize& denSize);
 int NumInWordArray(CWordArray& array, int val);

--- a/GShr/GdiTools.cpp
+++ b/GShr/GdiTools.cpp
@@ -923,8 +923,8 @@ void ResizeBitmap(CBitmap *pBMap, int iNewX, int iNewY, CPalette* pPalOld,
 {
     BITMAP bminfo;
     pBMap->GetObject(sizeof(BITMAP), &bminfo);
-    int iBltWd = min(iNewX, bminfo.bmWidth);
-    int iBltHt = min(iNewY, bminfo.bmHeight);
+    int iBltWd = CB::min(iNewX, bminfo.bmWidth);
+    int iBltHt = CB::min(iNewY, bminfo.bmHeight);
 
     CBitmap bmap;
     bminfo.bmHeight = iNewY;

--- a/GShr/LBoxGrfx.h
+++ b/GShr/LBoxGrfx.h
@@ -43,11 +43,65 @@
 // These messages are sent by the CGrafixListBox to its parent window.
 // It allows the list's content to be overridden. It's primary use
 // is to deliver a random selection of pieces or markers.
-#define WM_OVERRIDE_SELECTED_ITEM       (WM_USER + 500) // WPARAM = int*
-#define WM_OVERRIDE_SELECTED_ITEM_LIST  (WM_USER + 501) // WPARAM = CWordArray*
+#define WM_OVERRIDE_SELECTED_ITEM       (WM_USER + 500) // WPARAM = COverrideInfoBase<>*
+struct COverrideInfoBase
+{
+protected:
+    COverrideInfoBase(DragType dt) : m_dragType(dt) {}
+
+    template<DragType DT>
+    void CheckTypeBase() const
+    {
+        ASSERT(m_dragType == DT);
+        /* TODO:  This check could be removed to improve release
+            build performance if we trust ourselves to always
+            catch any m_dragType mistakes in testing.  */
+        if (m_dragType != DT)
+        {
+            AfxThrowInvalidArgException();
+        }
+    }
+
+private:
+    const DragType m_dragType;
+};
+
+template<DragType DT>
+struct COverrideInfo
+{
+};
+
+template<>
+struct COverrideInfo<DRAG_MARKER> : private COverrideInfoBase
+{
+    COverrideInfo(MarkID& mid) : COverrideInfoBase(DRAG_MARKER), m_markID(mid) {}
+
+    void CheckType() { CheckTypeBase<DRAG_MARKER>(); }
+
+    MarkID& m_markID;
+};
+
+template<>
+struct COverrideInfo<DRAG_TILE> : private COverrideInfoBase
+{
+    COverrideInfo(TileID& tid) : COverrideInfoBase(DRAG_TILE), m_tileID(tid) {}
+
+    void CheckType() { CheckTypeBase<DRAG_TILE>(); }
+
+    TileID& m_tileID;
+};
+
+#define WM_OVERRIDE_SELECTED_ITEM_LIST  (WM_USER + 501) // WPARAM = std::vector<XxxxID<LPARAM>>*, LPARAM = XxxxID::PREFIX
 
 /////////////////////////////////////////////////////////////////////////////
 // Custom Listbox - containing colors
+
+/* I want CGrafixListBox::m_pItemMap to be type-specific.
+    However, I don't want to replicate the message map for each
+    different type of CGrafixListBox::m_pItemMap.  Therefore,
+    split CGrafixListBox into a base class that contains the
+    message map, and a templatized derived class that contains
+    the type-specific CGrafixListBox::m_pItemMap. */
 
 class CGrafixListBox : public CListBox
 {
@@ -61,30 +115,13 @@ public:
     void EnableDrag(BOOL bEnable = TRUE) { m_bAllowDrag = bEnable; }
     void EnableSelfDrop(BOOL bEnable = TRUE) { m_bAllowSelfDrop = bEnable; }
     void EnableDropScroll(BOOL bEnable = TRUE) { m_bAllowDropScroll = bEnable; }
-    CWordArray* GetItemMap() { return m_pItemMap; }
-    WORD GetCurMapItem();
-    void GetCurMappedItemList(CWordArray* pLst);
-    BOOL IsMultiSelect()
+    BOOL IsMultiSelect() const
         { return (GetStyle() & (LBS_EXTENDEDSEL | LBS_MULTIPLESEL)) != 0; }
-    // Note: the following pointer is only good during drag and drop.
-    // the data is only good during the drop. It is essentially a
-    // hack to have valid data when selecting items with Shift-Click.
-    // Ask Microsoft why I had to do this. The number of selections
-    // data in the case of a shift click isn't valid until the button
-    // is released. Makes it tough to use a pre setup list during the
-    // drag operation.
-    CWordArray* GetMappedMultiSelectList() { return &m_multiSelList; }
 
 // Operations
 public:
-    void SetItemMap(CWordArray* pMap, BOOL bKeepPosition = TRUE);
-    void UpdateList(BOOL bKeepPosition = TRUE);
-    void SetCurSelMapped(WORD nMapVal);
-    void SetCurSelsMapped(CWordArray& items);
     void SetSelFromPoint(CPoint point);
     void ShowFirstSelection();
-    int  MapIndexToItem(int nIndex);
-    int  MapItemToIndex(int nItem);
     void MakeItemVisible(int nItem);
 
     // Notification Tooltip Support
@@ -96,28 +133,36 @@ public:
 
 // Overrides - the subclass of this class must override these
 public:
-    virtual int OnItemHeight(int nIndex) = 0;
-    virtual void OnItemDraw(CDC* pDC, int nIndex, UINT nAction, UINT nState,
-        CRect rctItem) = 0;
-    virtual BOOL OnDragSetup(DragInfo* pDI) { return FALSE; }
-    virtual void OnDragCleanup(DragInfo* pDI) { }
+    virtual unsigned OnItemHeight(size_t nIndex) /* override */ = 0;
+    virtual void OnItemDraw(CDC* pDC, size_t nIndex, UINT nAction, UINT nState,
+        CRect rctItem) /* override */ = 0;
+    virtual BOOL OnDragSetup(DragInfo* pDI) /* override */
+    {
+        pDI->m_dragType = DRAG_INVALID;
+        return FALSE;
+    }
+    virtual void OnDragCleanup(DragInfo* pDI) /* override */ { }
 
     // For tool tip processing
-    virtual BOOL OnIsToolTipsEnabled() { return FALSE; }
-    virtual int  OnGetHitItemCodeAtPoint(CPoint point, CRect& rct) { return -1; }
-    virtual void OnGetTipTextForItemCode(int nItemCode, CString& strTip, CString& strTitle) { }
+    virtual BOOL OnIsToolTipsEnabled() /* override */ { return FALSE; }
+    virtual int  OnGetHitItemCodeAtPoint(CPoint point, CRect& rct) /* override */ { return -1; }
+    virtual void OnGetTipTextForItemCode(int nItemCode, CString& strTip, CString& strTitle) /* override */ { }
+
+    /* N.B.:  Conceptually, this declaration belongs to
+        CTileBaseListBox, but it doesn't hurt much to declare it
+        in general, and doing it here allows override checks of
+        CGrafixListBoxData<>::OnGetItemDebugIDCode. */
+    virtual int OnGetItemDebugIDCode(size_t nItem) /* override */ = 0;
 
 // Implementation
 protected:
-    CWordArray* m_pItemMap;         // Maps index to item
-    CWordArray m_multiSelList;      // Holds mapped multi select items on drop
-
     // Tool tip support
     CToolTipCtrl m_toolMsgTip;      // Tooltip for notifications
     CToolTipCtrl m_toolTip;         // Tooltip of tile text popups
     int     m_nCurItemCode;         // current active tip item code
 
     // Drag and scroll support vars
+    static DragInfo di;
     BOOL    m_bAllowDrag;
     BOOL    m_bAllowSelfDrop;       // Only if m_bAllowDrag == TRUE
     BOOL    m_bAllowDropScroll;     // Scroll on OnDragItem
@@ -139,10 +184,12 @@ protected:
     void  DrawSingle(int nIndex);
 
     // Overrides
-    virtual void MeasureItem(LPMEASUREITEMSTRUCT lpMIS);
-    virtual void DrawItem(LPDRAWITEMSTRUCT lpDIS);
+    virtual void MeasureItem(LPMEASUREITEMSTRUCT lpMIS) override;
+    virtual void DrawItem(LPDRAWITEMSTRUCT lpDIS) override;
 
-    virtual LRESULT WindowProc(UINT message, WPARAM wParam, LPARAM lParam);
+    virtual LRESULT WindowProc(UINT message, WPARAM wParam, LPARAM lParam) override;
+
+    virtual void OnDragEnd(CPoint point) /* override */= 0;
 
     //{{AFX_MSG(CGrafixListBox)
     afx_msg void OnLButtonDown(UINT nFlags, CPoint point);
@@ -153,6 +200,197 @@ protected:
     afx_msg LRESULT OnDragItem(WPARAM wParam, LPARAM lParam);
     //}}AFX_MSG
     DECLARE_MESSAGE_MAP()
+};
+
+/* Some derived classes (e.g., CMarkListBox) derive from
+    (previous) CGrafixListBox indirectly through another class
+    (e.g., CTileBaseListBox), so allow that by letting derived
+    class specify another base class */
+template<typename BASE_WND, typename T>
+class CGrafixListBoxData : public BASE_WND
+{
+    static_assert(std::is_same_v<XxxxID<T::PREFIX>, T>, "requires XxxxID");
+public:
+    CGrafixListBoxData() : m_pItemMap(NULL) {}
+
+    const std::vector<T>* GetItemMap() { return m_pItemMap; }
+    T GetCurMapItem() const
+    {
+        ASSERT(!IsMultiSelect());
+        ASSERT(m_pItemMap);
+        int nItem = GetCurSel();
+        ASSERT(nItem >= 0);
+        ASSERT(value_preserving_cast<size_t>(nItem) < m_pItemMap->size());
+        return m_pItemMap->at(value_preserving_cast<size_t>(nItem));
+    }
+    void GetCurMappedItemList(std::vector<T>& pLst)
+    {
+        pLst.clear();
+        ASSERT(IsMultiSelect());
+        int nSels = GetSelCount();
+        if (nSels == LB_ERR || nSels == 0)
+            return;
+        std::vector<int> pSelTbl(value_preserving_cast<size_t>(nSels));
+        GetSelItems(nSels, pSelTbl.data());
+        pLst.reserve(pSelTbl.size());
+        for (size_t i = 0; i < pSelTbl.size(); i++)
+            pLst.push_back(MapIndexToItem(value_preserving_cast<size_t>(pSelTbl[i])));
+        return;
+    }
+    // Note: the following reference is only good during drag and drop.
+    // the data is only good during the drop. It is essentially a
+    // hack to have valid data when selecting items with Shift-Click.
+    // Ask Microsoft why I had to do this. The number of selections
+    // data in the case of a shift click isn't valid until the button
+    // is released. Makes it tough to use a pre setup list during the
+    // drag operation.
+    const std::vector<T>& GetMappedMultiSelectList() { return m_multiSelList; }
+
+    void SetItemMap(const std::vector<T>* pMap, BOOL bKeepPosition = TRUE)
+    {
+        m_pItemMap = pMap;
+        UpdateList(bKeepPosition);
+    }
+    // bKeepPosition == TRUE means current selection is maintained.
+    void UpdateList(BOOL bKeepPosition = TRUE)
+    {
+        if (m_pItemMap == NULL)
+        {
+            ResetContent();
+            return;
+        }
+
+        SetRedraw(FALSE);
+        int nCurSel = IsMultiSelect() ? -1 : GetCurSel();
+        int nTopIdx = GetTopIndex();
+        int nFcsIdx = GetCaretIndex();
+        ResetContent();
+        int nItem;
+        for (nItem = 0; nItem < value_preserving_cast<int>(m_pItemMap->size()); nItem++)
+            AddString(" ");             // Fill with dummy data
+        if (bKeepPosition)
+        {
+            if (nTopIdx >= 0)
+                SetTopIndex(CB::min(nTopIdx, nItem - 1));
+            if (nFcsIdx >= 0)
+                SetCaretIndex(CB::min(nFcsIdx, nItem - 1), FALSE);
+            if (nCurSel >= 0)
+                SetCurSel(CB::min(nCurSel, nItem - 1));
+        }
+        SetRedraw(TRUE);
+        Invalidate();
+    }
+    void SetCurSelMapped(T nMapVal)
+    {
+        ASSERT(m_pItemMap);
+        for (size_t i = 0; i < m_pItemMap->size(); i++)
+        {
+            if (m_pItemMap->at(i) == nMapVal)
+            {
+                SetCurSel(value_preserving_cast<int>(i));
+                SetTopIndex(value_preserving_cast<int>(i));
+            }
+        }
+    }
+    void SetCurSelsMapped(const std::vector<T>& items)
+    {
+        ASSERT(m_pItemMap);
+        ASSERT(IsMultiSelect());
+
+        SetSel(-1, FALSE);      // Deselect all
+        for (size_t i = 0; i < items.size(); i++)
+        {
+            for (size_t j = 0; j < m_pItemMap->size(); j++)
+            {
+                if (m_pItemMap->at(j) == items[i])
+                    SetSel(value_preserving_cast<int>(j));
+            }
+        }
+    }
+
+    T MapIndexToItem(size_t nIndex)
+    {
+        ASSERT(m_pItemMap);
+        ASSERT(nIndex < m_pItemMap->size());
+        return m_pItemMap->at(nIndex);
+    }
+    size_t MapItemToIndex(T nItem)
+    {
+        ASSERT(m_pItemMap);
+        for (size_t i = 0; i < m_pItemMap->size(); i++)
+        {
+            if (nItem == m_pItemMap->at(i))
+                return i;
+        }
+        return Invalid_v<size_t>;                  // Failed to find it
+    }
+
+protected:
+    virtual void OnDragEnd(CPoint point) override
+    {
+        if (di.m_dragType == DRAG_INVALID)
+        {
+            // do nothing
+        }
+        else if (IsMultiSelect())
+        {
+            // Get the final selection results after the mouse was released.
+            GetCurMappedItemList(m_multiSelList);
+
+            CWnd* pWnd = GetParent();
+            ASSERT(pWnd != NULL);
+            pWnd->SendMessage(WM_OVERRIDE_SELECTED_ITEM_LIST, reinterpret_cast<WPARAM>(&m_multiSelList), T::PREFIX);
+        }
+        else
+        {
+            // The parent may want to override the value.
+            if (di.m_dragType == DRAG_MARKER)
+            {
+                COverrideInfo<DRAG_MARKER> oi(di.GetSubInfo<DRAG_MARKER>().m_markID);
+                CWnd* pWnd = GetParent();
+                ASSERT(pWnd != NULL);
+                pWnd->SendMessage(WM_OVERRIDE_SELECTED_ITEM, reinterpret_cast<WPARAM>(&oi));
+            }
+            else if (di.m_dragType == DRAG_TILE)
+            {
+                COverrideInfo<DRAG_TILE> oi(di.GetSubInfo<DRAG_TILE>().m_tileID);
+                CWnd* pWnd = GetParent();
+                ASSERT(pWnd != NULL);
+                pWnd->SendMessage(WM_OVERRIDE_SELECTED_ITEM, reinterpret_cast<WPARAM>(&oi));
+            }
+            else
+            {
+                ASSERT(!"unexpected dragType");
+            }
+        }
+
+        ReleaseCapture();
+        SetCursor(LoadCursor(NULL, IDC_ARROW));
+
+        CWnd* pWnd = GetWindowFromPoint(point);
+        if (pWnd == NULL || (!m_bAllowSelfDrop && pWnd == this))
+        {
+            OnDragCleanup(&di);         // Tell subclass we're all done.
+            return;
+        }
+        di.m_point = point;
+        di.m_pointClient = point;       // list box relative
+        ClientToScreen(&di.m_point);
+        pWnd->ScreenToClient(&di.m_point);
+
+        pWnd->SendMessage(WM_DRAGDROP, phaseDragDrop,
+            (LPARAM)(LPVOID)&di);
+        OnDragCleanup(&di);         // Tell subclass we're all done.
+        m_multiSelList.clear();
+    }
+
+    /* N.B.:  Only CTileBaseListBox requires providing this, but
+        it doesn't hurt much to provide it in general.  */
+    virtual int OnGetItemDebugIDCode(size_t nItem) override { return value_preserving_cast<int>(static_cast<WORD>(MapIndexToItem(nItem))); }
+
+private:
+    const std::vector<T>* m_pItemMap;         // Maps index to item
+    std::vector<T> m_multiSelList;      // Holds mapped multi select items on drop
 };
 
 #endif

--- a/GShr/LBoxMark.h
+++ b/GShr/LBoxMark.h
@@ -44,7 +44,7 @@ enum  MarkerTrayViz;
 
 /////////////////////////////////////////////////////////////////////////////
 
-class CMarkListBox : public CTileBaseListBox
+class CMarkListBox : public CGrafixListBoxData<CTileBaseListBox, MarkID>
 {
 // Construction
 public:
@@ -58,7 +58,7 @@ public:
         m_strHiddenString = pszHiddenString;
     }
 
-    virtual CTileManager* GetTileManager();
+    virtual CTileManager* GetTileManager() override;
 
 // Operations
 public:
@@ -76,16 +76,16 @@ protected:
     int             m_bDisplayIDs;      // Set to prop [Settings]:DisplayIDs
 
     // Overrides
-    virtual int OnItemHeight(int nIndex);
-    virtual void OnItemDraw(CDC* pDC, int nIndex, UINT nAction, UINT nState,
-        CRect rctItem);
-    virtual BOOL OnDragSetup(DragInfo* pDI);
+    virtual unsigned OnItemHeight(size_t nIndex) override;
+    virtual void OnItemDraw(CDC* pDC, size_t nIndex, UINT nAction, UINT nState,
+        CRect rctItem) override;
+    virtual BOOL OnDragSetup(DragInfo* pDI) override;
 
     // Tool tip processing
-    virtual BOOL OnIsToolTipsEnabled();
-    virtual int  OnGetHitItemCodeAtPoint(CPoint point, CRect& rct);
-    virtual void OnGetTipTextForItemCode(int nItemCode, CString& strTip, CString& strTitle);
-    virtual BOOL OnDoesItemHaveTipText(int nItem);
+    virtual BOOL OnIsToolTipsEnabled() override;
+    virtual int  OnGetHitItemCodeAtPoint(CPoint point, CRect& rct) override;
+    virtual void OnGetTipTextForItemCode(int nItemCode, CString& strTip, CString& strTitle) override;
+    virtual BOOL OnDoesItemHaveTipText(size_t nItem) override;
 
     //{{AFX_MSG(CMarkListBox)
 //  afx_msg int OnCreate(LPCREATESTRUCT lpCreateStruct);

--- a/GShr/LBoxPiec.h
+++ b/GShr/LBoxPiec.h
@@ -40,7 +40,7 @@ class CGamDoc;
 
 /////////////////////////////////////////////////////////////////////////////
 
-class CPieceListBox : public CTileBaseListBox
+class CPieceListBox : public CGrafixListBoxData<CTileBaseListBox, PieceID>
 {
 // Construction
 public:
@@ -50,7 +50,7 @@ public:
 public:
     void SetDocument(CGamDoc* pDoc);
 
-    virtual CTileManager* GetTileManager();
+    virtual CTileManager* GetTileManager() override;
 
 // Operations
 public:
@@ -61,16 +61,16 @@ protected:
     CPieceManager*  m_pPMgr;
 
     // Overrides
-    virtual int OnItemHeight(int nIndex);
-    virtual void OnItemDraw(CDC* pDC, int nIndex, UINT nAction, UINT nState,
-        CRect rctItem);
-    virtual BOOL OnDragSetup(DragInfo* pDI);
+    virtual unsigned OnItemHeight(size_t nIndex) override;
+    virtual void OnItemDraw(CDC* pDC, size_t nIndex, UINT nAction, UINT nState,
+        CRect rctItem) override;
+    virtual BOOL OnDragSetup(DragInfo* pDI) override;
 
     // Tool tip processing
-    virtual BOOL OnIsToolTipsEnabled();
-    virtual int  OnGetHitItemCodeAtPoint(CPoint point, CRect& rct);
-    virtual void OnGetTipTextForItemCode(int nItemCode, CString& strTip, CString& strTitle);
-    virtual BOOL OnDoesItemHaveTipText(int nItem);
+    virtual BOOL OnIsToolTipsEnabled() override;
+    virtual int  OnGetHitItemCodeAtPoint(CPoint point, CRect& rct) override;
+    virtual void OnGetTipTextForItemCode(int nItemCode, CString& strTip, CString& strTitle) override;
+    virtual BOOL OnDoesItemHaveTipText(size_t nItem) override;
 
     //{{AFX_MSG(CPieceListBox)
     afx_msg int OnCreate(LPCREATESTRUCT lpCreateStruct);

--- a/GShr/LBoxTileBase.cpp
+++ b/GShr/LBoxTileBase.cpp
@@ -57,7 +57,7 @@ CTileBaseListBox::CTileBaseListBox()
 
 /////////////////////////////////////////////////////////////////////////////
 
-int CTileBaseListBox::DoOnItemHeight(TileID tid1, TileID tid2)
+unsigned CTileBaseListBox::DoOnItemHeight(TileID tid1, TileID tid2)
 {
     ASSERT(tid1 != nullTid);        // At least one tile needs to exist
 
@@ -74,16 +74,16 @@ int CTileBaseListBox::DoOnItemHeight(TileID tid1, TileID tid2)
         nHt2 = tile.GetHeight();
     }
     // Listbox lines can only be 255 pixels high.
-    int nHt = min(2 * tileBorder + max(nHt1, nHt2), 255);
+    LONG nHt = CB::min(2 * tileBorder + CB::max(nHt1, nHt2), 255);
 
     if (m_bDisplayIDs || m_bTipMarkItems)   // See if we're drawing debug ID's
-        nHt = max(nHt, g_res.tm8ss.tmHeight + g_res.tm8ss.tmExternalLeading);
-    return nHt;
+        nHt = CB::max(nHt, g_res.tm8ss.tmHeight + g_res.tm8ss.tmExternalLeading);
+    return value_preserving_cast<unsigned>(nHt);
 }
 
 /////////////////////////////////////////////////////////////////////////////
 
-void CTileBaseListBox::DoOnDrawItem(CDC *pDC, int nItem, UINT nAction, UINT nState,
+void CTileBaseListBox::DoOnDrawItem(CDC *pDC, size_t nItem, UINT nAction, UINT nState,
     CRect rctItem, TileID tid1, TileID tid2)
 {
     if (nAction & (ODA_DRAWENTIRE | ODA_SELECT))
@@ -146,7 +146,7 @@ void CTileBaseListBox::DrawTileImage(CDC* pDC, CRect rctItem, BOOL bDrawIt, int&
 // Optionally draw debug code string for item. If bDrawIt is false,
 // x is advanced the size of the string anyway but nothing is rendered
 
-void CTileBaseListBox::DrawItemDebugIDCode(CDC* pDC, int nItem, CRect rctItem, BOOL bDrawIt, int& x)
+void CTileBaseListBox::DrawItemDebugIDCode(CDC* pDC, size_t nItem, CRect rctItem, BOOL bDrawIt, int& x)
 {
     if (m_bDisplayIDs)
     {
@@ -202,7 +202,7 @@ void CTileBaseListBox::DrawTipMarker(CDC* pDC, CRect rctItem, BOOL bVisible, int
     }
 }
 
-void CTileBaseListBox::OnGetItemDebugString(int nItem, CString& str)
+void CTileBaseListBox::OnGetItemDebugString(size_t nItem, CString& str)
 {
     str.Format("[%d] ", OnGetItemDebugIDCode(nItem));
 }
@@ -228,7 +228,7 @@ void CTileBaseListBox::GetTileRectsForItem(int nItem, TileID tidLeft, TileID tid
     // rendered to left of tile images
     CDC* pDC = GetDC();
     DrawTipMarker(pDC, rctItem, FALSE, x);
-    DrawItemDebugIDCode(pDC, nItem, rctItem, FALSE, x);
+    DrawItemDebugIDCode(pDC, value_preserving_cast<size_t>(nItem), rctItem, FALSE, x);
     ReleaseDC(pDC);
 
     rctLeft.left = x;

--- a/GShr/LBoxTileBase.h
+++ b/GShr/LBoxTileBase.h
@@ -55,13 +55,13 @@ protected:
 // Helpers...
 protected:
     void DrawTileImage(CDC* pDC, CRect rctItem, BOOL bDrawIt, int& x, TileID tid);
-    void DrawItemDebugIDCode(CDC* pDC, int nItem, CRect rctItem, BOOL bDrawIt, int& x);
+    void DrawItemDebugIDCode(CDC* pDC, size_t nItem, CRect rctItem, BOOL bDrawIt, int& x);
 
     void SetupTipMarkerIfRequired();
     void DrawTipMarker(CDC* pDC, CRect rctItem, BOOL bVisible, int& x);
 
-    int  DoOnItemHeight(TileID tid1, TileID tid2);
-    void DoOnDrawItem(CDC *pDC, int nItem, UINT nAction, UINT nState, CRect rctItem,
+    unsigned DoOnItemHeight(TileID tid1, TileID tid2);
+    void DoOnDrawItem(CDC *pDC, size_t nItem, UINT nAction, UINT nState, CRect rctItem,
         TileID tid1, TileID tid2);
 
     void GetTileRectsForItem(int nItem, TileID tidLeft, TileID tidRight, CRect& rctLeft,
@@ -69,15 +69,15 @@ protected:
 
 // Overrides...
 public:
-    virtual CTileManager* GetTileManager() = 0;
+    virtual CTileManager* GetTileManager() /* override */ = 0;
 
 // Overrides...
 protected:
-    virtual BOOL OnDoesItemHaveTipText(int nItem) { return FALSE; }
+    virtual BOOL OnDoesItemHaveTipText(size_t nItem) /* override */ { return FALSE; }
 
-    // Subclass should only override one of these if any...
-    virtual int  OnGetItemDebugIDCode(int nItem) { return MapIndexToItem(nItem); }
-    virtual void OnGetItemDebugString(int nItem, CString& str);
+    // see CGrafixListBox::OnGetItemDebugIDCode comment
+    virtual int  OnGetItemDebugIDCode(size_t nItem) override = 0;
+    virtual void OnGetItemDebugString(size_t nItem, CString & str) /* override */;
 
     //{{AFX_MSG(CTileBaseListBox)
     //}}AFX_MSG

--- a/GShr/LBoxTileBase2.cpp
+++ b/GShr/LBoxTileBase2.cpp
@@ -57,7 +57,7 @@ CTileBaseListBox2::CTileBaseListBox2()
 
 /////////////////////////////////////////////////////////////////////////////
 
-int CTileBaseListBox2::DoOnItemHeight(TileID tid1, TileID tid2)
+unsigned CTileBaseListBox2::DoOnItemHeight(TileID tid1, TileID tid2)
 {
     ASSERT(tid1 != nullTid);        // At least one tile needs to exist
 
@@ -74,16 +74,16 @@ int CTileBaseListBox2::DoOnItemHeight(TileID tid1, TileID tid2)
         nHt2 = tile.GetHeight();
     }
     // Listbox lines can only be 255 pixels high.
-    int nHt = min(2 * tileBorder + max(nHt1, nHt2), 255);
+    int nHt = CB::min(2 * tileBorder + CB::max(nHt1, nHt2), 255);
 
     if (m_bDisplayIDs || m_bTipMarkItems)   // See if we're drawing debug ID's
-        nHt = max(nHt, g_res.tm8ss.tmHeight + g_res.tm8ss.tmExternalLeading);
-    return nHt;
+        nHt = CB::max(nHt, g_res.tm8ss.tmHeight + g_res.tm8ss.tmExternalLeading);
+    return value_preserving_cast<unsigned>(nHt);
 }
 
 /////////////////////////////////////////////////////////////////////////////
 
-void CTileBaseListBox2::DoOnDrawItem(CDC *pDC, int nItem, UINT nAction, UINT nState,
+void CTileBaseListBox2::DoOnDrawItem(CDC *pDC, size_t nItem, UINT nAction, UINT nState,
     CRect rctItem, TileID tid1, TileID tid2)
 {
     if (nAction & (ODA_DRAWENTIRE | ODA_SELECT))
@@ -146,7 +146,7 @@ void CTileBaseListBox2::DrawTileImage(CDC* pDC, CRect rctItem, BOOL bDrawIt, int
 // Optionally draw debug code string for item. If bDrawIt is false,
 // x is advanced the size of the string anyway but nothing is rendered
 
-void CTileBaseListBox2::DrawItemDebugIDCode(CDC* pDC, int nItem, CRect rctItem, BOOL bDrawIt, int& x)
+void CTileBaseListBox2::DrawItemDebugIDCode(CDC* pDC, size_t nItem, CRect rctItem, BOOL bDrawIt, int& x)
 {
     if (m_bDisplayIDs)
     {
@@ -202,20 +202,20 @@ void CTileBaseListBox2::DrawTipMarker(CDC* pDC, CRect rctItem, BOOL bVisible, in
     }
 }
 
-void CTileBaseListBox2::OnGetItemDebugString(int nItem, CString& str)
+void CTileBaseListBox2::OnGetItemDebugString(size_t nItem, CString& str)
 {
     str.Format("[%d] ", (DWORD)OnGetItemDebugIDCode(nItem));
 }
 
 /////////////////////////////////////////////////////////////////////////////
 
-void CTileBaseListBox2::GetTileRectsForItem(int nItem, TileID tidLeft, TileID tidRight,
+void CTileBaseListBox2::GetTileRectsForItem(size_t nItem, TileID tidLeft, TileID tidRight,
     CRect& rctLeft, CRect& rctRight)
 {
     ASSERT(tidLeft != nullTid);
 
     CRect rctItem;
-    GetItemRect(nItem, &rctItem);
+    GetItemRect(value_preserving_cast<int>(nItem), &rctItem);
 
     rctRight.SetRectEmpty();                    // Initially empty the right rect
 

--- a/GShr/LBoxTileBase2.h
+++ b/GShr/LBoxTileBase2.h
@@ -55,29 +55,29 @@ protected:
 // Helpers...
 protected:
     void DrawTileImage(CDC* pDC, CRect rctItem, BOOL bDrawIt, int& x, TileID tid);
-    void DrawItemDebugIDCode(CDC* pDC, int nItem, CRect rctItem, BOOL bDrawIt, int& x);
+    void DrawItemDebugIDCode(CDC* pDC, size_t nItem, CRect rctItem, BOOL bDrawIt, int& x);
 
     void SetupTipMarkerIfRequired();
     void DrawTipMarker(CDC* pDC, CRect rctItem, BOOL bVisible, int& x);
 
-    int  DoOnItemHeight(TileID tid1, TileID tid2);
-    void DoOnDrawItem(CDC *pDC, int nItem, UINT nAction, UINT nState, CRect rctItem,
+    unsigned DoOnItemHeight(TileID tid1, TileID tid2);
+    void DoOnDrawItem(CDC *pDC, size_t nItem, UINT nAction, UINT nState, CRect rctItem,
         TileID tid1, TileID tid2);
 
-    void GetTileRectsForItem(int nItem, TileID tidLeft, TileID tidRight, CRect& rctLeft,
+    void GetTileRectsForItem(size_t nItem, TileID tidLeft, TileID tidRight, CRect& rctLeft,
         CRect& rctRight);
 
 // Overrides...
 public:
-    virtual CTileManager* GetTileManager() = 0;
+    virtual CTileManager* GetTileManager() /* override */ = 0;
 
 // Overrides...
 protected:
-    virtual BOOL OnDoesItemHaveTipText(int nItem) { return FALSE; }
+    virtual BOOL OnDoesItemHaveTipText(size_t nItem) /* override */ { return FALSE; }
 
     // Subclass should only override one of these if any...
-    virtual void* OnGetItemDebugIDCode(int nItem) { return MapIndexToItem(nItem); }
-    virtual void  OnGetItemDebugString(int nItem, CString& str);
+    virtual const void* OnGetItemDebugIDCode(size_t nItem) /* override */ { return MapIndexToItem(nItem); }
+    virtual void  OnGetItemDebugString(size_t nItem, CString& str) /* override */;
 
     //{{AFX_MSG(CTileBaseListBox)
     //}}AFX_MSG

--- a/GShr/MapStrng.h
+++ b/GShr/MapStrng.h
@@ -45,10 +45,10 @@ const DWORD GAMEELEM_OBJECTID_MASK = 0xFFFE0000L; // else...top 15 bits nonzero 
                                                   // otherwise it's a piece ID with side code
 
 inline GameElement MakePieceElement(PieceID pid, int nSide = 0)
-    { return (GameElement)(pid | (DWORD)nSide << 16); }
+    { return (GameElement)(static_cast<WORD>(pid) | (DWORD)nSide << 16); }
 
 inline GameElement MakeMarkerElement(MarkID mid)
-    { return (GameElement)((DWORD)mid | GAMEELEM_MARKERID_FLAG); }
+    { return (GameElement)((DWORD)static_cast<WORD>(mid) | GAMEELEM_MARKERID_FLAG); }
 
 #if defined(GPLAY)
 inline GameElement MakeObjectIDElement(ObjectID dwObjectID)
@@ -68,7 +68,7 @@ inline BOOL IsGameElementAnObjectID(GameElement elem)
     }
 
 inline PieceID GetPieceIDFromElement(GameElement elem)
-    { return (PieceID)(elem & 0xFFFF); }
+    { return static_cast<PieceID>(elem & 0xFFFF); }
 
 #if defined(GPLAY)
 inline ObjectID GetObjectIDFromElement(GameElement elem)

--- a/GShr/Rotate.cpp
+++ b/GShr/Rotate.cpp
@@ -270,10 +270,10 @@ static void FindRectVectorMinMax(POINT* pPnts, CPoint& pntMin, CPoint& pntMax)
     pntMax.y = INT_MIN;
     for (int i = 0; i < numPnts; i++)
     {
-        pntMin.x = min(pntMin.x, pPnts[i].x);
-        pntMin.y = min(pntMin.y, pPnts[i].y);
-        pntMax.x = max(pntMax.x, pPnts[i].x);
-        pntMax.y = max(pntMax.y, pPnts[i].y);
+        pntMin.x = CB::min(pntMin.x, pPnts[i].x);
+        pntMin.y = CB::min(pntMin.y, pPnts[i].y);
+        pntMax.x = CB::max(pntMax.x, pPnts[i].x);
+        pntMax.y = CB::max(pntMax.y, pPnts[i].y);
     }
 }
 

--- a/GShr/TileSet.cpp
+++ b/GShr/TileSet.cpp
@@ -36,11 +36,11 @@ static char THIS_FILE[] = __FILE__;
 
 //////////////////////////////////////////////////////////////////
 
-BOOL CTileSet::HasTileID(TileID tid)
+BOOL CTileSet::HasTileID(TileID tid) const
 {
-    for (int i = 0; i < m_tidTbl.GetSize(); i++)
+    for (size_t i = 0; i < m_tidTbl.size(); i++)
     {
-        if ((TileID)m_tidTbl.GetAt(i) == tid)
+        if (m_tidTbl.at(i) == tid)
             return TRUE;
     }
     return FALSE;
@@ -48,44 +48,49 @@ BOOL CTileSet::HasTileID(TileID tid)
 
 void CTileSet::RemoveTileID(TileID tid)
 {
-    for (int i = 0; i < m_tidTbl.GetSize(); i++)
+    for (size_t i = 0; i < m_tidTbl.size(); i++)
     {
-        if ((TileID)m_tidTbl.GetAt(i) == tid)
+        if (m_tidTbl.at(i) == tid)
         {
-            m_tidTbl.RemoveAt(i);
+            m_tidTbl.erase(m_tidTbl.begin() + value_preserving_cast<ptrdiff_t>(i));
             return;
         }
     }
 }
 
-int CTileSet::FindTileID(TileID tid)
+size_t CTileSet::FindTileID(TileID tid) const
 {
-    for (int i = 0; i < m_tidTbl.GetSize(); i++)
+    for (size_t i = 0; i < m_tidTbl.size(); i++)
     {
-        if ((TileID)m_tidTbl.GetAt(i) == tid)
+        if (m_tidTbl.at(i) == tid)
             return i;
     }
-    return -1;
+    return Invalid_v<size_t>;
 }
 
-void CTileSet::AddTileID(TileID tid, int nPos /* = -1 */)
+void CTileSet::AddTileID(TileID tid, size_t nPos /* = Invalid_v<size_t> */)
 {
-    if (nPos < 0)
-        m_tidTbl.Add((WORD)tid);
+    if (nPos == Invalid_v<size_t>)
+        m_tidTbl.push_back(tid);
     else
     {
-        ASSERT(nPos <= m_tidTbl.GetSize());
-        m_tidTbl.InsertAt(nPos, (WORD)tid);
+        ASSERT(nPos <= m_tidTbl.size());
+        m_tidTbl.insert(m_tidTbl.begin() + value_preserving_cast<ptrdiff_t>(nPos), tid);
     }
 }
 
 void CTileSet::Serialize(CArchive& ar)
 {
     if (ar.IsStoring())
+    {
         ar << m_strName;
+        ar << m_tidTbl;
+    }
     else
+    {
         ar >> m_strName;
-    m_tidTbl.Serialize(ar);
+        ar >> m_tidTbl;
+    }
 }
 
 

--- a/GShr/WinState.h
+++ b/GShr/WinState.h
@@ -83,10 +83,10 @@ protected:
 protected:
     CWinStateElement* GetWindowState(CWnd* pWnd);
     BOOL RestoreWindowState(CWnd* pWnd, CWinStateElement* pWse);
-    void GetDocumentFrameList(CPtrArray& tblFrames);
+    void GetDocumentFrameList(std::vector<CFrameWnd*>& tblFrames);
     CWnd* GetDocumentFrameHavingRuntimeClass(CRuntimeClass* pClass);
 
-    void ArrangeFrameListInZOrder(CPtrArray& tblFrames);
+    void ArrangeFrameListInZOrder(std::vector<CFrameWnd*>& tblFrames);
     static BOOL CALLBACK EnumFrames(HWND hWnd, LPARAM dwTblFramePtr);
 
     void SetUpListIfNeedTo();


### PR DESCRIPTION
This is a big changeset to review, but I didn't think the intermediate stages would much sense before the final result.

The original code uses typedef unsigned short TileID/MarkID/PieceID.  However, this means TileID/MarkID/PieceID are just additional names for unsigned short, and thus assigning a MarkID to a PieceID is permitted by the compiler.  I have changed this by making a template class for the IDs, and each ID type is given a different template parameter value, so the compiler views them as separate types and refuses to allow mixing the types.  However, this does require changing a lot of code that was written based on the IDs being unsigned short, which is part of why this changeset is so large.

Another reason the changeset is so large is that I discovered some repetitive code to handle storing growable arrays using GlobalAlloc instead of regular C++ heap.  I replaced that code with another template class.  I admit it is possible that should have been a separate changeset, but those arrays were indexed by the ID types, so I already needed to rewrite the code some to handle that change, and I think it was less work to replace the repetitive code with a template rather than fix each repetition separately.

Yet another issue is that std::vector and, following that model, the new GlobalAlloc growable array use size_t as an index, but most of MFC and current CyberBoard code uses int as its index type.  I actually think size_t makes more sense, so I didn't create an int-based std::vector replacement.  However, that means I was doing a lot of casting back and forth between size_t and int, so I added a template function similar to dynamic_cast<> that will throw if the conversion does not preserve the value across the conversion, and use it frequently.  If all of that casting bothers you, I think I could redo this patch using an int-based replacement for std::vector and the new GlobalAlloc growable array.  However, even doing that would require changing the existing code that uses int to intptr_t in the long run when we convert to 64bit code.  As such, I would rather use size_t.