### PR TITLE
Have CGbxProjView::DoBoardClone() call CGamDoc::SetLoadingVersion()

### DIFF
--- a/GM/GmDoc.cpp
+++ b/GM/GmDoc.cpp
@@ -614,7 +614,8 @@ void CGamDoc::Serialize(CArchive& ar)
                     AfxThrowArchiveException(CArchiveException::genericException);
                 }
             }
-            SetLoadingVersion(NumVersion(verMajor, verMinor));
+            SetLoadingVersionGuard setLoadingVersionGuard(NumVersion(verMajor, verMinor),
+                                                            NumVersion(fileGbxVerMajor, fileGbxVerMinor));
             ar >> bucket;           // Eat program version
             ar >> bucket;
 
@@ -681,8 +682,6 @@ void CGamDoc::Serialize(CArchive& ar)
 
             if (CGamDoc::GetLoadingVersion() >= NumVersion(2, 90))// Ver 2.90
                 CColorPalette::CustomColorsSerialize(ar, m_pCustomColors);
-
-            SetLoadingVersion(NumVersion(fileGbxVerMajor, fileGbxVerMinor));
         }
         CATCH(CArchiveException, e)
         {

--- a/GM/GmDoc.h
+++ b/GM/GmDoc.h
@@ -47,6 +47,10 @@
 #include    "MapStrng.h"
 #endif
 
+#ifndef     __VERSIONS_H__
+#include    "Versions.h"
+#endif
+
 //////////////////////////////////////////////////////////////////////
 
 #define     KEY_PASS_POSTFIX        "BaDkArMa"
@@ -181,6 +185,7 @@ public:
     // Current Tile Manager. Only valid when Serializing
     static CTileManager* GetCurrentTileManager() { return c_pTileMgr; }
     static void SetLoadingVersion(int ver) { c_fileVersion = ver; }
+    using SetLoadingVersionGuard = ::SetLoadingVersionGuard<CGamDoc>;
     static int GetLoadingVersion() { return c_fileVersion; }
     // -------- //
     DWORD GetGameBoxID() { return m_dwGameID; }

--- a/GM/VwPrjgb1.cpp
+++ b/GM/VwPrjgb1.cpp
@@ -146,6 +146,7 @@ void CGbxProjView::DoBoardClone()
     CBoard* pNewBoard = NULL;
     TRY
     {
+        CGamDoc::SetLoadingVersionGuard setLoadingVersionGuard(NumVersion(fileGbxVerMajor, fileGbxVerMinor));
         CMemFile file;
         CArchive arSave(&file, CArchive::store);
         arSave.m_pDocument = pDoc;

--- a/GP/GamDoc.h
+++ b/GP/GamDoc.h
@@ -65,6 +65,10 @@
 #include    "MoveMgr.h"
 #endif
 
+#ifndef     __VERSIONS_H__
+#include    "Versions.h"
+#endif
+
 ////////////////////////////////////////////////////////////////
 
 class CGameBox;
@@ -144,6 +148,7 @@ public:
     static CFontTbl* GetFontManager()
         { return CGameBox::GetFontManager(); }
     static void SetLoadingVersion(int ver) { c_fileVersion = ver; }
+    using SetLoadingVersionGuard = ::SetLoadingVersionGuard<CGamDoc>;
     static int GetLoadingVersion() { return c_fileVersion; }
     // The version of the loaded file is used to determine
     // if the game histories need to be upgraded and written

--- a/GP/GamDoc3.cpp
+++ b/GP/GamDoc3.cpp
@@ -138,7 +138,8 @@ void CGamDoc::SerializeMoveSet(CArchive& ar, CHistRecord*& pHist)
             AfxMessageBox(IDS_ERR_GAMENEWER, MB_OK | MB_ICONEXCLAMATION);
             AfxThrowArchiveException(CArchiveException::genericException);
         }
-        SetLoadingVersion(NumVersion(verMajor, verMinor));
+        SetLoadingVersionGuard setLoadingVersionGuard(NumVersion(verMajor, verMinor),
+                                                        NumVersion(fileGamVerMajor, fileGamVerMinor));
 
         BYTE byteBucket;        // Place to dump unused bytes
         ar >> byteBucket;       // Eat the program version
@@ -160,8 +161,6 @@ void CGamDoc::SerializeMoveSet(CArchive& ar, CHistRecord*& pHist)
             pHist->m_pMList.reset(new CMoveList);
             pHist->m_pMList->Serialize(ar, FALSE);             // before Ver2.90
         }
