### PR TITLE
Have CDib::DIBToBitmap return std::unique_ptr<>

### DIFF
--- a/GM/ClipBrd.cpp
+++ b/GM/ClipBrd.cpp
@@ -70,7 +70,7 @@ CBitmap* GetClipboardBitmap(CWnd* pWnd, CPalette *pPal /* = NULL */)
         pWnd->EndWaitCursor();
         return NULL;
     }
-    CBitmap* pBMap = dib.DIBToBitmap(pPal);
+    CBitmap* pBMap = dib.DIBToBitmap(pPal).release();
     pWnd->EndWaitCursor();
     return pBMap;
 }

--- a/GM/GmDoc.cpp
+++ b/GM/GmDoc.cpp
@@ -516,18 +516,17 @@ TileID CGamDoc::CreateTileFromDib(CDib* pDib, size_t nTSet)
     int yTile = pDib->Height();
     TileID tid = m_pTMgr->CreateTile(nTSet, CSize(xTile, yTile),
         CSize(xTile/2, yTile/2), RGB(255, 255, 255));
-    CBitmap* pBMap = pDib->DIBToBitmap(GetAppPalette());
+    std::unique_ptr<CBitmap> pBMap = pDib->DIBToBitmap(GetAppPalette());
     CBitmap bmHalf;
-    CloneScaledBitmap(&bmHalf, pBMap, CSize(xTile/2, yTile/2),
+    CloneScaledBitmap(&bmHalf, pBMap.get(), CSize(xTile/2, yTile/2),
         COLORONCOLOR);
 
     CTile tile;
     m_pTMgr->GetTile(tid, &tile, fullScale);
-    tile.Update(pBMap);
+    tile.Update(pBMap.get());
     m_pTMgr->GetTile(tid, &tile, halfScale);
     tile.Update(&bmHalf);
 
-    delete pBMap;
     return tid;
 }
 

--- a/GM/VwEdtbrd.cpp
+++ b/GM/VwEdtbrd.cpp
@@ -1666,13 +1666,11 @@ void CBrdEditView::OnEditPasteBitmapFromFile()
         AfxMessageBox(IDP_ERR_LOADBITMAP, MB_ICONEXCLAMATION);
         return;
     }
-    CBitmap* pBMap = dib.DIBToBitmap(GetAppPalette());
+    std::unique_ptr<CBitmap> pBMap = dib.DIBToBitmap(GetAppPalette());
     ASSERT(pBMap != NULL);
 
     CBitmapImage* pDObj = new CBitmapImage;
     pDObj->SetBitmap(0, 0, (HBITMAP)pBMap->Detach(), fullScale);
-
-    delete pBMap;
 
     GetSelectList()->PurgeList(TRUE);           // Clear current select list
     AddDrawObject(pDObj);

--- a/GM/VwTilesl.cpp
+++ b/GM/VwTilesl.cpp
@@ -367,17 +367,16 @@ void CTileSelView::DoTileRotation(int nAngle)
     ASSERT(pDib != NULL);
     if (pDib == NULL)
         return;             // MEMORY ERROR
-    CBitmap* pbmFull = pDib->DIBToBitmap(GetAppPalette());
+    std::unique_ptr<CBitmap> pbmFull = pDib->DIBToBitmap(GetAppPalette());
     delete pDib;
 
     pDib = Rotate16BitDib(&dibHalf, nAngle, RGB(255, 255, 255));
     ASSERT(pDib != NULL);
     if (pDib == NULL)
     {
-        delete pbmFull;
         return;             // MEMORY ERROR
     }
-    CBitmap* pbmHalf = pDib->DIBToBitmap(GetAppPalette());
+    std::unique_ptr<CBitmap> pbmHalf = pDib->DIBToBitmap(GetAppPalette());
     delete pDib;
 
     if (pbmFull != NULL && pbmHalf != NULL)
@@ -393,8 +392,6 @@ void CTileSelView::DoTileRotation(int nAngle)
         m_pEditView->SetCurrentBitmap(m_tid, &m_bmFull);
         Invalidate();
     }