-
-        SetLoadingVersion(NumVersion(fileGamVerMajor, fileGamVerMinor));
     }
 }
 

--- a/GP/GameBox.cpp
+++ b/GP/GameBox.cpp
@@ -97,8 +97,6 @@ BOOL CGameBox::Load(CGamDoc* pDoc, LPCSTR pszPathName, CString& strErr,
     ar.m_pDocument = pDoc;
     ar.m_bForceFlat = FALSE;
 
-    int nSaveLoadingVersion = CGamDoc::GetLoadingVersion();
-
     TRY
     {
         GetMainFrame()->BeginWaitCursor();
@@ -123,7 +121,7 @@ BOOL CGameBox::Load(CGamDoc* pDoc, LPCSTR pszPathName, CString& strErr,
             return FALSE;
         }
         SetLoadingVersion(NumVersion(verMajor, verMinor));
-        CGamDoc::SetLoadingVersion(NumVersion(verMajor, verMinor));
+        CGamDoc::SetLoadingVersionGuard setLoadingVersionGuard(NumVersion(verMajor, verMinor));
 
         ar >> cEatThis;         // Eat program version
         ar >> cEatThis;
@@ -194,12 +192,14 @@ BOOL CGameBox::Load(CGamDoc* pDoc, LPCSTR pszPathName, CString& strErr,
         ar.Close();
         file.Close();
         GetMainFrame()->EndWaitCursor();
+        c_pTileMgr = NULL;
     }
     CATCH(CMemoryException, e)
     {
         file.Abort();       // Will not throw an exception
         GetMainFrame()->EndWaitCursor();
         strErr.LoadString(IDS_ERR_GBXNOMEM);
+        c_pTileMgr = NULL;
         return FALSE;
     }
     AND_CATCH_ALL(e)
@@ -207,10 +207,9 @@ BOOL CGameBox::Load(CGamDoc* pDoc, LPCSTR pszPathName, CString& strErr,
         file.Abort();       // Will not throw an exception
         GetMainFrame()->EndWaitCursor();
         strErr.LoadString(IDS_ERR_GBXREAD);
+        c_pTileMgr = NULL;
         return FALSE;
     }
     END_CATCH_ALL
-    c_pTileMgr = NULL;
-    CGamDoc::SetLoadingVersion(nSaveLoadingVersion);
     return TRUE;
 }

--- a/GP/GeoBoard.cpp
+++ b/GP/GeoBoard.cpp
@@ -431,8 +431,7 @@ CBoard* CGeomorphicBoard::CloneBoard(CBoard& pOrigBoard)
     // we may be loading an earlier version game or scenario. In
     // this case the board data has already been upgraded. Make
     // a copy of the current loading version so we can restore it.
-    int nCurLoadingVersion = CGamDoc::GetLoadingVersion();
-    CGamDoc::SetLoadingVersion(NumVersion(fileGsnVerMajor, fileGsnVerMinor));
+    CGamDoc::SetLoadingVersionGuard setLoadingVersionGuard(NumVersion(fileGsnVerMajor, fileGsnVerMinor));
 
     CBoard* pNewBoard = NULL;
     TRY
@@ -457,7 +456,6 @@ CBoard* CGeomorphicBoard::CloneBoard(CBoard& pOrigBoard)
     }
     END_CATCH_ALL
 
-    CGamDoc::SetLoadingVersion(nCurLoadingVersion);
     return pNewBoard;
 }
 

--- a/GShr/Versions.h
+++ b/GShr/Versions.h
@@ -105,5 +105,28 @@ inline int NumVersion(int major, int minor) { return major * 256 + minor; }
 
 #define FILEEXT_GTLB        "gtl"   // File extension for tile library files
 
+/* This is an RAII helper for setting the current file format
+    version, and then changing it to a different version when
+    the need for the current version is done.  Defaults to
+    different version being the version in use before creating
+    this object, but that version can be overridden to set a
+    different version.  */
+template<typename T>
+class SetLoadingVersionGuard
+{
+public:
+    SetLoadingVersionGuard(int ctorVer, int dtorVer = T::GetLoadingVersion()) :
+        m_dtorVer(dtorVer)
+    {
+        T::SetLoadingVersion(ctorVer);
+    }
+    ~SetLoadingVersionGuard()
+    {
+        T::SetLoadingVersion(m_dtorVer);
+    }
+private:
+    const int m_dtorVer;
+};
+
 #endif
 


### PR DESCRIPTION
Otherwise, CGbxProjView::DoBoardClone() will fail if no other
.gbx was loaded previously.

Fix #44 