-    if (pbmFull != NULL) delete pbmFull;
-    if (pbmHalf != NULL) delete pbmHalf;
 }
 
 /////////////////////////////////////////////////////////////////////////////

--- a/GP/DlgRot.cpp
+++ b/GP/DlgRot.cpp
@@ -120,7 +120,7 @@ void CRotateDialog::OnRotApply()
 
         if (pRDib != NULL)
         {
-            m_bmapTbl[i] = pRDib->DIBToBitmap(GetAppPalette());
+            m_bmapTbl[i] = pRDib->DIBToBitmap(GetAppPalette()).release();
             delete pRDib;
         }
     }

--- a/GP/MapFace.cpp
+++ b/GP/MapFace.cpp
@@ -66,7 +66,7 @@ TileID CTileFacingMap::CreateFacingTileID(ElementState state, TileID baseTileID)
     CDib* pRDib = Rotate16BitDib(&dibSrc, nAngleDegCW, m_pTMgr->GetTransparentColor());
     if (pRDib == NULL)
         AfxThrowMemoryException();
-    CBitmap* pBMapFull = pRDib->DIBToBitmap(GetAppPalette());
+    std::unique_ptr<CBitmap> pBMapFull = pRDib->DIBToBitmap(GetAppPalette());
     ASSERT(pBMapFull != NULL);
     BITMAP bmapInfo;
     pBMapFull->GetObject(sizeof(BITMAP), &bmapInfo);
@@ -83,7 +83,7 @@ TileID CTileFacingMap::CreateFacingTileID(ElementState state, TileID baseTileID)
     pRDib = Rotate16BitDib(&dibSrc, nAngleDegCW, m_pTMgr->GetTransparentColor());
     if (pRDib == NULL)
         AfxThrowMemoryException();
-    CBitmap* pBMapHalf = pRDib->DIBToBitmap(GetAppPalette());
+    std::unique_ptr<CBitmap> pBMapHalf = pRDib->DIBToBitmap(GetAppPalette());
 
     ASSERT(pBMapHalf != NULL);
     pBMapHalf->GetObject(sizeof(BITMAP), &bmapInfo);
@@ -97,10 +97,7 @@ TileID CTileFacingMap::CreateFacingTileID(ElementState state, TileID baseTileID)
 
     // Create the tile in our special tile set...
     TileID tidNew = m_pTMgr->CreateTile(m_nTileSet, sizeFull, sizeHalf, crSmall);
-    m_pTMgr->UpdateTile(tidNew, pBMapFull, pBMapHalf, crSmall);
-
-    delete pBMapFull;
-    delete pBMapHalf;
+    m_pTMgr->UpdateTile(tidNew, pBMapFull.get(), pBMapHalf.get(), crSmall);
 
     // Finally, add the piece facing mapping...
     SetAt(state, tidNew);

--- a/GShr/CDib.cpp
+++ b/GShr/CDib.cpp
@@ -155,7 +155,7 @@ BOOL CDib::BitmapToDIB(CBitmap* pBM, CPalette* pPal, int nBPP/* = 16*/)
     return m_hDib != NULL;
 }
 
-CBitmap* CDib::DIBToBitmap(CPalette *pPal, BOOL bDibSect /* = TRUE */)
+std::unique_ptr<CBitmap> CDib::DIBToBitmap(CPalette *pPal, BOOL bDibSect /* = TRUE */)
 {
     if (bDibSect)
     {
@@ -178,7 +178,7 @@ CBitmap* CDib::DIBToBitmap(CPalette *pPal, BOOL bDibSect /* = TRUE */)
 
         memDC.SelectPalette(prvPal, FALSE);
 
-        CBitmap* pBMap = new CBitmap;
+        std::unique_ptr<CBitmap> pBMap(new CBitmap);
         pBMap->Attach((HGDIOBJ)hDibSect);
         return pBMap;
 
@@ -190,7 +190,7 @@ CBitmap* CDib::DIBToBitmap(CPalette *pPal, BOOL bDibSect /* = TRUE */)
         ASSERT(hBMap != NULL);
         if (hBMap != NULL)
         {
-            CBitmap* pBMap = new CBitmap;
+            std::unique_ptr<CBitmap> pBMap(new CBitmap);
             pBMap->Attach((HGDIOBJ)hBMap);
             return pBMap;
         }

--- a/GShr/CDib.h
+++ b/GShr/CDib.h
@@ -43,7 +43,7 @@ public:
     BOOL WriteDIBtoPNGFile(LPCSTR pszName);
     BOOL CloneDIB(CDib *pDib);
     BOOL BitmapToDIB(CBitmap* pBM, CPalette* pPal = NULL, int nBPP = 16);
-    CBitmap* DIBToBitmap(CPalette *pPal, BOOL bDibSect = TRUE);
+    std::unique_ptr<CBitmap> DIBToBitmap(CPalette *pPal, BOOL bDibSect = TRUE);
     BOOL AppendDIB(CDib *pDib);
     BOOL RemoveDIBSlice(int y, int ht);
     void AddColorsToPaletteEntryTable(LPPALETTEENTRY pLP, int nSize,

--- a/GShr/DrawObj.cpp
+++ b/GShr/DrawObj.cpp
@@ -845,10 +845,9 @@ void CBitmapImage::Serialize(CArchive& ar)
         ar >> dib;
         if (dib.m_hDib != NULL)
         {
-            CBitmap* pBMap = dib.DIBToBitmap(GetAppPalette());
+            std::unique_ptr<CBitmap> pBMap = dib.DIBToBitmap(GetAppPalette());
             ASSERT(pBMap != NULL);
             m_bitmap.Attach(pBMap->Detach());
-            delete pBMap;
         }
     }
 }

--- a/GShr/TileMgr.cpp
+++ b/GShr/TileMgr.cpp
@@ -380,8 +380,8 @@ void CTileManager::CreateTilesFromTileImageArchive(CArchive& ar,
     }
     for (DWORD i = 0; i < nTileCount; i++)
     {
-        CBitmap*    pBMapFull;
-        CBitmap*    pBMapHalf;
+        std::unique_ptr<CBitmap> pBMapFull;
+        std::unique_ptr<CBitmap> pBMapHalf;
         COLORREF    crSmall;
         BITMAP      bmInfoFull;
         BITMAP      bmInfoHalf;
@@ -407,12 +407,9 @@ void CTileManager::CreateTilesFromTileImageArchive(CArchive& ar,
             crSmall, nPos);
         if (nPos != Invalid_v<size_t>)
             nPos++;             // Position to next insertion point
-        UpdateTile(tid, pBMapFull, pBMapHalf, crSmall);
+        UpdateTile(tid, pBMapFull.get(), pBMapHalf.get(), crSmall);
         if (pTidTbl)
             pTidTbl->push_back(tid);
-
-        delete pBMapFull;
-        delete pBMapHalf;
     }
 #endif
 }

--- a/GShr/TileSht.cpp
+++ b/GShr/TileSht.cpp
@@ -112,7 +112,7 @@ void CTileSheet::Serialize(CArchive& ar)
             ar >> dib;
             if (dib.m_lpDib != NULL)
             {
-                m_pBMap.reset(dib.DIBToBitmap(GetAppPalette()));
+                m_pBMap = dib.DIBToBitmap(GetAppPalette());
                 BITMAP bmInfo;
                 m_pBMap->GetObject(sizeof(bmInfo), &bmInfo);
                 TRACE3("-- Loaded Tile Sheet for cx=%d, cy=%d tiles. Tile sheet height = %d\n",


### PR DESCRIPTION
instead of bare pointer to fix CBitmapImage::CopyAttributes()
memory leak.  Note that this commit is changing code everywhere
except where the original code is wrong, but is in line with the
long term goal of modernizing the code base.

Fix #46