### PR TITLE
Propconst+notnull+ptrlist

### DIFF
--- a/GM/ClipBrd.cpp
+++ b/GM/ClipBrd.cpp
@@ -39,7 +39,7 @@ BOOL IsClipboardBitmap()
     return IsClipboardFormatAvailable(CF_DIB);
 }
 
-void SetClipboardBitmap(CWnd* pWnd, const CBitmap& pBMap, CPalette *pPal /* = NULL */)
+void SetClipboardBitmap(CWnd* pWnd, const CBitmap& pBMap, const CPalette *pPal /* = NULL */)
 {
     if (pWnd->OpenClipboard())
     {
@@ -55,7 +55,7 @@ void SetClipboardBitmap(CWnd* pWnd, const CBitmap& pBMap, CPalette *pPal /* = NU
     }
 }
 
-OwnerOrNullPtr<CBitmap> GetClipboardBitmap(CWnd* pWnd, CPalette *pPal /* = NULL */)
+OwnerOrNullPtr<CBitmap> GetClipboardBitmap(CWnd* pWnd, const CPalette *pPal /* = NULL */)
 {
     if (!pWnd->OpenClipboard())
         return NULL;

--- a/GM/ClipBrd.cpp
+++ b/GM/ClipBrd.cpp
@@ -55,7 +55,7 @@ void SetClipboardBitmap(CWnd* pWnd, const CBitmap& pBMap, CPalette *pPal /* = NU
     }
 }
 
-CBitmap* GetClipboardBitmap(CWnd* pWnd, CPalette *pPal /* = NULL */)
+OwnerOrNullPtr<CBitmap> GetClipboardBitmap(CWnd* pWnd, CPalette *pPal /* = NULL */)
 {
     if (!pWnd->OpenClipboard())
         return NULL;
@@ -70,7 +70,7 @@ CBitmap* GetClipboardBitmap(CWnd* pWnd, CPalette *pPal /* = NULL */)
         pWnd->EndWaitCursor();
         return NULL;
     }
-    CBitmap* pBMap = dib.DIBToBitmap(pPal).release();
+    OwnerPtr<CBitmap> pBMap = dib.DIBToBitmap(pPal);
     pWnd->EndWaitCursor();
     return pBMap;
 }

--- a/GM/ClipBrd.cpp
+++ b/GM/ClipBrd.cpp
@@ -39,7 +39,7 @@ BOOL IsClipboardBitmap()
     return IsClipboardFormatAvailable(CF_DIB);
 }
 
-void SetClipboardBitmap(CWnd* pWnd, CBitmap *pBMap, CPalette *pPal /* = NULL */)
+void SetClipboardBitmap(CWnd* pWnd, const CBitmap& pBMap, CPalette *pPal /* = NULL */)
 {
     if (pWnd->OpenClipboard())
     {
@@ -47,7 +47,7 @@ void SetClipboardBitmap(CWnd* pWnd, CBitmap *pBMap, CPalette *pPal /* = NULL */)
         EmptyClipboard();
 
         CDib dib;
-        dib.BitmapToDIB(pBMap, pPal);
+        dib.BitmapToDIB(&pBMap, pPal);
         SetClipboardData(CF_DIB, CopyHandle((HANDLE)dib.m_hDib));
 
         CloseClipboard();

--- a/GM/ClipBrd.h
+++ b/GM/ClipBrd.h
@@ -27,7 +27,7 @@
 
 BOOL IsClipboardBitmap();
 void SetClipboardBitmap(CWnd* pWnd, const CBitmap& pBMap, CPalette *pPal = NULL);
-CBitmap* GetClipboardBitmap(CWnd* pWnd, CPalette *pPal = NULL);
+OwnerOrNullPtr<CBitmap> GetClipboardBitmap(CWnd* pWnd, CPalette *pPal = NULL);
 
 #endif
 

--- a/GM/ClipBrd.h
+++ b/GM/ClipBrd.h
@@ -26,7 +26,7 @@
 #define _CLIPBRD_H
 
 BOOL IsClipboardBitmap();
-void SetClipboardBitmap(CWnd* pWnd, CBitmap *pBMap, CPalette *pPal = NULL);
+void SetClipboardBitmap(CWnd* pWnd, const CBitmap& pBMap, CPalette *pPal = NULL);
 CBitmap* GetClipboardBitmap(CWnd* pWnd, CPalette *pPal = NULL);
 
 #endif

--- a/GM/ClipBrd.h
+++ b/GM/ClipBrd.h
@@ -26,8 +26,8 @@
 #define _CLIPBRD_H
 
 BOOL IsClipboardBitmap();
-void SetClipboardBitmap(CWnd* pWnd, const CBitmap& pBMap, CPalette *pPal = NULL);
-OwnerOrNullPtr<CBitmap> GetClipboardBitmap(CWnd* pWnd, CPalette *pPal = NULL);
+void SetClipboardBitmap(CWnd* pWnd, const CBitmap& pBMap, const CPalette *pPal = NULL);
+OwnerOrNullPtr<CBitmap> GetClipboardBitmap(CWnd* pWnd, const CPalette *pPal = NULL);
 
 #endif
 

--- a/GM/GmDoc.cpp
+++ b/GM/GmDoc.cpp
@@ -516,7 +516,7 @@ TileID CGamDoc::CreateTileFromDib(CDib* pDib, size_t nTSet)
     int yTile = pDib->Height();
     TileID tid = m_pTMgr->CreateTile(nTSet, CSize(xTile, yTile),
         CSize(xTile/2, yTile/2), RGB(255, 255, 255));
-    std::unique_ptr<CBitmap> pBMap = pDib->DIBToBitmap(GetAppPalette());
+    OwnerPtr<CBitmap> pBMap = pDib->DIBToBitmap(GetAppPalette());
     CBitmap bmHalf;
     CloneScaledBitmap(&bmHalf, pBMap.get(), CSize(xTile/2, yTile/2),
         COLORONCOLOR);

--- a/GM/LBoxTile.cpp
+++ b/GM/LBoxTile.cpp
@@ -115,13 +115,13 @@ void CTileListBox::OnItemDraw(CDC* pDC, size_t nIndex, UINT nAction, UINT nState
             pDC->SelectObject(prvFont);
         }
 
-        tile.BitBlt(pDC, x, y);
+        tile.BitBlt(*pDC, x, y);
 
         if (m_bDrawAllScales)
         {
             x += tile.GetWidth() + 2 * tileBorder;
             y += tile.GetHeight() / 4;
-            tileHalf.BitBlt(pDC, x, y);
+            tileHalf.BitBlt(*pDC, x, y);
             x += tileHalf.GetWidth() + 2 * tileBorder;
             y = rctItem.CenterPoint().y - 4;
             CBrush brSmall(tileSmall.GetSmallColor());

--- a/GM/SelObjs.cpp
+++ b/GM/SelObjs.cpp
@@ -645,7 +645,7 @@ void CSelList::CopyToClipboard()
     CBitmapImage* pDObj = (CBitmapImage*)pSel->m_pObj;
     ASSERT(pDObj != NULL);
     ASSERT(pDObj->GetType() == CDrawObj::drawBitmap);
-    SetClipboardBitmap(m_pView, &pDObj->m_bitmap);
+    SetClipboardBitmap(m_pView, pDObj->m_bitmap);
 }
 
 void CSelList::Open()

--- a/GM/SelObjs.cpp
+++ b/GM/SelObjs.cpp
@@ -54,7 +54,7 @@ CBrush* NEAR CSelection::c_pPrvBrush = NULL;
 
 /////////////////////////////////////////////////////////////////////
 
-void CSelection::DrawTracker(CDC* pDC, TrackMode eMode)
+void CSelection::DrawTracker(CDC& pDC, TrackMode eMode) const
 {
     if (eMode == trkSelected)
         DrawHandles(pDC);
@@ -62,17 +62,17 @@ void CSelection::DrawTracker(CDC* pDC, TrackMode eMode)
         DrawTrackingImage(pDC, eMode);
 }
 
-void CSelection::DrawHandles(CDC* pDC)
+void CSelection::DrawHandles(CDC& pDC) const
 {
     int n = GetHandleCount();
     for (int i = 0; i < n; i++)
     {
         CRect rect = GetHandleRect(i);
-        pDC->PatBlt(rect.left, rect.top, rect.Width(), rect.Height(), DSTINVERT);
+        pDC.PatBlt(rect.left, rect.top, rect.Width(), rect.Height(), DSTINVERT);
     }
 }
 
-int CSelection::HitTestHandles(CPoint point)
+int CSelection::HitTestHandles(CPoint point) const
 {
     int n = GetHandleCount();
     for (int i = 0; i < n; i++)
@@ -94,7 +94,7 @@ void CSelection::InvalidateHandles()
 }
 
 // Returns handle rectangle in logical coords.
-CRect CSelection::GetHandleRect(int nHandleID)
+CRect CSelection::GetHandleRect(int nHandleID) const
 {
     // Get the center of the handle in logical coords
     CPoint point = GetHandleLoc(nHandleID);
@@ -120,31 +120,31 @@ void CSelection::Invalidate()
 //=---------------------------------------------------=//
 // Static methods...
 
-void CSelection::SetupTrackingDraw(CDC* pDC)
+void CSelection::SetupTrackingDraw(CDC& pDC)
 {
-    c_nPrvROP2 = pDC->SetROP2(R2_XORPEN);
-    c_pPrvPen = pDC->SelectObject(&c_penDot);
-    c_pPrvBrush = (CBrush*)pDC->SelectStockObject(NULL_BRUSH);
+    c_nPrvROP2 = pDC.SetROP2(R2_XORPEN);
+    c_pPrvPen = pDC.SelectObject(&c_penDot);
+    c_pPrvBrush = static_cast<CBrush*>(pDC.SelectStockObject(NULL_BRUSH));
 }
 
-void CSelection::CleanUpTrackingDraw(CDC* pDC)
+void CSelection::CleanUpTrackingDraw(CDC& pDC)
 {
-    pDC->SetROP2(c_nPrvROP2);
-    pDC->SelectObject(c_pPrvPen);
-    pDC->SelectObject(c_pPrvBrush);
+    pDC.SetROP2(c_nPrvROP2);
+    pDC.SelectObject(c_pPrvPen);
+    pDC.SelectObject(c_pPrvBrush);
 }
 
 /////////////////////////////////////////////////////////////////////
 // Rectangle Selection Processing
 
-void CSelRect::DrawTrackingImage(CDC* pDC, TrackMode eMode)
+void CSelRect::DrawTrackingImage(CDC& pDC, TrackMode eMode) const
 {
     SetupTrackingDraw(pDC);
-    pDC->Rectangle(m_rect);
+    pDC.Rectangle(m_rect);
     CleanUpTrackingDraw(pDC);
 }
 
-HCURSOR CSelRect::GetHandleCursor(int nHandleID)
+HCURSOR CSelRect::GetHandleCursor(int nHandleID) const
 {
     LPCSTR id;
     switch (nHandleID)
@@ -163,7 +163,7 @@ HCURSOR CSelRect::GetHandleCursor(int nHandleID)
 }
 
 // Returns handle location in logical coords.
-CPoint CSelRect::GetHandleLoc(int nHandleID)
+CPoint CSelRect::GetHandleLoc(int nHandleID) const
 {
     int x, y;
 
@@ -247,25 +247,25 @@ void CSelRect::UpdateObject(BOOL bInvalidate,
 /////////////////////////////////////////////////////////////////////
 // Ellipse Selection Processing
 
-void CSelEllipse::DrawTrackingImage(CDC* pDC, TrackMode eMode)
+void CSelEllipse::DrawTrackingImage(CDC& pDC, TrackMode eMode) const
 {
     SetupTrackingDraw(pDC);
-    pDC->Ellipse(m_rect);
+    pDC.Ellipse(m_rect);
     CleanUpTrackingDraw(pDC);
 }
 
 /////////////////////////////////////////////////////////////////////
 // Line Selection Processing
 
-void CSelLine::DrawTrackingImage(CDC* pDC, TrackMode eMode)
+void CSelLine::DrawTrackingImage(CDC& pDC, TrackMode eMode) const
 {
     SetupTrackingDraw(pDC);
-    pDC->MoveTo(m_rect.left, m_rect.top);
-    pDC->LineTo(m_rect.right, m_rect.bottom);
+    pDC.MoveTo(m_rect.left, m_rect.top);
+    pDC.LineTo(m_rect.right, m_rect.bottom);
     CleanUpTrackingDraw(pDC);
 }
 
-HCURSOR CSelLine::GetHandleCursor(int nHandleID)
+HCURSOR CSelLine::GetHandleCursor(int nHandleID) const
 {
     LPCSTR id;
     switch (nHandleID)
@@ -281,7 +281,7 @@ HCURSOR CSelLine::GetHandleCursor(int nHandleID)
 }
 
 // Returns handle location in logical coords.
-CPoint CSelLine::GetHandleLoc(int nHandleID)
+CPoint CSelLine::GetHandleLoc(int nHandleID) const
 {
     int x, y;
 
@@ -317,7 +317,7 @@ void CSelLine::MoveHandle(int nHandle, CPoint point)
     }
 }
 
-CRect CSelLine::GetRect()
+CRect CSelLine::GetRect() const
 {
     CRect rct = m_rect;
     rct.NormalizeRect();
@@ -371,21 +371,21 @@ CSelPoly::CSelPoly(CBrdEditView& pView, CPolyObj& pObj) :
     m_nPnts = pObj.m_nPnts;
 }
 
-void CSelPoly::DrawTrackingImage(CDC* pDC, TrackMode eMode)
+void CSelPoly::DrawTrackingImage(CDC& pDC, TrackMode eMode) const
 {
     ASSERT(m_pPnts);
     SetupTrackingDraw(pDC);
-    pDC->Polyline(m_pPnts, m_nPnts);
+    pDC.Polyline(m_pPnts, m_nPnts);
     CleanUpTrackingDraw(pDC);
 }
 
-HCURSOR CSelPoly::GetHandleCursor(int nHandleID)
+HCURSOR CSelPoly::GetHandleCursor(int nHandleID) const
 {
     return AfxGetApp()->LoadStandardCursor(IDC_CROSS);
 }
 
 // Returns handle location in logical coords.
-CPoint CSelPoly::GetHandleLoc(int nHandleID)
+CPoint CSelPoly::GetHandleLoc(int nHandleID) const
 {
     ASSERT(m_pPnts);
     return CPoint(m_pPnts[nHandleID]);
@@ -407,7 +407,7 @@ void CSelPoly::Offset(CPoint ptDelta)
     }
 }
 
-CRect CSelPoly::GetRect()
+CRect CSelPoly::GetRect() const
 {
     CRect rct;
     rct.SetRectEmpty();
@@ -463,15 +463,15 @@ void CSelPoly::UpdateObject(BOOL bInvalidate,
 /////////////////////////////////////////////////////////////////////
 // Generic Object Selection Processing
 
-void CSelGeneric::DrawTrackingImage(CDC* pDC, TrackMode eMode)
+void CSelGeneric::DrawTrackingImage(CDC& pDC, TrackMode eMode) const
 {
     SetupTrackingDraw(pDC);
-    pDC->Rectangle(m_rect);
+    pDC.Rectangle(m_rect);
     CleanUpTrackingDraw(pDC);
 }
 
 // Returns handle location in logical coords.
-CPoint CSelGeneric::GetHandleLoc(int nHandleID)
+CPoint CSelGeneric::GetHandleLoc(int nHandleID) const
 {
     int x, y;
 
@@ -526,7 +526,7 @@ int CSelList::HitTestHandles(CPoint point)
     return GetCount() == 1 ? GetHead()->HitTestHandles(point) : hitNothing;
 }
 
-void CSelList::MoveHandle(UINT m_nHandle, CPoint point)
+void CSelList::MoveHandle(int m_nHandle, CPoint point)
 {
     // No support for multiselect handles.
     if (GetCount() == 1)
@@ -534,9 +534,9 @@ void CSelList::MoveHandle(UINT m_nHandle, CPoint point)
     CalcEnclosingRect();
 }
 
-CSelection* CSelList::AddObject(CDrawObj* pObj, BOOL bInvalidate)
+CSelection* CSelList::AddObject(CDrawObj& pObj, BOOL bInvalidate)
 {
-    CSelection* pSel = pObj->CreateSelectProxy(*m_pView);
+    CSelection* pSel = pObj.CreateSelectProxy(*m_pView);
     ASSERT(pSel != NULL);
     AddHead(pSel);
     CalcEnclosingRect();
@@ -545,7 +545,7 @@ CSelection* CSelList::AddObject(CDrawObj* pObj, BOOL bInvalidate)
     return pSel;
 }
 
-void CSelList::RemoveObject(CDrawObj* pObj, BOOL bInvalidate)
+void CSelList::RemoveObject(const CDrawObj& pObj, BOOL bInvalidate)
 {
     POSITION pos1, pos2;
     pos1 = GetHeadPosition();
@@ -553,7 +553,7 @@ void CSelList::RemoveObject(CDrawObj* pObj, BOOL bInvalidate)
     {
         pos2 = pos1;
         CSelection* pSel = (CSelection*)GetNext(pos1);
-        if (pSel->m_pObj == pObj)
+        if (pSel->m_pObj == &pObj)
         {
             if (bInvalidate)
                 pSel->InvalidateHandles();  // So view updates
@@ -566,13 +566,13 @@ void CSelList::RemoveObject(CDrawObj* pObj, BOOL bInvalidate)
     ASSERT(FALSE);                      //// Object wasn't in list ////
 }
 
-BOOL CSelList::IsObjectSelected(CDrawObj* pObj) const
+BOOL CSelList::IsObjectSelected(const CDrawObj& pObj) const
 {
     POSITION pos = GetHeadPosition();
     while (pos != NULL)
     {
         CSelection* pSel = (CSelection*)GetNext(pos);
-        if (pSel->m_pObj == pObj)
+        if (pSel->m_pObj == &pObj)
             return TRUE;
     }
     return FALSE;
@@ -602,9 +602,9 @@ BOOL CSelList::IsDObjFlagSetInSomeSelectedObjects(DWORD dwFlag) const
     return FALSE;
 }
 
-static void SetDObjFlags(CDrawObj* pObj, DWORD dwFlags)
+static void SetDObjFlags(CDrawObj& pObj, DWORD dwFlags)
 {
-    pObj->SetDObjFlags(dwFlags);
+    pObj.SetDObjFlags(dwFlags);
 }
 
 void CSelList::SetDObjFlagInAllSelectedObjects(DWORD dwFlag)
@@ -612,9 +612,9 @@ void CSelList::SetDObjFlagInAllSelectedObjects(DWORD dwFlag)
     ForAllSelections(SetDObjFlags, dwFlag);
 }
 
-static void ClearDObjFlags(CDrawObj* pObj, DWORD dwFlags)
+static void ClearDObjFlags(CDrawObj& pObj, DWORD dwFlags)
 {
-    pObj->ClearDObjFlags(dwFlags);
+    pObj.ClearDObjFlags(dwFlags);
 }
 
 void CSelList::ClearDObjFlagInAllSelectedObjects(DWORD dwFlag)
@@ -661,12 +661,12 @@ void CSelList::Open()
 }
 
 // Assumes RECTs are normalized!!
-void CbUnionRect(RECT* pRctDst, RECT* pRctSrc1, RECT* pRctSrc2)
+void CbUnionRect(RECT& pRctDst, const RECT& pRctSrc1, const RECT& pRctSrc2)
 {
-    pRctDst->left = CB::min(pRctSrc1->left, pRctSrc2->left);
-    pRctDst->top = CB::min(pRctSrc1->top, pRctSrc2->top);
-    pRctDst->right = CB::max(pRctSrc1->right, pRctSrc2->right);
-    pRctDst->bottom = CB::max(pRctSrc1->bottom, pRctSrc2->bottom);
+    pRctDst.left = CB::min(pRctSrc1.left, pRctSrc2.left);
+    pRctDst.top = CB::min(pRctSrc1.top, pRctSrc2.top);
+    pRctDst.right = CB::max(pRctSrc1.right, pRctSrc2.right);
+    pRctDst.bottom = CB::max(pRctSrc1.bottom, pRctSrc2.bottom);
 }
 
 void CSelList::CalcEnclosingRect()
@@ -679,7 +679,7 @@ void CSelList::CalcEnclosingRect()
         if (m_rctEncl.IsRectNull())
             m_rctEncl = pSel->GetRect();
         else
-            CbUnionRect(&m_rctEncl, &m_rctEncl, &pSel->GetRect());
+            CbUnionRect(m_rctEncl, m_rctEncl, pSel->GetRect());
     }
 }
 
@@ -697,13 +697,13 @@ void CSelList::Offset(CPoint ptDelta)
 // Called by view OnDraw(). This entry makes it possible
 // to turn off handles during a drag operation.
 
-void CSelList::OnDraw(CDC *pDC)
+void CSelList::OnDraw(CDC& pDC)
 {
     if (m_eTrkMode == trkSelected)
         DrawTracker(pDC);
 }
 
-void CSelList::DrawTracker(CDC *pDC, TrackMode eTrkMode)
+void CSelList::DrawTracker(CDC& pDC, TrackMode eTrkMode)
 {
     if (eTrkMode != trkCurrent)
         m_eTrkMode = eTrkMode;
@@ -768,7 +768,7 @@ void CSelList::UpdateObjects(BOOL bInvalidate,
     }
 }
 
-void CSelList::ForAllSelections(void (*pFunc)(CDrawObj* pObj, DWORD dwUser),
+void CSelList::ForAllSelections(void (*pFunc)(CDrawObj& pObj, DWORD dwUser),
     DWORD dwUserVal)
 {
     POSITION pos = GetHeadPosition();
@@ -776,7 +776,7 @@ void CSelList::ForAllSelections(void (*pFunc)(CDrawObj* pObj, DWORD dwUser),
     {
         CSelection* pSel = (CSelection*)GetNext(pos);
         ASSERT(pSel != NULL);
-        pFunc(pSel->m_pObj.get(), dwUserVal);
+        pFunc(*pSel->m_pObj, dwUserVal);
     }
 }
 

--- a/GM/SelObjs.h
+++ b/GM/SelObjs.h
@@ -59,14 +59,14 @@ class CSelection
 {
 // Constructors
 public:
-    CSelection(CBrdEditView* pView, CDrawObj* pObj)
-        : m_pView (pView), m_pObj (pObj), m_rect (pObj->GetRect())     //DFM19991221
+    CSelection(CBrdEditView& pView, CDrawObj& pObj)
+        : m_pView (&pView), m_pObj (&pObj), m_rect (pObj.GetRect())     //DFM19991221
     {}                                                                 //DFM19991221
     virtual ~CSelection() {}
 
 // Attributes
 public:
-    CDrawObj* m_pObj;           // Associated object that is selected
+    RefPtr<CDrawObj> m_pObj;           // Associated object that is selected
     CRect     m_rect;           // Enclosing rect for selected object
 
     virtual HCURSOR GetHandleCursor(int nHandle)
@@ -98,7 +98,7 @@ protected:
 
 // Implementation
 protected:
-    CBrdEditView*   m_pView;            // Selection's view
+    RefPtr<CBrdEditView> m_pView;            // Selection's view
     // -- Class level support methods -- //
     static void SetupTrackingDraw(CDC* pDC);
     static void CleanUpTrackingDraw(CDC* pDC);
@@ -116,8 +116,8 @@ class CSelRect : public CSelection
 {
 // Constructors
 public:
-    CSelRect(CBrdEditView* pView, CRectObj* pObj) : CSelection(pView, pObj)
-        { m_rect = pObj->GetRect(); }
+    CSelRect(CBrdEditView& pView, CRectObj& pObj) : CSelection(pView, pObj)
+        { m_rect = pObj.GetRect(); }
 
 // Overrides
 public:
@@ -139,7 +139,7 @@ class CSelEllipse : public CSelRect
 {
 // Constructors
 public:
-    CSelEllipse(CBrdEditView* pView, CRectObj* pObj) : CSelRect(pView, pObj) {}
+    CSelEllipse(CBrdEditView& pView, CRectObj& pObj) : CSelRect(pView, pObj) {}
 
 // Overrides
 protected:
@@ -153,8 +153,8 @@ class CSelLine : public CSelection
 {
 // Constructors
 public:
-    CSelLine(CBrdEditView* pView, CLine* pObj) : CSelection(pView, pObj)
-        { pObj->GetLine(m_rect.left, m_rect.top, m_rect.right, m_rect.bottom); }
+    CSelLine(CBrdEditView& pView, CLine& pObj) : CSelection(pView, pObj)
+        { pObj.GetLine(m_rect.left, m_rect.top, m_rect.right, m_rect.bottom); }
 
 // Attributes
 public:
@@ -180,7 +180,7 @@ class CSelPoly : public CSelection
 {
 // Constructors
 public:
-    CSelPoly(CBrdEditView* pView, CPolyObj* pObj);
+    CSelPoly(CBrdEditView& pView, CPolyObj& pObj);
     virtual ~CSelPoly() { if (m_pPnts) delete m_pPnts; }
 
 // Attributes
@@ -200,7 +200,7 @@ protected:
     virtual void DrawTrackingImage(CDC* pDC, TrackMode eMode);
     virtual CPoint GetHandleLoc(int nHandleID);
     virtual int GetHandleCount()
-        { return ((CPolyObj*)m_pObj)->m_nPnts; }
+        { return static_cast<const CPolyObj&>(*m_pObj).m_nPnts; }
     virtual void UpdateObject(BOOL bInvalidate = TRUE,
         BOOL bUpdateObjectExtent = TRUE);
 };
@@ -214,8 +214,8 @@ class CSelGeneric : public CSelection
 {
 // Constructors
 public:
-    CSelGeneric(CBrdEditView* pView, CDrawObj* pObj) : CSelection(pView, pObj)
-        { m_rect = pObj->GetRect(); }
+    CSelGeneric(CBrdEditView& pView, CDrawObj& pObj) : CSelection(pView, pObj)
+        { m_rect = pObj.GetRect(); }
 
 // Overrides
 public:
@@ -237,8 +237,11 @@ class CSelList : public CPtrList
 {
 // Constructors
 public:
-    CSelList(CBrdEditView* pView) { m_pView = pView; }
-    CSelList() { m_pView = NULL; m_eTrkMode = trkSelected; }
+    CSelList(CBrdEditView& pView) :
+        m_pView(&pView),
+        m_eTrkMode(trkSelected)
+    {
+    }
     ~CSelList() { PurgeList(FALSE); }
 
 // Attributes
@@ -255,7 +258,6 @@ public:
     void CopyToClipboard();
     void Open();
     // -------- //
-    void SetView(CBrdEditView* pView) { m_pView = pView; }
     void SetTrackingMode(TrackMode eTrkMode) { m_eTrkMode = eTrkMode; }
     TrackMode GetTrackingMode() const { return m_eTrkMode; }
     CRect GetEnclosingRect() const { return m_rctEncl; }
@@ -291,7 +293,7 @@ public:
 
 // Implementation
 protected:
-    CBrdEditView* m_pView;          // Selection's view
+    RefPtr<CBrdEditView> m_pView;          // Selection's view
     TrackMode     m_eTrkMode;       // Current list tracking mode.
     CRect         m_rctEncl;        // Enclosing rect.
     // -------- //

--- a/GM/SelObjs.h
+++ b/GM/SelObjs.h
@@ -232,8 +232,18 @@ protected:
 
 /////////////////////////////////////////////////////////////////////
 
-class CSelList : public CPtrList
+class CSelList : private std::list<OwnerPtr<CSelection>>
 {
+    using BASE = std::list<OwnerPtr<CSelection>>;
+public:
+    using BASE::iterator;
+    using BASE::begin;
+    using BASE::empty;
+    using BASE::end;
+    using BASE::front;
+    using BASE::pop_front;
+    using BASE::size;
+
 // Constructors
 public:
     CSelList(CBrdEditView& pView) :
@@ -241,13 +251,15 @@ public:
         m_eTrkMode(trkSelected)
     {
     }
-    ~CSelList() { PurgeList(FALSE); }
+    CSelList(const CSelList&) = delete;
+    CSelList& operator=(const CSelList&) = delete;
+    ~CSelList() = default;
 
 // Attributes
 public:
-    BOOL IsMultipleSelects() const { return GetCount() > 1; }
-    BOOL IsSingleSelect() const { return GetCount() == 1; }
-    BOOL IsAnySelects() const { return GetCount() > 0; }
+    BOOL IsMultipleSelects() const { return size() > size_t(1); }
+    BOOL IsSingleSelect() const { return size() == size_t(1); }
+    BOOL IsAnySelects() const { return !empty(); }
     BOOL IsObjectSelected(const CDrawObj& pObj) const;
     BOOL IsCopyToClipboardPossible() const;
 
@@ -263,15 +275,14 @@ public:
 
 // Operations
 public:
-    CSelection* GetHead() { return (CSelection*)CPtrList::GetHead(); }
-    CSelection* AddObject(CDrawObj& pObj, BOOL bInvalidate = FALSE);
+    CSelection& AddObject(CDrawObj& pObj, BOOL bInvalidate = FALSE);
     void RemoveObject(const CDrawObj& pObj, BOOL bInvalidate = FALSE);
     // -------- //
     void InvalidateListHandles(BOOL bUpdate = FALSE);
     void InvalidateList(BOOL bUpdate = FALSE);
     void PurgeList(BOOL bInvalidate = TRUE);
     // -------- //
-    int HitTestHandles(CPoint point);
+    int HitTestHandles(CPoint point) const;
     // -------- //
     void Offset(CPoint ptDelta);
     void MoveHandle(int m_nHandle, CPoint point);

--- a/GM/SelObjs.h
+++ b/GM/SelObjs.h
@@ -69,18 +69,18 @@ public:
     RefPtr<CDrawObj> m_pObj;           // Associated object that is selected
     CRect     m_rect;           // Enclosing rect for selected object
 
-    virtual HCURSOR GetHandleCursor(int nHandle) /* override */
+    virtual HCURSOR GetHandleCursor(int nHandle) const /* override */
         { return AfxGetApp()->LoadStandardCursor(IDC_ARROW); }
-    virtual CRect GetRect() /* override */ { return m_rect; }
+    virtual CRect GetRect() const /* override */ { return m_rect; }
 
 // Operations
 public:
-    virtual int  HitTestHandles(CPoint point) /* override */;
+    virtual int HitTestHandles(CPoint point) const /* override */;
     // ------- //
     virtual void MoveHandle(int m_nHandle, CPoint point) /* override */ {}
     virtual void Offset(CPoint ptDelta) /* override */ { m_rect += ptDelta; }
     // ------- //
-    virtual void DrawTracker(CDC *pDC, TrackMode eMode) /* override */;
+    virtual void DrawTracker(CDC& pDC, TrackMode eMode) const /* override */;
     virtual void InvalidateHandles() /* override */;
     virtual void Invalidate() /* override */;
     virtual void UpdateObject(BOOL bInvalidate = TRUE,
@@ -90,18 +90,18 @@ public:
 
 // Miscellaneous Implementer's Overrides
 protected:
-    virtual CRect GetHandleRect(int nHandleID) /* override */;
-    virtual CPoint GetHandleLoc(int nHandleID) /* override */ = 0;
-    virtual int GetHandleCount() /* override */ = 0;
-    virtual void DrawHandles(CDC* pDC) /* override */;
-    virtual void DrawTrackingImage(CDC* pDC, TrackMode eMode) /* override */ = 0;
+    virtual CRect GetHandleRect(int nHandleID) const /* override */;
+    virtual CPoint GetHandleLoc(int nHandleID) const /* override */ = 0;
+    virtual int GetHandleCount() const /* override */ = 0;
+    virtual void DrawHandles(CDC& pDC) const /* override */;
+    virtual void DrawTrackingImage(CDC& pDC, TrackMode eMode) const /* override */ = 0;
 
 // Implementation
 protected:
     RefPtr<CBrdEditView> m_pView;            // Selection's view
     // -- Class level support methods -- //
-    static void SetupTrackingDraw(CDC* pDC);
-    static void CleanUpTrackingDraw(CDC* pDC);
+    static void SetupTrackingDraw(CDC& pDC);
+    static void CleanUpTrackingDraw(CDC& pDC);
     // -- Class variables -- //
     static CPen     NEAR c_penDot;
     static int      NEAR c_nPrvROP2;
@@ -121,13 +121,13 @@ public:
 
 // Overrides
 public:
-    virtual HCURSOR GetHandleCursor(int nHandleID) override;
+    virtual HCURSOR GetHandleCursor(int nHandleID) const override;
     virtual void MoveHandle(int m_nHandle, CPoint point) override;
 
 protected:
-    virtual void DrawTrackingImage(CDC* pDC, TrackMode eMode) override;
-    virtual CPoint GetHandleLoc(int nHandleID) override;
-    virtual int GetHandleCount() override { return 8; }
+    virtual void DrawTrackingImage(CDC& pDC, TrackMode eMode) const override;
+    virtual CPoint GetHandleLoc(int nHandleID) const override;
+    virtual int GetHandleCount() const override { return 8; }
     virtual void UpdateObject(BOOL bInvalidate = TRUE,
         BOOL bUpdateObjectExtent = TRUE) override;
 };
@@ -143,7 +143,7 @@ public:
 
 // Overrides
 protected:
-    virtual void DrawTrackingImage(CDC* pDC, TrackMode eMode) override;
+    virtual void DrawTrackingImage(CDC& pDC, TrackMode eMode) const override;
 };
 
 /////////////////////////////////////////////////////////////////////
@@ -158,17 +158,17 @@ public:
 
 // Attributes
 public:
-    virtual CRect GetRect() override;
+    virtual CRect GetRect() const override;
 
 // Overrides
 public:
-    virtual HCURSOR GetHandleCursor(int nHandleID) override;
+    virtual HCURSOR GetHandleCursor(int nHandleID) const override;
     virtual void MoveHandle(int m_nHandle, CPoint point) override;
 
 protected:
-    virtual void DrawTrackingImage(CDC* pDC, TrackMode eMode) override;
-    virtual CPoint GetHandleLoc(int nHandleID) override;
-    virtual int GetHandleCount() override { return 2; }
+    virtual void DrawTrackingImage(CDC& pDC, TrackMode eMode) const override;
+    virtual CPoint GetHandleLoc(int nHandleID) const override;
+    virtual int GetHandleCount() const override { return 2; }
     virtual void UpdateObject(BOOL bInvalidate = TRUE,
         BOOL bUpdateObjectExtent = TRUE) override;
 };
@@ -185,22 +185,22 @@ public:
 
 // Attributes
 public:
-    virtual CRect GetRect() override;
+    virtual CRect GetRect() const override;
     // -------- //
     POINT*   m_pPnts;
     int      m_nPnts;
 
 // Overrides
 public:
-    virtual HCURSOR GetHandleCursor(int nHandleID) override;
+    virtual HCURSOR GetHandleCursor(int nHandleID) const override;
     virtual void MoveHandle(int m_nHandle, CPoint point) override;
     virtual void Offset(CPoint ptDelta) override;
 
 protected:
-    virtual void DrawTrackingImage(CDC* pDC, TrackMode eMode) override;
-    virtual CPoint GetHandleLoc(int nHandleID) override;
-    virtual int GetHandleCount() override
-        { return static_cast<CPolyObj&>(*m_pObj).m_nPnts; }
+    virtual void DrawTrackingImage(CDC& pDC, TrackMode eMode) const override;
+    virtual CPoint GetHandleLoc(int nHandleID) const override;
+    virtual int GetHandleCount() const override
+        { return static_cast<const CPolyObj&>(*m_pObj).m_nPnts; }
     virtual void UpdateObject(BOOL bInvalidate = TRUE,
         BOOL bUpdateObjectExtent = TRUE) override;
 };
@@ -219,14 +219,14 @@ public:
 
 // Overrides
 public:
-    virtual HCURSOR GetHandleCursor(int nHandleID) override
+    virtual HCURSOR GetHandleCursor(int nHandleID) const override
         { return AfxGetApp()->LoadStandardCursor(IDC_ARROW); }
     virtual void MoveHandle(int m_nHandle, CPoint point) override {}
 
 protected:
-    virtual void DrawTrackingImage(CDC* pDC, TrackMode eMode) override;
-    virtual CPoint GetHandleLoc(int nHandleID) override;
-    virtual int GetHandleCount() override { return 4; }
+    virtual void DrawTrackingImage(CDC& pDC, TrackMode eMode) const override;
+    virtual CPoint GetHandleLoc(int nHandleID) const override;
+    virtual int GetHandleCount() const override { return 4; }
     virtual void UpdateObject(BOOL bInvalidate = TRUE,
         BOOL bUpdateObjectExtent = TRUE) override;
 };
@@ -249,7 +249,7 @@ public:
     BOOL IsMultipleSelects() const { return GetCount() > 1; }
     BOOL IsSingleSelect() const { return GetCount() == 1; }
     BOOL IsAnySelects() const { return GetCount() > 0; }
-    BOOL IsObjectSelected(CDrawObj* pObj) const;
+    BOOL IsObjectSelected(const CDrawObj& pObj) const;
     BOOL IsCopyToClipboardPossible() const;
 
     BOOL IsDObjFlagSetInAllSelectedObjects(DWORD dwFlag) const;
@@ -265,29 +265,29 @@ public:
 // Operations
 public:
     CSelection* GetHead() { return (CSelection*)CPtrList::GetHead(); }
-    CSelection* AddObject(CDrawObj* pObj, BOOL bInvalidate = FALSE);
-    void RemoveObject(CDrawObj* pObj, BOOL bInvalidate = FALSE);
+    CSelection* AddObject(CDrawObj& pObj, BOOL bInvalidate = FALSE);
+    void RemoveObject(const CDrawObj& pObj, BOOL bInvalidate = FALSE);
     // -------- //
     void InvalidateListHandles(BOOL bUpdate = FALSE);
     void InvalidateList(BOOL bUpdate = FALSE);
     void PurgeList(BOOL bInvalidate = TRUE);
     // -------- //
-    int  HitTestHandles(CPoint point);
+    int HitTestHandles(CPoint point);
     // -------- //
     void Offset(CPoint ptDelta);
-    void MoveHandle(UINT m_nHandle, CPoint point);
+    void MoveHandle(int m_nHandle, CPoint point);
 
     void SetDObjFlagInAllSelectedObjects(DWORD dwFlag);
     void ClearDObjFlagInAllSelectedObjects(DWORD dwFlag);
 
     // -------- //
-    void OnDraw(CDC *pDC);  // Called by view OnDraw()
-    void DrawTracker(CDC *pDC, TrackMode eTrkMode = trkCurrent);
+    void OnDraw(CDC& pDC);  // Called by view OnDraw()
+    void DrawTracker(CDC& pDC, TrackMode eTrkMode = trkCurrent);
     // -------- //
     void UpdateObjects(BOOL bInvalidate = TRUE,
         BOOL bUpdateObjectExtent = TRUE );
     // -------- //
-    void ForAllSelections(void (*pFunc)(CDrawObj* pObj, DWORD dwUser),
+    void ForAllSelections(void (*pFunc)(CDrawObj& pObj, DWORD dwUser),
         DWORD dwUserVal);
     // -------- //
 

--- a/GM/SelObjs.h
+++ b/GM/SelObjs.h
@@ -69,32 +69,32 @@ public:
     RefPtr<CDrawObj> m_pObj;           // Associated object that is selected
     CRect     m_rect;           // Enclosing rect for selected object
 
-    virtual HCURSOR GetHandleCursor(int nHandle)
+    virtual HCURSOR GetHandleCursor(int nHandle) /* override */
         { return AfxGetApp()->LoadStandardCursor(IDC_ARROW); }
-    virtual CRect GetRect() { return m_rect; }
+    virtual CRect GetRect() /* override */ { return m_rect; }
 
 // Operations
 public:
-    virtual int  HitTestHandles(CPoint point);
+    virtual int  HitTestHandles(CPoint point) /* override */;
     // ------- //
-    virtual void MoveHandle(int m_nHandle, CPoint point) {}
-    virtual void Offset(CPoint ptDelta) { m_rect += ptDelta; }
+    virtual void MoveHandle(int m_nHandle, CPoint point) /* override */ {}
+    virtual void Offset(CPoint ptDelta) /* override */ { m_rect += ptDelta; }
     // ------- //
-    virtual void DrawTracker(CDC *pDC, TrackMode eMode);
-    virtual void InvalidateHandles();
-    virtual void Invalidate();
+    virtual void DrawTracker(CDC *pDC, TrackMode eMode) /* override */;
+    virtual void InvalidateHandles() /* override */;
+    virtual void Invalidate() /* override */;
     virtual void UpdateObject(BOOL bInvalidate = TRUE,
-        BOOL bUpdateObjectExtent = TRUE) {}
-    virtual void Open()  {}
-    virtual void Close() {}
+        BOOL bUpdateObjectExtent = TRUE) /* override */ {}
+    virtual void Open()  /* override */ {}
+    virtual void Close() /* override */ {}
 
 // Miscellaneous Implementer's Overrides
 protected:
-    virtual CRect GetHandleRect(int nHandleID);
-    virtual CPoint GetHandleLoc(int nHandleID) = 0;
-    virtual int GetHandleCount() = 0;
-    virtual void DrawHandles(CDC* pDC);
-    virtual void DrawTrackingImage(CDC* pDC, TrackMode eMode) = 0;
+    virtual CRect GetHandleRect(int nHandleID) /* override */;
+    virtual CPoint GetHandleLoc(int nHandleID) /* override */ = 0;
+    virtual int GetHandleCount() /* override */ = 0;
+    virtual void DrawHandles(CDC* pDC) /* override */;
+    virtual void DrawTrackingImage(CDC* pDC, TrackMode eMode) /* override */ = 0;
 
 // Implementation
 protected:
@@ -121,15 +121,15 @@ public:
 
 // Overrides
 public:
-    virtual HCURSOR GetHandleCursor(int nHandleID);
-    virtual void MoveHandle(int m_nHandle, CPoint point);
+    virtual HCURSOR GetHandleCursor(int nHandleID) override;
+    virtual void MoveHandle(int m_nHandle, CPoint point) override;
 
 protected:
-    virtual void DrawTrackingImage(CDC* pDC, TrackMode eMode);
-    virtual CPoint GetHandleLoc(int nHandleID);
-    virtual int GetHandleCount() { return 8; }
+    virtual void DrawTrackingImage(CDC* pDC, TrackMode eMode) override;
+    virtual CPoint GetHandleLoc(int nHandleID) override;
+    virtual int GetHandleCount() override { return 8; }
     virtual void UpdateObject(BOOL bInvalidate = TRUE,
-        BOOL bUpdateObjectExtent = TRUE);
+        BOOL bUpdateObjectExtent = TRUE) override;
 };
 
 /////////////////////////////////////////////////////////////////////
@@ -143,7 +143,7 @@ public:
 
 // Overrides
 protected:
-    virtual void DrawTrackingImage(CDC* pDC, TrackMode eMode);
+    virtual void DrawTrackingImage(CDC* pDC, TrackMode eMode) override;
 };
 
 /////////////////////////////////////////////////////////////////////
@@ -158,19 +158,19 @@ public:
 
 // Attributes
 public:
-    virtual CRect GetRect();
+    virtual CRect GetRect() override;
 
 // Overrides
 public:
-    virtual HCURSOR GetHandleCursor(int nHandleID);
-    virtual void MoveHandle(int m_nHandle, CPoint point);
+    virtual HCURSOR GetHandleCursor(int nHandleID) override;
+    virtual void MoveHandle(int m_nHandle, CPoint point) override;
 
 protected:
-    virtual void DrawTrackingImage(CDC* pDC, TrackMode eMode);
-    virtual CPoint GetHandleLoc(int nHandleID);
-    virtual int GetHandleCount() { return 2; }
+    virtual void DrawTrackingImage(CDC* pDC, TrackMode eMode) override;
+    virtual CPoint GetHandleLoc(int nHandleID) override;
+    virtual int GetHandleCount() override { return 2; }
     virtual void UpdateObject(BOOL bInvalidate = TRUE,
-        BOOL bUpdateObjectExtent = TRUE);
+        BOOL bUpdateObjectExtent = TRUE) override;
 };
 
 /////////////////////////////////////////////////////////////////////
@@ -185,24 +185,24 @@ public:
 
 // Attributes
 public:
-    virtual CRect GetRect();
+    virtual CRect GetRect() override;
     // -------- //
     POINT*   m_pPnts;
     int      m_nPnts;
 
 // Overrides
 public:
-    virtual HCURSOR GetHandleCursor(int nHandleID);
-    virtual void MoveHandle(int m_nHandle, CPoint point);
-    virtual void Offset(CPoint ptDelta);
+    virtual HCURSOR GetHandleCursor(int nHandleID) override;
+    virtual void MoveHandle(int m_nHandle, CPoint point) override;
+    virtual void Offset(CPoint ptDelta) override;
 
 protected:
-    virtual void DrawTrackingImage(CDC* pDC, TrackMode eMode);
-    virtual CPoint GetHandleLoc(int nHandleID);
-    virtual int GetHandleCount()
-        { return static_cast<const CPolyObj&>(*m_pObj).m_nPnts; }
+    virtual void DrawTrackingImage(CDC* pDC, TrackMode eMode) override;
+    virtual CPoint GetHandleLoc(int nHandleID) override;
+    virtual int GetHandleCount() override
+        { return static_cast<CPolyObj&>(*m_pObj).m_nPnts; }
     virtual void UpdateObject(BOOL bInvalidate = TRUE,
-        BOOL bUpdateObjectExtent = TRUE);
+        BOOL bUpdateObjectExtent = TRUE) override;
 };
 
 /////////////////////////////////////////////////////////////////////
@@ -219,16 +219,16 @@ public:
 
 // Overrides
 public:
-    virtual HCURSOR GetHandleCursor(int nHandleID)
+    virtual HCURSOR GetHandleCursor(int nHandleID) override
         { return AfxGetApp()->LoadStandardCursor(IDC_ARROW); }
-    virtual void MoveHandle(int m_nHandle, CPoint point) {}
+    virtual void MoveHandle(int m_nHandle, CPoint point) override {}
 
 protected:
-    virtual void DrawTrackingImage(CDC* pDC, TrackMode eMode);
-    virtual CPoint GetHandleLoc(int nHandleID);
-    virtual int GetHandleCount() { return 4; }
+    virtual void DrawTrackingImage(CDC* pDC, TrackMode eMode) override;
+    virtual CPoint GetHandleLoc(int nHandleID) override;
+    virtual int GetHandleCount() override { return 4; }
     virtual void UpdateObject(BOOL bInvalidate = TRUE,
-        BOOL bUpdateObjectExtent = TRUE);
+        BOOL bUpdateObjectExtent = TRUE) override;
 };
 
 /////////////////////////////////////////////////////////////////////

--- a/GM/SelObjs.h
+++ b/GM/SelObjs.h
@@ -181,14 +181,13 @@ class CSelPoly : public CSelection
 // Constructors
 public:
     CSelPoly(CBrdEditView& pView, CPolyObj& pObj);
-    virtual ~CSelPoly() { if (m_pPnts) delete m_pPnts; }
+    virtual ~CSelPoly() = default;
 
 // Attributes
 public:
     virtual CRect GetRect() const override;
     // -------- //
-    POINT*   m_pPnts;
-    int      m_nPnts;
+    std::vector<POINT> m_Pnts;
 
 // Overrides
 public:
@@ -200,7 +199,7 @@ protected:
     virtual void DrawTrackingImage(CDC& pDC, TrackMode eMode) const override;
     virtual CPoint GetHandleLoc(int nHandleID) const override;
     virtual int GetHandleCount() const override
-        { return static_cast<const CPolyObj&>(*m_pObj).m_nPnts; }
+        { return value_preserving_cast<int>(static_cast<const CPolyObj&>(*m_pObj).m_Pnts.size()); }
     virtual void UpdateObject(BOOL bInvalidate = TRUE,
         BOOL bUpdateObjectExtent = TRUE) override;
 };

--- a/GM/ToolImag.h
+++ b/GM/ToolImag.h
@@ -41,11 +41,11 @@ public:
 
 // Attributes
 public:
-    IToolType m_eToolType;
+    const IToolType m_eToolType;
 
 // Operations
 public:
-    static CImageTool* GetTool(IToolType eType);
+    static CImageTool& GetTool(IToolType eType);
     // ----------- //
     virtual void OnLButtonDown(CBitEditView* pView, UINT nFlags, CPoint point);
     virtual void OnLButtonUp(CBitEditView* pView, UINT nFlags, CPoint point);
@@ -54,9 +54,10 @@ public:
         { return FALSE; }
 
 // Implementation
-public:
+private:
     // -- Class variables -- //
-    static CPtrList c_toolLib;
+    static std::vector<CImageTool*> c_toolLib;
+protected:
     // Drag related vars....
     static CPoint c_ptDown;         // Document coords.
     static CPoint c_ptLast;

--- a/GM/ToolObjs.cpp
+++ b/GM/ToolObjs.cpp
@@ -138,14 +138,14 @@ void CSelectTool::OnLButtonDown(CBrdEditView* pView, UINT nFlags,
     }
     // Object is under mouse. See if also selected. If not,
     // add to list.
-    if (!pSLst->IsObjectSelected(pObj))
+    if (!pSLst->IsObjectSelected(*pObj))
     {
         if ((nFlags & MK_SHIFT) == 0)       // Shift click adds to list
             pSLst->PurgeList(TRUE);         // Clear current select list
         if ((nFlags & MK_CONTROL) != 0)     // Control click drills down
             pView->SelectAllUnderPoint(point);
         else
-            pSLst->AddObject(pObj, TRUE);
+            pSLst->AddObject(*pObj, TRUE);
         CTool::OnLButtonDown(pView, nFlags, point);
         StartDragTimer(pView);
         if (pSLst->IsMultipleSelects())
@@ -165,7 +165,7 @@ void CSelectTool::OnLButtonDown(CBrdEditView* pView, UINT nFlags,
     // wont start until it expires.
     if ((nFlags & MK_SHIFT) != 0)
     {
-        pSLst->RemoveObject(pObj, TRUE);
+        pSLst->RemoveObject(*pObj, TRUE);
         return;
     }
     CTool::OnLButtonDown(pView, nFlags, point);
@@ -282,14 +282,14 @@ void CSelectTool::OnMouseMove(CBrdEditView* pView, UINT nFlags, CPoint point)
         if (m_eSelMode == smodeMove && !m_rectMultiBorder.IsRectNull())
             DrawSelectionRect(&dc, &m_rectMultiBorder);
         else
-            pSLst->DrawTracker(&dc, eTrkMode); // Erase previous tracker
+            pSLst->DrawTracker(dc, eTrkMode); // Erase previous tracker
 
         MoveSelections(pSLst, point);
 
         if (m_eSelMode == smodeMove && !m_rectMultiBorder.IsRectNull())
             DrawSelectionRect(&dc, &m_rectMultiBorder);
         else
-            pSLst->DrawTracker(&dc, eTrkMode); // Erase previous tracker
+            pSLst->DrawTracker(dc, eTrkMode); // Erase previous tracker
     }
     c_ptLast = point;               // Save new 'last' position
 }
@@ -363,7 +363,7 @@ void CSelectTool::OnTimer(CBrdEditView* pView, UINT nIDEvent)
         // pick up the work.
         CClientDC dc(pView);
         pView->OnPrepareScaledDC(&dc);
-        pSLst->DrawTracker(&dc, trkSelected);   // Turn off handles
+        pSLst->DrawTracker(dc, trkSelected);   // Turn off handles
 
         // If the snap grid is active. Force the enclosing rect onto
         // the snap grid. Also force the previously saved mouse points
@@ -379,7 +379,7 @@ void CSelectTool::OnTimer(CBrdEditView* pView, UINT nIDEvent)
         CPoint ptDelta = (CPoint)(c_ptLast - c_ptDown);
         pSLst->Offset(ptDelta);
 
-        pSLst->DrawTracker(&dc, trkMoving);
+        pSLst->DrawTracker(dc, trkMoving);
     }
     else
     {
@@ -438,7 +438,7 @@ void CSelectTool::StartSizingOperation(CBrdEditView* pView, UINT nFlags,
     CTool::OnLButtonDown(pView, nFlags, point);
     CClientDC dc(pView);
     pView->OnPrepareScaledDC(&dc);
-    pSLst->DrawTracker(&dc, trkSizing);
+    pSLst->DrawTracker(dc, trkSizing);
 }
 
 void CSelectTool::DrawSelectionRect(CDC* pDC, CRect* pRct)
@@ -512,7 +512,7 @@ BOOL CSelectTool::ProcessAutoScroll(CBrdEditView* pView)
             else if (m_eSelMode == smodeMove && !m_rectMultiBorder.IsRectNull())
                 DrawSelectionRect(&dc, &m_rectMultiBorder);
             else
-                pSLst->DrawTracker(&dc);    // Turn off tracker
+                pSLst->DrawTracker(dc);    // Turn off tracker
 
             pView->OnScroll(nScrollID, 0, TRUE);
             pView->UpdateWindow();          // Redraw image content.
@@ -541,7 +541,7 @@ BOOL CSelectTool::ProcessAutoScroll(CBrdEditView* pView)
                 if (m_eSelMode == smodeMove && !m_rectMultiBorder.IsRectNull())
                     DrawSelectionRect(&dc, &m_rectMultiBorder);
                 else
-                    pSLst->DrawTracker(&dc);    // Turn off tracker
+                    pSLst->DrawTracker(dc);    // Turn off tracker
             }
             return TRUE;
         }
@@ -622,7 +622,7 @@ void CShapeTool::OnLButtonDown(CBrdEditView* pView, UINT nFlags, CPoint point)
     int nDragHandle;
     pView->AdjustPoint(point);
     m_pObj = CreateDrawObj(pView, point, nDragHandle);
-    pSLst->AddObject(m_pObj, TRUE);
+    pSLst->AddObject(*m_pObj, TRUE);
     s_selectTool.StartSizingOperation(pView, nFlags, point, nDragHandle);
 }
 
@@ -775,7 +775,7 @@ void CPolyTool::OnLButtonDown(CBrdEditView* pView, UINT nFlags, CPoint point)
             DrawRubberLine(&dc);            // Turn on last rubber line
 
             // Directly draw the object.
-            m_pObj->Draw(&dc, pView->GetCurrentScale());
+            m_pObj->Draw(dc, pView->GetCurrentScale());
 //      }
     }
 }
@@ -825,7 +825,7 @@ void CPolyTool::OnMouseMove(CBrdEditView* pView, UINT nFlags, CPoint point)
         c_ptDown = point;
         c_ptLast = rawPoint;
         // Directly draw the object.
-        m_pObj->Draw(&dc, pView->GetCurrentScale());
+        m_pObj->Draw(dc, pView->GetCurrentScale());
     }
     else
         c_ptLast = point;

--- a/GM/ToolObjs.cpp
+++ b/GM/ToolObjs.cpp
@@ -47,7 +47,7 @@ const int scrollZone = 8;                   //From INI?
 /////////////////////////////////////////////////////////////////
 // Class variables
 
-CPtrList CTool::c_toolLib;          // Tool library
+std::vector<CTool*> CTool::c_toolLib;          // Tool library
 
 CPoint CTool::c_ptDown;             // Mouse down location
 CPoint CTool::c_ptLast;             // Last mouse location
@@ -69,22 +69,22 @@ static CCellEraserTool  s_eraserCellTool;
 ////////////////////////////////////////////////////////////////////////
 // CTool - Basic tool support (abstract class)
 
-CTool::CTool(ToolType eType)
+CTool::CTool(ToolType eType) :
+    m_eToolType(eType)
 {
-    m_eToolType = eType;
-    c_toolLib.AddTail(this);
+    size_t i = static_cast<size_t>(eType);
+    c_toolLib.resize(std::max(i + size_t(1), c_toolLib.size()));
+    ASSERT(!c_toolLib[i]);
+    c_toolLib[i] = this;
 }
 
-CTool* CTool::GetTool(ToolType eToolType)
+CTool& CTool::GetTool(ToolType eToolType)
 {
-    POSITION pos = c_toolLib.GetHeadPosition();
-    while (pos != NULL)
-    {
-        CTool* pTool = (CTool*)c_toolLib.GetNext(pos);
-        if (pTool->m_eToolType == eToolType)
-            return pTool;
-    }
-    return NULL;
+    size_t i = static_cast<size_t>(eToolType);
+    ASSERT(i < c_toolLib.size());
+    CTool& retval = CheckedDeref(c_toolLib[i]);
+    ASSERT(retval.m_eToolType == eToolType);
+    return retval;
 }
 
 void CTool::OnLButtonDown(CBrdEditView* pView, UINT nFlags, CPoint point)

--- a/GM/ToolObjs.cpp
+++ b/GM/ToolObjs.cpp
@@ -417,11 +417,11 @@ BOOL CSelectTool::OnSetCursor(CBrdEditView* pView, UINT nHitTest)
     {
         // Check if cursor is over a handle. If it is,
         // get handle cursor.
-        CSelection* pSelObj = (CSelection*)pSLst->GetHead();
-        int nHandle = pSelObj->HitTestHandles(point);
+        CSelection& pSelObj = *pSLst->front();
+        int nHandle = pSelObj.HitTestHandles(point);
         if (nHandle >= 0)
         {
-            SetCursor(pSelObj->GetHandleCursor(nHandle));
+            SetCursor(pSelObj.GetHandleCursor(nHandle));
             return TRUE;
         }
     }

--- a/GM/ToolObjs.cpp
+++ b/GM/ToolObjs.cpp
@@ -762,7 +762,7 @@ void CPolyTool::OnLButtonDown(CBrdEditView* pView, UINT nFlags, CPoint point)
             DrawRubberLine(&dc);            // Turn off last rubber line
 
             // Check if back at the original point
-            CPoint pnt(m_pObj->m_pPnts[0]);
+            CPoint pnt(m_pObj->m_Pnts[size_t(0)]);
             if (pnt == point)
             {
                 FinalizePolygon(pView);
@@ -814,7 +814,7 @@ void CPolyTool::OnMouseMove(CBrdEditView* pView, UINT nFlags, CPoint point)
 
         pView->AdjustPoint(point);
         // Check if back at the original point
-        CPoint pnt(m_pObj->m_pPnts[0]);
+        CPoint pnt(m_pObj->m_Pnts[size_t(0)]);
         if (pnt == point)
         {
             FinalizePolygon(pView);
@@ -873,7 +873,7 @@ void CPolyTool::FinalizePolygon(CBrdEditView* pView,
     if (m_pObj == NULL)
         return;         // Nothing to do.
 
-    if (m_pObj->m_nPnts >= 2 && !bForceDestroy)
+    if (m_pObj->m_Pnts.size() >= size_t(2) && !bForceDestroy)
     {
         // Update the "dummy" object to make it the real thing.
         m_pObj->SetForeColor(pView->GetForeColor());

--- a/GM/ToolObjs.h
+++ b/GM/ToolObjs.h
@@ -50,11 +50,11 @@ public:
 
 // Attributes
 public:
-    ToolType m_eToolType;
+    const ToolType m_eToolType;
 
 // Operations
 public:
-    static CTool* GetTool(ToolType eType);
+    static CTool& GetTool(ToolType eType);
     // ----------- //
     virtual void OnLButtonDown(CBrdEditView* pView, UINT nFlags, CPoint point);
     virtual void OnLButtonDblClk(CBrdEditView* pView, UINT nFlags, CPoint point) {}
@@ -65,9 +65,10 @@ public:
         { return FALSE; }
 
 // Implementation
-public:
+private:
     // -- Class variables -- //
-    static CPtrList c_toolLib;
+    static std::vector<CTool*> c_toolLib;
+protected:
     // Drag related vars....
     static CPoint c_ptDown;         // Document coords.
     static CPoint c_ptLast;

--- a/GM/VwBitedt.cpp
+++ b/GM/VwBitedt.cpp
@@ -1276,10 +1276,10 @@ void CBitEditView::OnEditCopy()
     if (m_nCurToolID == ID_ITOOL_SELECT && m_bmPaste.m_hObject != NULL &&
         !m_rctPaste.IsRectEmpty())
     {
-        SetClipboardBitmap(this, &m_bmPaste, GetAppPalette());
+        SetClipboardBitmap(this, m_bmPaste, GetAppPalette());
     }
     else
-        SetClipboardBitmap(this, &m_bmView, GetAppPalette());
+        SetClipboardBitmap(this, m_bmView, GetAppPalette());
 }
 
 void CBitEditView::OnEditPaste()

--- a/GM/VwBitedt.cpp
+++ b/GM/VwBitedt.cpp
@@ -959,40 +959,25 @@ void CBitEditView::OnContextMenu(CWnd* pWnd, CPoint point)
 void CBitEditView::OnLButtonDown(UINT nFlags, CPoint point)
 {
     IToolType eToolType = MapToolType(m_nCurToolID);
-    CImageTool* pTool = CImageTool::GetTool(eToolType);
-    if (pTool != NULL)
-    {
-        ClientToWorkspace(point);
-        pTool->OnLButtonDown(this, nFlags, point);
-    }
-    else
-        CScrollView::OnLButtonDown(nFlags, point);
+    CImageTool& pTool = CImageTool::GetTool(eToolType);
+    ClientToWorkspace(point);
+    pTool.OnLButtonDown(this, nFlags, point);
 }
 
 void CBitEditView::OnMouseMove(UINT nFlags, CPoint point)
 {
     IToolType eToolType = MapToolType(m_nCurToolID);
-    CImageTool* pTool = CImageTool::GetTool(eToolType);
-    if (pTool != NULL)
-    {
-        ClientToWorkspace(point);
-        pTool->OnMouseMove(this, nFlags, point);
-    }
-    else
-        CScrollView::OnMouseMove(nFlags, point);
+    CImageTool& pTool = CImageTool::GetTool(eToolType);
+    ClientToWorkspace(point);
+    pTool.OnMouseMove(this, nFlags, point);
 }
 
 void CBitEditView::OnLButtonUp(UINT nFlags, CPoint point)
 {
     IToolType eToolType = MapToolType(m_nCurToolID);
-    CImageTool* pTool = CImageTool::GetTool(eToolType);
-    if (pTool != NULL)
-    {
-        ClientToWorkspace(point);
-        pTool->OnLButtonUp(this, nFlags, point);
-    }
-    else
-        CScrollView::OnLButtonUp(nFlags, point);
+    CImageTool& pTool = CImageTool::GetTool(eToolType);
+    ClientToWorkspace(point);
+    pTool.OnLButtonUp(this, nFlags, point);
 }
 
 BOOL CBitEditView::OnSetCursor(CWnd* pWnd, UINT nHitTest, UINT message)
@@ -1000,8 +985,8 @@ BOOL CBitEditView::OnSetCursor(CWnd* pWnd, UINT nHitTest, UINT message)
     IToolType eToolType = MapToolType(m_nCurToolID);
     if (pWnd == this && eToolType != itoolUnknown)
     {
-        CImageTool* pTool = CImageTool::GetTool(eToolType);
-        if(pTool != NULL && pTool->OnSetCursor(this, nHitTest))
+        CImageTool& pTool = CImageTool::GetTool(eToolType);
+        if(pTool.OnSetCursor(this, nHitTest))
             return TRUE;
     }
     return CScrollView::OnSetCursor(pWnd, nHitTest, message);

--- a/GM/VwBitedt.cpp
+++ b/GM/VwBitedt.cpp
@@ -1284,8 +1284,7 @@ void CBitEditView::OnEditCopy()
 
 void CBitEditView::OnEditPaste()
 {
-    CBitmap* pBMap = GetClipboardBitmap(this, GetAppPalette());
-    ASSERT(pBMap);
+    OwnerPtr<CBitmap> pBMap = GetClipboardBitmap(this, GetAppPalette());
 
     SetUndoFromView();
 
@@ -1303,7 +1302,6 @@ void CBitEditView::OnEditPaste()
         dlg.m_nPasteAction = nRescale;
         if (dlg.DoModal() != IDOK)
         {
-            delete pBMap;
             return;
         }
         nRescale = dlg.m_nPasteAction;
@@ -1316,16 +1314,14 @@ void CBitEditView::OnEditPaste()
 
     if (nRescale > 0)
     {
-        CloneScaledBitmap(&m_bmPaste, pBMap, m_size, STRETCH_DELETESCANS);
+        CloneScaledBitmap(&m_bmPaste, pBMap.get(), m_size, STRETCH_DELETESCANS);
         m_rctPaste.SetRect(0, 0, m_size.cx, m_size.cy);
     }
     else
     {
-        CloneBitmap(&m_bmPaste, pBMap);
+        CloneBitmap(&m_bmPaste, pBMap.get());
         m_rctPaste.SetRect(0, 0, bmInfo.bmWidth, bmInfo.bmHeight);
     }
-
-    delete pBMap;
 
 
     m_nLastToolID = m_nCurToolID;

--- a/GM/VwEdtbrd.cpp
+++ b/GM/VwEdtbrd.cpp
@@ -402,17 +402,15 @@ void CBrdEditView::SelectAllUnderPoint(CPoint point)
     if (pDwg == NULL)
         return;
 
-    CPtrList selLst;
+    std::vector<CB::not_null<CDrawObj*>> selLst;
     pDwg->DrillDownHitTest(point, selLst, m_nZoom,
         m_pBoard->GetApplyVisible());
 
-    POSITION pos;
-    for (pos = selLst.GetHeadPosition(); pos != NULL; )
+    for (size_t i = size_t(0) ; i < selLst.size() ; ++i)
     {
-        CDrawObj* pObj = (CDrawObj*)selLst.GetNext(pos);
-        ASSERT(pObj != NULL);
-        if (!m_selList.IsObjectSelected(*pObj))
-            m_selList.AddObject(*pObj, TRUE);
+        CDrawObj& pObj = *selLst[i];
+        if (!m_selList.IsObjectSelected(pObj))
+            m_selList.AddObject(pObj, TRUE);
     }
 }
 

--- a/GM/VwEdtbrd.cpp
+++ b/GM/VwEdtbrd.cpp
@@ -1608,15 +1608,16 @@ void CBrdEditView::OnEditPaste()
 {
     CBitmap* pBMap = GetClipboardBitmap(this, GetAppPalette());
 
-    CBitmapImage* pDObj = new CBitmapImage;
-    pDObj->SetBitmap(0, 0, (HBITMAP)pBMap->Detach(), fullScale);
+    {
+        OwnerPtr<CBitmapImage> pDObj = MakeOwner<CBitmapImage>();
+        pDObj->SetBitmap(0, 0, (HBITMAP)pBMap->Detach(), fullScale);
 
-    delete pBMap;
-
-    GetSelectList()->PurgeList(TRUE);           // Clear current select list
-    AddDrawObject(pDObj);
-    GetSelectList()->AddObject(pDObj, TRUE);
-    CRect rct = pDObj->GetEnclosingRect();
+        GetSelectList()->PurgeList(TRUE);           // Clear current select list
+        AddDrawObject(std::move(pDObj));
+    }
+    CDrawObj& pDObj = GetDrawList(FALSE)->Front();
+    GetSelectList()->AddObject(&pDObj, TRUE);
+    CRect rct = pDObj.GetEnclosingRect();
     InvalidateWorkspaceRect(&rct);
 }
 
@@ -1671,13 +1672,16 @@ void CBrdEditView::OnEditPasteBitmapFromFile()
     std::unique_ptr<CBitmap> pBMap = dib.DIBToBitmap(GetAppPalette());
     ASSERT(pBMap != NULL);
 
-    CBitmapImage* pDObj = new CBitmapImage;
-    pDObj->SetBitmap(0, 0, (HBITMAP)pBMap->Detach(), fullScale);
+    {
+        OwnerPtr<CBitmapImage> pDObj = MakeOwner<CBitmapImage>();
+        pDObj->SetBitmap(0, 0, (HBITMAP)pBMap->Detach(), fullScale);
 
-    GetSelectList()->PurgeList(TRUE);           // Clear current select list
-    AddDrawObject(pDObj);
-    GetSelectList()->AddObject(pDObj, TRUE);
-    CRect rct = pDObj->GetEnclosingRect();
+        GetSelectList()->PurgeList(TRUE);           // Clear current select list
+        AddDrawObject(std::move(pDObj));
+    }
+    CDrawObj& pDObj = GetDrawList(FALSE)->Front();
+    GetSelectList()->AddObject(&pDObj, TRUE);
+    CRect rct = pDObj.GetEnclosingRect();
     InvalidateWorkspaceRect(&rct);
 }
 

--- a/GM/VwEdtbrd.cpp
+++ b/GM/VwEdtbrd.cpp
@@ -1606,7 +1606,7 @@ void CBrdEditView::OnUpdateToolSuspendScaleVsibility(CCmdUI* pCmdUI)
 
 void CBrdEditView::OnEditPaste()
 {
-    CBitmap* pBMap = GetClipboardBitmap(this, GetAppPalette());
+    OwnerPtr<CBitmap> pBMap = GetClipboardBitmap(this, GetAppPalette());
 
     {
         OwnerPtr<CBitmapImage> pDObj = MakeOwner<CBitmapImage>();
@@ -1664,13 +1664,16 @@ void CBrdEditView::OnEditPasteBitmapFromFile()
         return;
     }
     CDib dib;
-    if (!dib.ReadDIBFile(file))
+    try
+    {
+        dib.ReadDIBFile(file);
+    }
+    catch (...)
     {
         AfxMessageBox(IDP_ERR_LOADBITMAP, MB_ICONEXCLAMATION);
         return;
     }
-    std::unique_ptr<CBitmap> pBMap = dib.DIBToBitmap(GetAppPalette());
-    ASSERT(pBMap != NULL);
+    OwnerPtr<CBitmap> pBMap = dib.DIBToBitmap(GetAppPalette());
 
     {
         OwnerPtr<CBitmapImage> pDObj = MakeOwner<CBitmapImage>();

--- a/GM/VwEdtbrd.cpp
+++ b/GM/VwEdtbrd.cpp
@@ -142,10 +142,9 @@ END_MESSAGE_MAP()
 /////////////////////////////////////////////////////////////////////////////
 // CBrdEditView construction/destruction
 
-CBrdEditView::CBrdEditView()
+CBrdEditView::CBrdEditView() :
+    m_selList(*this)
 {
-    m_selList.SetView(this);
-
     m_bOffScreen = TRUE;
     m_pBoard = NULL;
     m_pBMgr = NULL;
@@ -430,10 +429,10 @@ void CBrdEditView::DeleteObjsInSelectList(BOOL bInvalidate)
     while (!m_selList.IsEmpty())
     {
         CSelection* pSel = (CSelection*)m_selList.RemoveHead();
-        pDwg->RemoveObject(pSel->m_pObj);
+        pDwg->RemoveObject(pSel->m_pObj.get());
         if (bInvalidate)
             pSel->Invalidate();
-        delete pSel->m_pObj;
+        delete pSel->m_pObj.get();
         delete pSel;
     }
     GetDocument()->SetModifiedFlag();
@@ -455,8 +454,8 @@ void CBrdEditView::MoveObjsInSelectList(BOOL bToFront, BOOL bInvalidate)
     while (pos != NULL)
     {
         CSelection* pSel = (CSelection*)m_selList.GetNext(pos);
-        pDwg->RemoveObject(pSel->m_pObj);
-        m_tmpLst.AddTail(pSel->m_pObj);
+        pDwg->RemoveObject(pSel->m_pObj.get());
+        m_tmpLst.AddTail(pSel->m_pObj.get());
     }
     if (bToFront)
     {

--- a/GM/VwEdtbrd.cpp
+++ b/GM/VwEdtbrd.cpp
@@ -296,7 +296,7 @@ void CBrdEditView::OnPrepareScaledDC(CDC *pDC)
     PrepareScaledDC(pDC);
 }
 
-void CBrdEditView::ClientToWorkspace(CPoint& point)
+void CBrdEditView::ClientToWorkspace(CPoint& point) const
 {
     CPoint dpnt = GetDeviceScrollPosition();
     point += (CSize)dpnt;
@@ -305,7 +305,7 @@ void CBrdEditView::ClientToWorkspace(CPoint& point)
     ScalePoint(point, wsize, vsize);
 }
 
-void CBrdEditView::ClientToWorkspace(CRect& rect)
+void CBrdEditView::ClientToWorkspace(CRect& rect) const
 {
     CPoint dpnt = GetDeviceScrollPosition();
     rect += dpnt;
@@ -314,7 +314,7 @@ void CBrdEditView::ClientToWorkspace(CRect& rect)
     ScaleRect(rect, wsize, vsize);
 }
 
-void CBrdEditView::WorkspaceToClient(CPoint& point)
+void CBrdEditView::WorkspaceToClient(CPoint& point) const
 {
     CPoint dpnt = GetDeviceScrollPosition();
     CSize wsize, vsize;
@@ -323,7 +323,7 @@ void CBrdEditView::WorkspaceToClient(CPoint& point)
     point -= (CSize)dpnt;
 }
 
-void CBrdEditView::WorkspaceToClient(CRect& rect)
+void CBrdEditView::WorkspaceToClient(CRect& rect) const
 {
     CPoint dpnt = GetDeviceScrollPosition();
     CSize wsize, vsize;

--- a/GM/VwEdtbrd.cpp
+++ b/GM/VwEdtbrd.cpp
@@ -623,63 +623,40 @@ void CBrdEditView::OnContextMenu(CWnd* pWnd, CPoint point)
 void CBrdEditView::OnLButtonDown(UINT nFlags, CPoint point)
 {
     ToolType eToolType = MapToolType(m_nCurToolID);
-    CTool* pTool = CTool::GetTool(eToolType);
-    if (pTool != NULL)
-    {
-        ClientToWorkspace(point);
-        pTool->OnLButtonDown(this, nFlags, point);
-    }
-    else
-        CScrollView::OnLButtonDown(nFlags, point);
+    CTool& pTool = CTool::GetTool(eToolType);
+    ClientToWorkspace(point);
+    pTool.OnLButtonDown(this, nFlags, point);
 }
 
 void CBrdEditView::OnMouseMove(UINT nFlags, CPoint point)
 {
     ToolType eToolType = MapToolType(m_nCurToolID);
-    CTool* pTool = CTool::GetTool(eToolType);
-    if (pTool != NULL)
-    {
-        ClientToWorkspace(point);
-        pTool->OnMouseMove(this, nFlags, point);
-    }
-    else
-        CScrollView::OnMouseMove(nFlags, point);
+    CTool& pTool = CTool::GetTool(eToolType);
+    ClientToWorkspace(point);
+    pTool.OnMouseMove(this, nFlags, point);
 }
 
 void CBrdEditView::OnLButtonUp(UINT nFlags, CPoint point)
 {
     ToolType eToolType = MapToolType(m_nCurToolID);
-    CTool* pTool = CTool::GetTool(eToolType);
-    if (pTool != NULL)
-    {
-        ClientToWorkspace(point);
-        pTool->OnLButtonUp(this, nFlags, point);
-    }
-    else
-        CScrollView::OnLButtonUp(nFlags, point);
+    CTool& pTool = CTool::GetTool(eToolType);
+    ClientToWorkspace(point);
+    pTool.OnLButtonUp(this, nFlags, point);
 }
 
 void CBrdEditView::OnLButtonDblClk(UINT nFlags, CPoint point)
 {
     ToolType eToolType = MapToolType(m_nCurToolID);
-    CTool* pTool = CTool::GetTool(eToolType);
-    if (pTool != NULL)
-    {
-        ClientToWorkspace(point);
-        pTool->OnLButtonDblClk(this, nFlags, point);
-    }
-    else
-        CScrollView::OnLButtonDblClk(nFlags, point);
+    CTool& pTool = CTool::GetTool(eToolType);
+    ClientToWorkspace(point);
+    pTool.OnLButtonDblClk(this, nFlags, point);
 }
 
 void CBrdEditView::OnTimer(UINT nIDEvent)
 {
     ToolType eToolType = MapToolType(m_nCurToolID);
-    CTool* pTool = CTool::GetTool(eToolType);
-    if (pTool != NULL)
-        pTool->OnTimer(this, nIDEvent);
-    else
-        CScrollView::OnTimer(nIDEvent);
+    CTool& pTool = CTool::GetTool(eToolType);
+    pTool.OnTimer(this, nIDEvent);
 }
 
 BOOL CBrdEditView::OnSetCursor(CWnd* pWnd, UINT nHitTest, UINT message)
@@ -687,8 +664,8 @@ BOOL CBrdEditView::OnSetCursor(CWnd* pWnd, UINT nHitTest, UINT message)
     ToolType eToolType = MapToolType(m_nCurToolID);
     if (pWnd == this && eToolType != ttypeUnknown)
     {
-        CTool* pTool = CTool::GetTool(eToolType);
-        if(pTool != NULL && pTool->OnSetCursor(this, nHitTest))
+        CTool& pTool = CTool::GetTool(eToolType);
+        if(pTool.OnSetCursor(this, nHitTest))
             return TRUE;
     }
     return CScrollView::OnSetCursor(pWnd, nHitTest, message);
@@ -699,18 +676,19 @@ BOOL CBrdEditView::OnSetCursor(CWnd* pWnd, UINT nHitTest, UINT message)
 void CBrdEditView::OnChar(UINT nChar, UINT nRepCnt, UINT nFlags)
 {
     ToolType eToolType = MapToolType(m_nCurToolID);
-    CPolyTool* pTool = (CPolyTool*)CTool::GetTool(eToolType);
-    if (pTool != NULL && pTool->m_eToolType == ttypePolygon)
+    CTool& pTool = CTool::GetTool(eToolType);
+    if (pTool.m_eToolType == ttypePolygon)
     {
+        CPolyTool& pPolyTool = static_cast<CPolyTool&>(pTool);
         if (nChar == VK_ESCAPE)
         {
-            pTool->RemoveRubberBand(this);
-            pTool->FinalizePolygon(this, TRUE);
+            pPolyTool.RemoveRubberBand(this);
+            pPolyTool.FinalizePolygon(this, TRUE);
         }
         else if (nChar == VK_RETURN)
         {
-            pTool->RemoveRubberBand(this);
-            pTool->FinalizePolygon(this, FALSE);
+            pPolyTool.RemoveRubberBand(this);
+            pPolyTool.FinalizePolygon(this, FALSE);
         }
     }
     CScrollView::OnChar(nChar, nRepCnt, nFlags);
@@ -1334,11 +1312,12 @@ BOOL CBrdEditView::OnToolPalette(UINT id)
             // If we're changing away from the polygon tool
             // we need to act as if the escape key was hit.
             ToolType eToolType = MapToolType(m_nCurToolID);
-            CPolyTool* pTool = (CPolyTool*)CTool::GetTool(eToolType);
-            if (pTool != NULL && pTool->m_eToolType == ttypePolygon)
+            CTool& pTool = CTool::GetTool(eToolType);
+            if (pTool.m_eToolType == ttypePolygon)
             {
-                pTool->RemoveRubberBand(this);
-                pTool->FinalizePolygon(this, TRUE);
+                CPolyTool& pPolyTool = static_cast<CPolyTool&>(pTool);
+                pPolyTool.RemoveRubberBand(this);
+                pPolyTool.FinalizePolygon(this, TRUE);
             }
         }
         m_nLastToolID = m_nCurToolID;

--- a/GM/VwEdtbrd.h
+++ b/GM/VwEdtbrd.h
@@ -85,10 +85,10 @@ public:
 
     CSelList* GetSelectList() { return &m_selList; }
 
-    void ClientToWorkspace(CPoint& point);
-    void ClientToWorkspace(CRect& rect);
-    void WorkspaceToClient(CPoint& point);
-    void WorkspaceToClient(CRect& rect);
+    void ClientToWorkspace(CPoint& point) const;
+    void ClientToWorkspace(CRect& rect) const;
+    void WorkspaceToClient(CPoint& point) const;
+    void WorkspaceToClient(CRect& rect) const;
     void InvalidateWorkspaceRect(const CRect* pRect, BOOL bErase = FALSE);
     CPoint GetWorkspaceDim();
     void OnPrepareScaledDC(CDC *pDC);

--- a/GM/VwEdtbrd.h
+++ b/GM/VwEdtbrd.h
@@ -97,7 +97,7 @@ public:
     void AdjustRect(CRect& rct);
 
     CDrawObj* ObjectHitTest(CPoint point);
-    void AddDrawObject(CDrawObj* pObj);         // Add to active layer
+    void AddDrawObject(CDrawObj::OwnerPtr pObj);         // Add to active layer
     void DeleteDrawObject(CDrawObj* pObj);      // Delete from active layer
     void SelectWithinRect(CRect rctNet, BOOL bInclIntersects = FALSE);
     void SelectAllUnderPoint(CPoint point);

--- a/GM/VwTilesl.cpp
+++ b/GM/VwTilesl.cpp
@@ -363,35 +363,22 @@ void CTileSelView::DoTileRotation(int nAngle)
     if(!dibHalf.BitmapToDIB(&m_bmHalf, GetAppPalette()))
         return;             // MEMORY ERROR
 
-    CDib *pDib = Rotate16BitDib(&dibFull, nAngle, RGB(255, 255, 255));
-    ASSERT(pDib != NULL);
-    if (pDib == NULL)
-        return;             // MEMORY ERROR
-    std::unique_ptr<CBitmap> pbmFull = pDib->DIBToBitmap(GetAppPalette());
-    delete pDib;
+    OwnerPtr<CDib> pDib = Rotate16BitDib(&dibFull, nAngle, RGB(255, 255, 255));
+    OwnerPtr<CBitmap> pbmFull = pDib->DIBToBitmap(GetAppPalette());
 
     pDib = Rotate16BitDib(&dibHalf, nAngle, RGB(255, 255, 255));
-    ASSERT(pDib != NULL);
-    if (pDib == NULL)
-    {
-        return;             // MEMORY ERROR
-    }
-    std::unique_ptr<CBitmap> pbmHalf = pDib->DIBToBitmap(GetAppPalette());
-    delete pDib;
+    OwnerPtr<CBitmap> pbmHalf = pDib->DIBToBitmap(GetAppPalette());
 
-    if (pbmFull != NULL && pbmHalf != NULL)
-    {
-        m_bmFull.DeleteObject();
-        m_bmFull.Attach(pbmFull->Detach());
-        m_bmHalf.DeleteObject();
-        m_bmHalf.Attach(pbmHalf->Detach());
-        // Recompute selection window layout.
-        CalcViewLayout();
-        // Finally hand the full size tile to the bit editor.
-        SelectCurrentBitmap(fullScale);
-        m_pEditView->SetCurrentBitmap(m_tid, &m_bmFull);
-        Invalidate();
-    }
+    m_bmFull.DeleteObject();
+    m_bmFull.Attach(pbmFull->Detach());
+    m_bmHalf.DeleteObject();
+    m_bmHalf.Attach(pbmHalf->Detach());
+    // Recompute selection window layout.
+    CalcViewLayout();
+    // Finally hand the full size tile to the bit editor.
+    SelectCurrentBitmap(fullScale);
+    m_pEditView->SetCurrentBitmap(m_tid, &m_bmFull);
+    Invalidate();
 }
 
 /////////////////////////////////////////////////////////////////////////////

--- a/GP/DlgRot.cpp
+++ b/GP/DlgRot.cpp
@@ -46,15 +46,12 @@ CRotateDialog::CRotateDialog(CWnd* pParent /*=NULL*/)
     m_pDib = NULL;
     m_pRotBMap = NULL;
     m_crTrans = RGB(0, 0, 0);
-    for (int i = 0; i < 12; i++)
-        m_bmapTbl[i] = NULL;
 }
 
 CRotateDialog::~CRotateDialog()
 {
     if (m_pRotBMap) delete m_pRotBMap;
     if (m_pDib) delete m_pDib;
-    DeleteBMaps();
 }
 
 void CRotateDialog::DoDataExchange(CDataExchange* pDX)
@@ -81,8 +78,6 @@ void CRotateDialog::DeleteBMaps()
 {
     for (int i = 0; i < 12; i++)
     {
-        if (m_bmapTbl[i] != NULL)
-            delete m_bmapTbl[i];
         m_bmapTbl[i] = NULL;
     }
 }
@@ -111,18 +106,11 @@ void CRotateDialog::OnRotApply()
     CDib dibSrc;
     dibSrc.BitmapToDIB(m_pBMap, GetAppPalette());
 
-    CDib* pRDib;
-
     static int angTbl[12] = { 0, 30, 60, 90, 120, 150, 180, 210, 240, 270, 300, 330 };
     for (int i = 0; i < 12; i++)
     {
-        pRDib = Rotate16BitDib(&dibSrc, angTbl[i], m_crTrans);
-
-        if (pRDib != NULL)
-        {
-            m_bmapTbl[i] = pRDib->DIBToBitmap(GetAppPalette()).release();
-            delete pRDib;
-        }
+        OwnerPtr<CDib> pRDib = Rotate16BitDib(&dibSrc, angTbl[i], m_crTrans);
+        m_bmapTbl[i] = pRDib->DIBToBitmap(GetAppPalette());
     }
 
     CRect rct;
@@ -147,7 +135,7 @@ void CRotateDialog::OnPaint()
         int x = (i % 4) * 45;
         int y = (i / 4) * 45;
         if (m_bmapTbl[i])
-            BitmapBlt(&dc, rct.TopLeft() + CSize(x, y), m_bmapTbl[i]);
+            BitmapBlt(&dc, rct.TopLeft() + CSize(x, y), m_bmapTbl[i].get());
     }
     ResetPalette(&dc);
 

--- a/GP/DlgRot.h
+++ b/GP/DlgRot.h
@@ -48,7 +48,7 @@ public:
     CDib*       m_pDib;         //??
     CBitmap*    m_pRotBMap;     //??
 
-    CBitmap*    m_bmapTbl[12];  //!!testing
+    OwnerOrNullPtr<CBitmap> m_bmapTbl[12];  //!!testing
 
     void DeleteBMaps();
 

--- a/GP/GamDoc.cpp
+++ b/GP/GamDoc.cpp
@@ -516,7 +516,7 @@ CView* CGamDoc::FindPBoardView(const CPlayBoard& pPBoard)
 
 /////////////////////////////////////////////////////////////////////////////
 
-void CGamDoc::GetDocumentFrameList(std::vector<CFrameWnd*>& tblFrames)
+void CGamDoc::GetDocumentFrameList(std::vector<CB::not_null<CFrameWnd*>>& tblFrames)
 {
     tblFrames.clear();
 
@@ -1608,7 +1608,7 @@ void CGamDoc::OnEditSelectBoards()
     {
         // First close all the views of boards that are going
         // to be removed from the play list.
-        std::vector<CPlayBoard*> tblNotInList;
+        std::vector<CB::not_null<CPlayBoard*>> tblNotInList;
         pPBMgr->FindPBoardsNotInList(dlg.m_tblBrds, tblNotInList);
         for (size_t i = 0; i < tblNotInList.size(); i++)
         {

--- a/GP/GamDoc.cpp
+++ b/GP/GamDoc.cpp
@@ -462,11 +462,11 @@ void CGamDoc::DoInitialUpdate()
 
 void CGamDoc::UpdateAllViews(CView* pSender, LPARAM lHint, CObject* pHint)
 {
-    CGamDocHint* ph = (CGamDocHint*)pHint;
+    CGamDocHint* ph = static_cast<CGamDocHint*>(pHint);
     if (lHint == HINT_TRAYCHANGE)
     {
-        m_palTrayA.UpdatePaletteContents(ph->m_pTray);
-        m_palTrayB.UpdatePaletteContents(ph->m_pTray);
+        m_palTrayA.UpdatePaletteContents(ph->GetArgs<HINT_TRAYCHANGE>().m_pTray);
+        m_palTrayB.UpdatePaletteContents(ph->GetArgs<HINT_TRAYCHANGE>().m_pTray);
     }
     else if (lHint == HINT_GAMESTATEUSED)
     {
@@ -1557,7 +1557,7 @@ void CGamDoc::OnEditCreateTray()
         dlg.m_pYMgr->CreateTraySet(dlg.m_strName);
 
         CGamDocHint hint;
-        hint.m_pTray = NULL;
+        hint.GetArgs<HINT_TRAYCHANGE>().m_pTray = NULL;
         UpdateAllViews(NULL, HINT_TRAYCHANGE, &hint);
         SetModifiedFlag();
     }
@@ -1643,7 +1643,7 @@ void CGamDoc::OnEditImportPieceGroups()
     if (dlg.DoModal() == IDOK)
     {
         CGamDocHint hint;
-        hint.m_pTray = NULL;
+        hint.GetArgs<HINT_TRAYCHANGE>().m_pTray = NULL;
         UpdateAllViews(NULL, HINT_TRAYCHANGE, &hint);
         SetModifiedFlag();
     }
@@ -1669,7 +1669,7 @@ void CGamDoc::OnEditSelectGamePieces()
 
     // Notify all visible trays
     CGamDocHint hint;
-    hint.m_pTray = NULL;
+    hint.GetArgs<HINT_TRAYCHANGE>().m_pTray = NULL;
     UpdateAllViews(NULL, HINT_TRAYCHANGE, &hint);
     SetModifiedFlag();
 }

--- a/GP/GamDoc.h
+++ b/GP/GamDoc.h
@@ -141,7 +141,7 @@ public:
     struct Args<HINT_UPDATEOBJLIST>
     {
         CPlayBoard* m_pPBoard;
-        CPtrList*   m_pPtrList;
+        const std::vector<CB::not_null<CDrawObj*>>* m_pPtrList;
     };
 
     template<>
@@ -398,7 +398,7 @@ public:
         CPoint ptEnd, UINT nLineWd, COLORREF crLine, ObjectID dwObjID = ObjectID());
     void ModifyLineObject(CPlayBoard* pPBrd, CPoint ptBeg, CPoint ptEnd,
         UINT nLineWd, COLORREF crLine, CLine* pObj);
-    void ReorgObjsInDrawList(CPlayBoard *pPBrd, CPtrList* pList, BOOL bToFront);
+    void ReorgObjsInDrawList(CPlayBoard *pPBrd, std::vector<CB::not_null<CDrawObj*>>& pList, BOOL bToFront);
     void DeleteObjectsInTable(const std::vector<CB::not_null<CDrawObj*>>& pList);
     void SetObjectText(GameElement elem, LPCTSTR pszObjText);
     void SetObjectLockdownTable(const std::vector<CB::not_null<CDrawObj*>>& pLst, BOOL bLockState);

--- a/GP/GamDoc.h
+++ b/GP/GamDoc.h
@@ -370,8 +370,21 @@ public:
         int xStagger, int yStagger, CPlayBoard *pPBrd);
     size_t PlacePieceListInTray(const std::vector<PieceID>& pTbl, CTraySet& pYGrp, size_t nPos = Invalid_v<size_t>);
     size_t PlaceObjectListInTray(const CPtrList& pTbl, CTraySet& pYGrp, size_t nPos = Invalid_v<size_t>);
+    size_t PlaceObjectListInTray(std::vector<CB::not_null<CDrawObj*>>& pTbl, CTraySet& pYGrp, size_t nPos = Invalid_v<size_t>)
+    {
+        CPtrList temp;
+        CB::Copy(temp, pTbl);
+        return PlaceObjectListInTray(temp, pYGrp, nPos);
+    }
     void PlaceObjectListOnBoard(CPtrList *pLst, CPoint pntUpLeft,
         CPlayBoard *pPBrd, PlacePos ePos = placeDefault);
+    void PlaceObjectListOnBoard(const std::vector<CB::not_null<CDrawObj*>>& pLst, CPoint pntUpLeft,
+        CPlayBoard* pPBrd, PlacePos ePos = placeDefault)
+    {
+        CPtrList temp;
+        CB::Copy(temp, pLst);
+        PlaceObjectListOnBoard(&temp, pntUpLeft, pPBrd, ePos);
+    }
     void PlaceObjectTableOnBoard(CPoint pnt, const std::vector<CB::not_null<CDrawObj*>>& pTbl,
         int xStagger, int yStagger, CPlayBoard *pPBrd);
     void PlaceObjectTableOnBoard(const std::vector<CB::not_null<CDrawObj*>>& pTbl, CPlayBoard *pPBrd);
@@ -379,13 +392,26 @@ public:
         CSize sizeDelta, PlacePos ePos = placeDefault);
 
     void InvertPlayingPieceOnBoard(CPieceObj *pObj, CPlayBoard *pPBrd);
-    void InvertPlayingPieceListOnBoard(CPtrList *pLst, CPlayBoard *pPBrd);
+    void InvertPlayingPieceListOnBoard(CPtrList* pLst, CPlayBoard* pPBrd);
+    void InvertPlayingPieceListOnBoard(const std::vector<CB::not_null<CDrawObj*>>& pLst, CPlayBoard* pPBrd)
+    {
+        CPtrList temp;
+        CB::Copy(temp, pLst);
+        InvertPlayingPieceListOnBoard(&temp, pPBrd);
+    }
     void InvertPlayingPieceInTray(PieceID pid, BOOL bOkToNotifyTray = TRUE);
 
     void ChangePlayingPieceFacingOnBoard(CPieceObj *pObj, CPlayBoard* pPBrd,
         int nFacingDegCW);
     void ChangePlayingPieceFacingListOnBoard(CPtrList *pLst,
         CPlayBoard* pPBrd, int nFacingDegCW);
+    void ChangePlayingPieceFacingListOnBoard(const std::vector<CB::not_null<CDrawObj*>>& pLst,
+        CPlayBoard* pPBrd, int nFacingDegCW)
+    {
+        CPtrList temp;
+        CB::Copy(temp, pLst);
+        ChangePlayingPieceFacingListOnBoard(&temp, pPBrd, nFacingDegCW);
+    }
     void ChangePlayingPieceFacingInTray(PieceID pid, int nFacingDegCW);
     void ChangeMarkerFacingOnBoard(CMarkObj* pObj, CPlayBoard* pPBrd,
         int nFacingDegCW);
@@ -400,8 +426,20 @@ public:
         UINT nLineWd, COLORREF crLine, CLine* pObj);
     void ReorgObjsInDrawList(CPlayBoard *pPBrd, CPtrList* pList, BOOL bToFront);
     void DeleteObjectsInList(CPtrList *pList);
+    void DeleteObjectsInList(const std::vector<CB::not_null<CDrawObj*>>& pList)
+    {
+        CPtrList temp;
+        CB::Copy(temp, pList);
+        DeleteObjectsInList(&temp);
+    }
     void SetObjectText(GameElement elem, LPCTSTR pszObjText);
-    void SetObjectLockdownList(CPtrList *pLst, BOOL bLockState);
+    void SetObjectLockdownList(CPtrList* pLst, BOOL bLockState);
+    void SetObjectLockdownList(const std::vector<CB::not_null<CDrawObj*>>& pLst, BOOL bLockState)
+    {
+        CPtrList temp;
+        CB::Copy(temp, pLst);
+        SetObjectLockdownList(&temp, bLockState);
+    }
     void SetObjectLockdown(CDrawObj* pDObj, BOOL bLockState);
 
     BOOL RemovePieceFromCurrentLocation(PieceID pid, BOOL bDeleteIfBoard,

--- a/GP/GamDoc.h
+++ b/GP/GamDoc.h
@@ -256,7 +256,7 @@ public:
     void SaveRecordedMoves();
     void SaveHistoryMovesInFile(size_t nHistRec);
     void TransferPlaybackToHistoryTable(BOOL bTruncateAtCurrentMove = FALSE);
-    void AddMovesToGameHistoryTable(CHistRecord* pHist);
+    void AddMovesToGameHistoryTable(OwnerPtr<CHistRecord> pHist);
     BOOL DiscardCurrentRecording(BOOL bPrompt = TRUE);
     void AssignNewMoveGroup();
     void CreateRecordListIfRequired();

--- a/GP/GamDoc.h
+++ b/GP/GamDoc.h
@@ -481,9 +481,9 @@ public:
     CString     m_strCurMsg;    // Current user message under construction
     CStringArray m_astrMsgHist; // Current message history
 
-    int         m_nCurMove;     // Index of current move (-1 is at end)
+    size_t      m_nCurMove;     // Index of current move (Invalid_v<size_t> is at end)
     POSITION    m_posCurMove;   // Shadow of m_nCurMove. (NOSAVE)
-    int         m_nFirstMove;   // Index of first move record (usually 0 or 1)
+    size_t      m_nFirstMove;   // Index of first move record (usually 0 or 1)
     size_t      m_nCurHist;     // History being viewed if state is "hist"
     BOOL        m_bStepToNextHist; // If TRUE, step to next history record
     BOOL        m_bKeepSkipInd; // If TRUE skipped move indications aren't erased
@@ -493,8 +493,8 @@ public:
     // when a move file has been loaded for playback.
     CHistRecord* m_pPlayHist;
 
-    std::unique_ptr<CMoveList> m_pRcdMoves;    // Moves being recorded or move file playback
-    std::unique_ptr<CMoveList> m_pHistMoves;   // Currently loaded history from hist table
+    OwnerOrNullPtr<CMoveList> m_pRcdMoves;    // Moves being recorded or move file playback
+    OwnerOrNullPtr<CMoveList> m_pHistMoves;   // Currently loaded history from hist table
 
     // m_pMoves is a shadow of either m_pRctMoves or m_pHistMoves depending on the
     // gamestate m_eState.  (NOSAVE)
@@ -503,7 +503,7 @@ public:
 
     CGameElementStringMap m_mapStrings; // Mapping of pieces and markers to strings.
 
-    int             m_nMoveIdxAtBookMark;// Move list index at bookmark
+    size_t          m_nMoveIdxAtBookMark;// Move list index at bookmark
     CGameState*     m_pBookMark;// The state of things at the bookmark
 
     CHistoryTable*  m_pHistTbl; // Table containing history of game

--- a/GP/GamDoc.h
+++ b/GP/GamDoc.h
@@ -212,7 +212,7 @@ public:
         LPVOID lpvCreateParam);
     CView* FindPBoardView(const CPlayBoard& pPBoard);
     CView* MakeSurePBoardVisible(CPlayBoard& pPBoard);
-    void GetDocumentFrameList(std::vector<CFrameWnd*>& tblFrames);
+    void GetDocumentFrameList(std::vector<CB::not_null<CFrameWnd*>>& tblFrames);
 
     BOOL IsWindowStateAvailable() { return m_pWinState != NULL; }
     void RestoreWindowState();
@@ -293,9 +293,9 @@ public:
     size_t PlaceObjectListInTray(const CPtrList& pTbl, CTraySet& pYGrp, size_t nPos = Invalid_v<size_t>);
     void PlaceObjectListOnBoard(CPtrList *pLst, CPoint pntUpLeft,
         CPlayBoard *pPBrd, PlacePos ePos = placeDefault);
-    void PlaceObjectTableOnBoard(CPoint pnt, const std::vector<CDrawObj*>& pTbl,
+    void PlaceObjectTableOnBoard(CPoint pnt, const std::vector<CB::not_null<CDrawObj*>>& pTbl,
         int xStagger, int yStagger, CPlayBoard *pPBrd);
-    void PlaceObjectTableOnBoard(const std::vector<CDrawObj*>& pTbl, CPlayBoard *pPBrd);
+    void PlaceObjectTableOnBoard(const std::vector<CB::not_null<CDrawObj*>>& pTbl, CPlayBoard *pPBrd);
     void PlaceObjectOnBoard(CPlayBoard *pPBrd, CDrawObj::OwnerPtr pObj,
         CSize sizeDelta, PlacePos ePos = placeDefault);
 

--- a/GP/GamDoc.h
+++ b/GP/GamDoc.h
@@ -316,11 +316,11 @@ public:
     CString     GetGameElementString(GameElement gelem);
     BOOL        HasGameElementString(GameElement gelem);
     void        SetGameElementString(GameElement gelem, LPCTSTR pszString);
-    void        GetTipTextForObject(CDrawObj* pDObj, CString &strTip, CString* pStrTitle = NULL);
-    GameElement GetGameElementCodeForObject(CDrawObj* pDObj, BOOL bBottomSide = FALSE);
-    GameElement GetVerifiedGameElementCodeForObject(CDrawObj* pDObj, BOOL bBottomSide = FALSE);
+    void        GetTipTextForObject(const CDrawObj& pDObj, CString &strTip, CString* pStrTitle = NULL);
+    GameElement GetGameElementCodeForObject(const CDrawObj& pDObj, BOOL bBottomSide = FALSE);
+    GameElement GetVerifiedGameElementCodeForObject(const CDrawObj& pDObj, BOOL bBottomSide = FALSE);
     void        DoEditPieceText(PieceID pid, BOOL bEditTop);
-    void        DoEditObjectText(CDrawObj* pDObj);
+    void        DoEditObjectText(const CDrawObj& pDObj);
 
     void DoInitialUpdate();
     // Forced override of this (NOTE not virtual)
@@ -378,16 +378,16 @@ public:
     void PlaceObjectOnBoard(CPlayBoard *pPBrd, CDrawObj::OwnerPtr pObj,
         CSize sizeDelta, PlacePos ePos = placeDefault);
 
-    void InvertPlayingPieceOnBoard(CPieceObj *pObj, CPlayBoard *pPBrd);
+    void InvertPlayingPieceOnBoard(CPieceObj& pObj, CPlayBoard *pPBrd);
     void InvertPlayingPieceTableOnBoard(const std::vector<CB::not_null<CDrawObj*>>& pLst, CPlayBoard* pPBrd);
     void InvertPlayingPieceInTray(PieceID pid, BOOL bOkToNotifyTray = TRUE);
 
-    void ChangePlayingPieceFacingOnBoard(CPieceObj *pObj, CPlayBoard* pPBrd,
+    void ChangePlayingPieceFacingOnBoard(CPieceObj& pObj, CPlayBoard* pPBrd,
         int nFacingDegCW);
     void ChangePlayingPieceFacingTableOnBoard(const std::vector<CB::not_null<CDrawObj*>>& pLst,
         CPlayBoard* pPBrd, int nFacingDegCW);
     void ChangePlayingPieceFacingInTray(PieceID pid, int nFacingDegCW);
-    void ChangeMarkerFacingOnBoard(CMarkObj* pObj, CPlayBoard* pPBrd,
+    void ChangeMarkerFacingOnBoard(CMarkObj& pObj, CPlayBoard* pPBrd,
         int nFacingDegCW);
     void SetPieceOwnership(PieceID pid, DWORD dwOwnerMask);
     void SetPieceOwnershipTable(const std::vector<PieceID>& pTblPieces, DWORD dwOwnerMask);
@@ -402,7 +402,7 @@ public:
     void DeleteObjectsInTable(const std::vector<CB::not_null<CDrawObj*>>& pList);
     void SetObjectText(GameElement elem, LPCTSTR pszObjText);
     void SetObjectLockdownTable(const std::vector<CB::not_null<CDrawObj*>>& pLst, BOOL bLockState);
-    void SetObjectLockdown(CDrawObj* pDObj, BOOL bLockState);
+    void SetObjectLockdown(CDrawObj& pDObj, BOOL bLockState);
 
     BOOL RemovePieceFromCurrentLocation(PieceID pid, BOOL bDeleteIfBoard,
         BOOL bTrayHintAllowed = TRUE);

--- a/GP/GamDoc.h
+++ b/GP/GamDoc.h
@@ -369,49 +369,23 @@ public:
     void PlacePieceListOnBoard(CPoint pnt, const std::vector<PieceID>& pTbl,
         int xStagger, int yStagger, CPlayBoard *pPBrd);
     size_t PlacePieceListInTray(const std::vector<PieceID>& pTbl, CTraySet& pYGrp, size_t nPos = Invalid_v<size_t>);
-    size_t PlaceObjectListInTray(const CPtrList& pTbl, CTraySet& pYGrp, size_t nPos = Invalid_v<size_t>);
-    size_t PlaceObjectListInTray(std::vector<CB::not_null<CDrawObj*>>& pTbl, CTraySet& pYGrp, size_t nPos = Invalid_v<size_t>)
-    {
-        CPtrList temp;
-        CB::Copy(temp, pTbl);
-        return PlaceObjectListInTray(temp, pYGrp, nPos);
-    }
-    void PlaceObjectListOnBoard(CPtrList *pLst, CPoint pntUpLeft,
-        CPlayBoard *pPBrd, PlacePos ePos = placeDefault);
-    void PlaceObjectListOnBoard(const std::vector<CB::not_null<CDrawObj*>>& pLst, CPoint pntUpLeft,
-        CPlayBoard* pPBrd, PlacePos ePos = placeDefault)
-    {
-        CPtrList temp;
-        CB::Copy(temp, pLst);
-        PlaceObjectListOnBoard(&temp, pntUpLeft, pPBrd, ePos);
-    }
+    size_t PlaceObjectTableInTray(const std::vector<CB::not_null<CDrawObj*>> & pTbl, CTraySet& pYGrp, size_t nPos = Invalid_v<size_t>);
+    void PlaceObjectTableOnBoard(const std::vector<CB::not_null<CDrawObj*>>& pLst, CPoint pntUpLeft,
+        CPlayBoard* pPBrd, PlacePos ePos = placeDefault);
     void PlaceObjectTableOnBoard(CPoint pnt, const std::vector<CB::not_null<CDrawObj*>>& pTbl,
         int xStagger, int yStagger, CPlayBoard *pPBrd);
-    void PlaceObjectTableOnBoard(const std::vector<CB::not_null<CDrawObj*>>& pTbl, CPlayBoard *pPBrd);
+    void PlaceObjectTableOnBoard(const std::vector<CB::not_null<CDrawObj*>>& pTbl, CPlayBoard* pPBrd);
     void PlaceObjectOnBoard(CPlayBoard *pPBrd, CDrawObj::OwnerPtr pObj,
         CSize sizeDelta, PlacePos ePos = placeDefault);
 
     void InvertPlayingPieceOnBoard(CPieceObj *pObj, CPlayBoard *pPBrd);
-    void InvertPlayingPieceListOnBoard(CPtrList* pLst, CPlayBoard* pPBrd);
-    void InvertPlayingPieceListOnBoard(const std::vector<CB::not_null<CDrawObj*>>& pLst, CPlayBoard* pPBrd)
-    {
-        CPtrList temp;
-        CB::Copy(temp, pLst);
-        InvertPlayingPieceListOnBoard(&temp, pPBrd);
-    }
+    void InvertPlayingPieceTableOnBoard(const std::vector<CB::not_null<CDrawObj*>>& pLst, CPlayBoard* pPBrd);
     void InvertPlayingPieceInTray(PieceID pid, BOOL bOkToNotifyTray = TRUE);
 
     void ChangePlayingPieceFacingOnBoard(CPieceObj *pObj, CPlayBoard* pPBrd,
         int nFacingDegCW);
-    void ChangePlayingPieceFacingListOnBoard(CPtrList *pLst,
+    void ChangePlayingPieceFacingTableOnBoard(const std::vector<CB::not_null<CDrawObj*>>& pLst,
         CPlayBoard* pPBrd, int nFacingDegCW);
-    void ChangePlayingPieceFacingListOnBoard(const std::vector<CB::not_null<CDrawObj*>>& pLst,
-        CPlayBoard* pPBrd, int nFacingDegCW)
-    {
-        CPtrList temp;
-        CB::Copy(temp, pLst);
-        ChangePlayingPieceFacingListOnBoard(&temp, pPBrd, nFacingDegCW);
-    }
     void ChangePlayingPieceFacingInTray(PieceID pid, int nFacingDegCW);
     void ChangeMarkerFacingOnBoard(CMarkObj* pObj, CPlayBoard* pPBrd,
         int nFacingDegCW);
@@ -425,21 +399,9 @@ public:
     void ModifyLineObject(CPlayBoard* pPBrd, CPoint ptBeg, CPoint ptEnd,
         UINT nLineWd, COLORREF crLine, CLine* pObj);
     void ReorgObjsInDrawList(CPlayBoard *pPBrd, CPtrList* pList, BOOL bToFront);
-    void DeleteObjectsInList(CPtrList *pList);
-    void DeleteObjectsInList(const std::vector<CB::not_null<CDrawObj*>>& pList)
-    {
-        CPtrList temp;
-        CB::Copy(temp, pList);
-        DeleteObjectsInList(&temp);
-    }
+    void DeleteObjectsInTable(const std::vector<CB::not_null<CDrawObj*>>& pList);
     void SetObjectText(GameElement elem, LPCTSTR pszObjText);
-    void SetObjectLockdownList(CPtrList* pLst, BOOL bLockState);
-    void SetObjectLockdownList(const std::vector<CB::not_null<CDrawObj*>>& pLst, BOOL bLockState)
-    {
-        CPtrList temp;
-        CB::Copy(temp, pLst);
-        SetObjectLockdownList(&temp, bLockState);
-    }
+    void SetObjectLockdownTable(const std::vector<CB::not_null<CDrawObj*>>& pLst, BOOL bLockState);
     void SetObjectLockdown(CDrawObj* pDObj, BOOL bLockState);
 
     BOOL RemovePieceFromCurrentLocation(PieceID pid, BOOL bDeleteIfBoard,
@@ -447,7 +409,7 @@ public:
     void RemoveObjectFromCurrentLocation(CDrawObj* pObj);
     void ExpungeUnusedPiecesFromBoards();
 
-    void FindObjectListUnionRect(CPtrList* pLst, CRect& rct);
+    void FindObjectTableUnionRect(const std::vector<CB::not_null<CDrawObj*>>& pLst, CRect& rct);
 
     // Object and piece locator methods...
     BOOL FindPieceCurrentLocation(PieceID pid, CTraySet*& pTraySet,

--- a/GP/GamDoc.h
+++ b/GP/GamDoc.h
@@ -296,7 +296,7 @@ public:
     void PlaceObjectTableOnBoard(CPoint pnt, const std::vector<CDrawObj*>& pTbl,
         int xStagger, int yStagger, CPlayBoard *pPBrd);
     void PlaceObjectTableOnBoard(const std::vector<CDrawObj*>& pTbl, CPlayBoard *pPBrd);
-    void PlaceObjectOnBoard(CPlayBoard *pPBrd, CDrawObj* pObj,
+    void PlaceObjectOnBoard(CPlayBoard *pPBrd, CDrawObj::OwnerPtr pObj,
         CSize sizeDelta, PlacePos ePos = placeDefault);
 
     void InvertPlayingPieceOnBoard(CPieceObj *pObj, CPlayBoard *pPBrd);
@@ -313,9 +313,9 @@ public:
     void SetPieceOwnership(PieceID pid, DWORD dwOwnerMask);
     void SetPieceOwnershipTable(const std::vector<PieceID>& pTblPieces, DWORD dwOwnerMask);
 
-    CDrawObj* CreateMarkerObject(CPlayBoard* pPBrd, MarkID mid, CPoint pnt,
+    CDrawObj& CreateMarkerObject(CPlayBoard* pPBrd, MarkID mid, CPoint pnt,
         ObjectID dwObjID = ObjectID());
-    CDrawObj* CreateLineObject(CPlayBoard* pPBrd, CPoint ptBeg,
+    CDrawObj& CreateLineObject(CPlayBoard* pPBrd, CPoint ptBeg,
         CPoint ptEnd, UINT nLineWd, COLORREF crLine, ObjectID dwObjID = ObjectID());
     void ModifyLineObject(CPlayBoard* pPBrd, CPoint ptBeg, CPoint ptEnd,
         UINT nLineWd, COLORREF crLine, CLine* pObj);

--- a/GP/GamDoc.h
+++ b/GP/GamDoc.h
@@ -91,41 +91,119 @@ class CPlayerManager;
 
 ////////////////////////////////////////////////////////////////
 
-#define     HINT_ALWAYSUPDATE       0   // Must be zero!
+enum EGamDocHint
+{
+    HINT_ALWAYSUPDATE =             0,       // Must be zero!
 
-#define     HINT_BOARDCHANGE        0x0001
-#define     HINT_CLEARINDTIP        0x0002  // Clear any tooltip based indicators
-#define     HINT_GSNPROPCHANGE      0x0004
-#define     HINT_GAMPROPCHANGE      0x0008
-#define     HINT_TRAYCHANGE         0x0010  // pHint->m_pTray
-#define     HINT_UPDATEOBJECT       0x0100  // pHint->m_pDrawObj, m_pPBoard
-#define     HINT_UPDATEOBJLIST      0x0200  // pHint->m_pPtrList, m_pPBoard
-#define     HINT_UPDATEBOARD        0x0300  // pHint->m_pPBoard
-#define     HINT_UPDATESELECT       0x0400  // pHint->m_pPBoard, m_pSelList
-#define     HINT_UPDATESELECTLIST   0x0500  // resync select list. sender ignores.
-#define     HINT_GAMESTATEUSED      0x1000
-#define     HINT_POINTINVIEW        0x2000  // pHint->m_point, m_pPBoard
-#define     HINT_SELECTOBJ          0x4000  // pHint->m_pDrawObj, m_pPBoard
-#define     HINT_SELECTOBJLIST      0x8000  // pHint->m_pPtrList, m_pPBoard
+    HINT_BOARDCHANGE =              0x0001,
+    HINT_CLEARINDTIP =              0x0002, // Clear any tooltip based indicators
+    HINT_GSNPROPCHANGE =            0x0004,
+    HINT_GAMPROPCHANGE =            0x0008,
+    HINT_TRAYCHANGE =               0x0010,
+    HINT_UPDATEOBJECT =             0x0100,
+    HINT_UPDATEOBJLIST =            0x0200,
+    HINT_UPDATEBOARD =              0x0300,
+    HINT_UPDATESELECT =             0x0400,
+    HINT_UPDATESELECTLIST =         0x0500, // resync select list. sender ignores.
+    HINT_GAMESTATEUSED =            0x1000,
+    HINT_POINTINVIEW =              0x2000,
+    HINT_SELECTOBJ =                0x4000,
+    HINT_SELECTOBJLIST =            0x8000,
+
+    HINT_INVALID =                  -1,     // uninitialized Args
+};
 
 class CGamDocHint : public CObject
 {
     DECLARE_DYNCREATE(CGamDocHint);
 public:
-    union
+    CGamDocHint() : hint(HINT_INVALID) {}
+
+    template<EGamDocHint HINT>
+    struct Args
     {
-        CPlayBoard* m_pPBoard;
+    };
+
+    template<>
+    struct Args<HINT_TRAYCHANGE>
+    {
         CTraySet*   m_pTray;
     };
-    union
+
+    template<>
+    struct Args<HINT_UPDATEOBJECT>
     {
-        CSelList*   m_pSelList;
+        CPlayBoard* m_pPBoard;
         CDrawObj*   m_pDrawObj;
+    };
+
+    template<>
+    struct Args<HINT_UPDATEOBJLIST>
+    {
+        CPlayBoard* m_pPBoard;
         CPtrList*   m_pPtrList;
-        void*       m_pVoid;
-        int         m_nVal;
+    };
+
+    template<>
+    struct Args<HINT_UPDATEBOARD>
+    {
+        CPlayBoard* m_pPBoard;
+    };
+
+    template<>
+    struct Args<HINT_UPDATESELECT>
+    {
+        CPlayBoard* m_pPBoard;
+        CSelList*   m_pSelList;
+    };
+
+    template<>
+    struct Args<HINT_POINTINVIEW>
+    {
+        CPlayBoard* m_pPBoard;
         POINT       m_point;
     };
+
+    template<>
+    struct Args<HINT_SELECTOBJ>
+    {
+        CPlayBoard* m_pPBoard;
+        CDrawObj*   m_pDrawObj;
+    };
+
+    template<>
+    struct Args<HINT_SELECTOBJLIST>
+    {
+        CPlayBoard* m_pPBoard;
+        CPtrList*   m_pPtrList;
+    };
+
+    template<EGamDocHint HINT>
+    Args<HINT>& GetArgs()
+    {
+        if (hint == HINT_INVALID)
+        {
+            hint = HINT;
+        }
+        else if (HINT != hint)
+        {
+            CbThrowBadCastException();
+        }
+        return reinterpret_cast<Args<HINT>&>(args);
+    }
+
+private:
+    EGamDocHint hint;
+    union {
+        Args<HINT_TRAYCHANGE>       m_trayChange;
+        Args<HINT_UPDATEOBJECT>     m_updateObject;
+        Args<HINT_UPDATEOBJLIST>    m_updateObjList;
+        Args<HINT_UPDATEBOARD>      m_updateBoard;
+        Args<HINT_UPDATESELECT>     m_updateSelect;
+        Args<HINT_POINTINVIEW>      m_pointInView;
+        Args<HINT_SELECTOBJ>        m_selectObj;
+        Args<HINT_SELECTOBJLIST>    m_selectObjList;
+    } args;
 };
 
 ////////////////////////////////////////////////////////////////

--- a/GP/GamDoc.h
+++ b/GP/GamDoc.h
@@ -192,7 +192,8 @@ public:
     CMarkManager* GetMarkManager();
     CBoardManager* GetBoardManager();
     CPieceManager* GetPieceManager();
-    CPieceTable* GetPieceTable() { return m_pPTbl; }
+    const CPieceTable* GetPieceTable() const { return m_pPTbl; }
+    CPieceTable* GetPieceTable() { return const_cast<CPieceTable*>(std::as_const(*this).GetPieceTable()); }
     CTrayManager* GetTrayManager() { return m_pYMgr; }
     CPBoardManager* GetPBoardManager() { return m_pPBMgr; }
     CPlayerManager* GetPlayerManager() { return m_pPlayerMgr; }

--- a/GP/GamDoc.h
+++ b/GP/GamDoc.h
@@ -175,7 +175,7 @@ public:
     struct Args<HINT_SELECTOBJLIST>
     {
         CPlayBoard* m_pPBoard;
-        CPtrList*   m_pPtrList;
+        const std::vector<CB::not_null<CDrawObj*>>* m_pPtrList;
     };
 
     template<EGamDocHint HINT>
@@ -424,7 +424,7 @@ public:
     void EnsureBoardLocationVisible(CPlayBoard& pPBoard, CPoint point);
     void EnsureTrayIndexVisible(const CTraySet& pYSet, int nPos);
     void SelectObjectOnBoard(CPlayBoard& pPBoard, CDrawObj* pObj);
-    void SelectObjectListOnBoard(CPlayBoard& pPBoard, CPtrList* pList);
+    void SelectObjectListOnBoard(CPlayBoard& pPBoard, const std::vector<CB::not_null<CDrawObj*>>& pList);
     void SelectTrayItem(const CTraySet& pYSet, PieceID pid, UINT nResourceID);
     void SelectTrayItem(const CTraySet& pYSet, PieceID pid, LPCTSTR pszNotificationTip = NULL);
     void SelectMarkerPaletteItem(MarkID mid);

--- a/GP/GamDoc1.cpp
+++ b/GP/GamDoc1.cpp
@@ -259,7 +259,7 @@ void CGamDoc::PlaceObjectListOnBoard(CPtrList *pLst, CPoint pntUpLeft,
 
 //////////////////////////////////////////////////////////////////////
 
-void CGamDoc::PlaceObjectTableOnBoard(CPoint pnt, const std::vector<CDrawObj*>& pTbl,
+void CGamDoc::PlaceObjectTableOnBoard(CPoint pnt, const std::vector<CB::not_null<CDrawObj*>>& pTbl,
     int xStagger, int yStagger, CPlayBoard *pPBrd)
 {
     // Since we want the first entry of the list to be on top
@@ -280,9 +280,9 @@ void CGamDoc::PlaceObjectTableOnBoard(CPoint pnt, const std::vector<CDrawObj*>& 
     }
     for (size_t i = pTbl.size(); i > 0; i--)
     {
-        CDrawObj* pDObj = pTbl.at(i - 1);
-        CSize sizeDelta = pnt - pDObj->GetRect().CenterPoint();
-        PlaceObjectOnBoard(pPBrd, pDObj, sizeDelta, placeTop);
+        CDrawObj& pDObj = *pTbl.at(i - size_t(1));
+        CSize sizeDelta = pnt - pDObj.GetRect().CenterPoint();
+        PlaceObjectOnBoard(pPBrd, &pDObj, sizeDelta, placeTop);
         pnt -= CSize(xStagger, yStagger);
     }
 }
@@ -291,14 +291,14 @@ void CGamDoc::PlaceObjectTableOnBoard(CPoint pnt, const std::vector<CDrawObj*>& 
 // Places that objects in there current coordinates but changes
 // their Z-order.
 
-void CGamDoc::PlaceObjectTableOnBoard(const std::vector<CDrawObj*>& pTbl, CPlayBoard *pPBrd)
+void CGamDoc::PlaceObjectTableOnBoard(const std::vector<CB::not_null<CDrawObj*>>& pTbl, CPlayBoard *pPBrd)
 {
     // Since we want the first entry of the list to be on top
     // in the view, we'll walk the array from bottom to top.
     for (size_t i = pTbl.size(); i > 0; i--)
     {
-        CDrawObj* pDObj = pTbl.at(i - 1);
-        PlaceObjectOnBoard(pPBrd, pDObj, CSize(0,0), placeTop);
+        CDrawObj& pDObj = *pTbl.at(i - size_t(1));
+        PlaceObjectOnBoard(pPBrd, &pDObj, CSize(0,0), placeTop);
     }
 }
 

--- a/GP/GamDoc1.cpp
+++ b/GP/GamDoc1.cpp
@@ -459,29 +459,29 @@ size_t CGamDoc::PlaceObjectTableInTray(const std::vector<CB::not_null<CDrawObj*>
 
 //////////////////////////////////////////////////////////////////////
 // (RECORDS)
-void CGamDoc::InvertPlayingPieceOnBoard(CPieceObj *pObj, CPlayBoard* pPBrd)
+void CGamDoc::InvertPlayingPieceOnBoard(CPieceObj& pObj, CPlayBoard* pPBrd)
 {
-    if (!m_pPTbl->Is2Sided(pObj->m_pid))
+    if (!m_pPTbl->Is2Sided(pObj.m_pid))
         return;
     if (!IsQuietPlayback())
     {
         CGamDocHint hint;
         hint.GetArgs<HINT_UPDATEOBJECT>().m_pPBoard = pPBrd;
-        hint.GetArgs<HINT_UPDATEOBJECT>().m_pDrawObj = pObj;
+        hint.GetArgs<HINT_UPDATEOBJECT>().m_pDrawObj = &pObj;
         UpdateAllViews(NULL, HINT_UPDATEOBJECT, &hint);
     }
 
-    m_pPTbl->FlipPieceOver(pObj->m_pid);
-    pObj->ResyncExtentRect();
+    m_pPTbl->FlipPieceOver(pObj.m_pid);
+    pObj.ResyncExtentRect();
 
     // Record processing
-    RecordPieceSetSide(pObj->m_pid, GetPieceTable()->IsFrontUp(pObj->m_pid));
+    RecordPieceSetSide(pObj.m_pid, GetPieceTable()->IsFrontUp(pObj.m_pid));
 
     if (!IsQuietPlayback())
     {
         CGamDocHint hint;
         hint.GetArgs<HINT_UPDATEOBJECT>().m_pPBoard = pPBrd;
-        hint.GetArgs<HINT_UPDATEOBJECT>().m_pDrawObj = pObj;
+        hint.GetArgs<HINT_UPDATEOBJECT>().m_pDrawObj = &pObj;
         UpdateAllViews(NULL, HINT_UPDATEOBJECT, &hint);
     }
     SetModifiedFlag();
@@ -494,7 +494,7 @@ void CGamDoc::InvertPlayingPieceTableOnBoard(const std::vector<CB::not_null<CDra
         CDrawObj& pObj = **pos;
         // Only pieces are flipped. Others are left as they are.
         if (pObj.GetType() == CDrawObj::drawPieceObj)
-            InvertPlayingPieceOnBoard(&static_cast<CPieceObj&>(pObj), pPBrd);
+            InvertPlayingPieceOnBoard(static_cast<CPieceObj&>(pObj), pPBrd);
     }
 }
 
@@ -521,27 +521,27 @@ void CGamDoc::InvertPlayingPieceInTray(PieceID pid, BOOL bOkToNotifyTray /* = TR
 
 //////////////////////////////////////////////////////////////////////
 // (RECORDS)
-void CGamDoc::ChangePlayingPieceFacingOnBoard(CPieceObj *pObj, CPlayBoard* pPBrd,
+void CGamDoc::ChangePlayingPieceFacingOnBoard(CPieceObj& pObj, CPlayBoard* pPBrd,
     int nFacingDegCW)
 {
     if (!IsQuietPlayback())
     {
         CGamDocHint hint;
         hint.GetArgs<HINT_UPDATEOBJECT>().m_pPBoard = pPBrd;
-        hint.GetArgs<HINT_UPDATEOBJECT>().m_pDrawObj = pObj;
+        hint.GetArgs<HINT_UPDATEOBJECT>().m_pDrawObj = &pObj;
         UpdateAllViews(NULL, HINT_UPDATEOBJECT, &hint);
     }
-    m_pPTbl->SetPieceFacing(pObj->m_pid, nFacingDegCW);
-    pObj->ResyncExtentRect();
+    m_pPTbl->SetPieceFacing(pObj.m_pid, nFacingDegCW);
+    pObj.ResyncExtentRect();
 
     // Record processing
-    RecordPieceSetFacing(pObj->m_pid, nFacingDegCW);
+    RecordPieceSetFacing(pObj.m_pid, nFacingDegCW);
 
     if (!IsQuietPlayback())
     {
         CGamDocHint hint;
         hint.GetArgs<HINT_UPDATEOBJECT>().m_pPBoard = pPBrd;
-        hint.GetArgs<HINT_UPDATEOBJECT>().m_pDrawObj = pObj;
+        hint.GetArgs<HINT_UPDATEOBJECT>().m_pDrawObj = &pObj;
         UpdateAllViews(NULL, HINT_UPDATEOBJECT, &hint);
     }
     SetModifiedFlag();
@@ -555,9 +555,9 @@ void CGamDoc::ChangePlayingPieceFacingTableOnBoard(const std::vector<CB::not_nul
         CDrawObj& pObj = **pos;
         // Only pieces and markers are rotated. Others are left as they are.
         if (pObj.GetType() == CDrawObj::drawPieceObj)
-            ChangePlayingPieceFacingOnBoard(&static_cast<CPieceObj&>(pObj), pPBrd, nFacingDegCW);
+            ChangePlayingPieceFacingOnBoard(static_cast<CPieceObj&>(pObj), pPBrd, nFacingDegCW);
         else if (pObj.GetType() == CDrawObj::drawMarkObj)
-            ChangeMarkerFacingOnBoard(&static_cast<CMarkObj&>(pObj), pPBrd, nFacingDegCW);
+            ChangeMarkerFacingOnBoard(static_cast<CMarkObj&>(pObj), pPBrd, nFacingDegCW);
     }
 }
 
@@ -584,27 +584,27 @@ void CGamDoc::ChangePlayingPieceFacingInTray(PieceID pid, int nFacingDegCW)
 //////////////////////////////////////////////////////////////////////
 // (RECORDS)
 
-void CGamDoc::ChangeMarkerFacingOnBoard(CMarkObj *pObj, CPlayBoard* pPBrd,
+void CGamDoc::ChangeMarkerFacingOnBoard(CMarkObj& pObj, CPlayBoard* pPBrd,
     int nFacingDegCW)
 {
     if (!IsQuietPlayback())
     {
         CGamDocHint hint;
         hint.GetArgs<HINT_UPDATEOBJECT>().m_pPBoard = pPBrd;
-        hint.GetArgs<HINT_UPDATEOBJECT>().m_pDrawObj = pObj;
+        hint.GetArgs<HINT_UPDATEOBJECT>().m_pDrawObj = &pObj;
         UpdateAllViews(NULL, HINT_UPDATEOBJECT, &hint);
     }
-    pObj->SetFacing(nFacingDegCW);
-    pObj->ResyncExtentRect();
+    pObj.SetFacing(nFacingDegCW);
+    pObj.ResyncExtentRect();
 
     // Record processing
-    RecordMarkerSetFacing(pObj->GetObjectID(), pObj->m_mid, nFacingDegCW);
+    RecordMarkerSetFacing(pObj.GetObjectID(), pObj.m_mid, nFacingDegCW);
 
     if (!IsQuietPlayback())
     {
         CGamDocHint hint;
         hint.GetArgs<HINT_UPDATEOBJECT>().m_pPBoard = pPBrd;
-        hint.GetArgs<HINT_UPDATEOBJECT>().m_pDrawObj = pObj;
+        hint.GetArgs<HINT_UPDATEOBJECT>().m_pDrawObj = &pObj;
         UpdateAllViews(NULL, HINT_UPDATEOBJECT, &hint);
     }
     SetModifiedFlag();
@@ -667,16 +667,16 @@ void CGamDoc::SetObjectLockdownTable(const std::vector<CB::not_null<CDrawObj*>>&
     for (auto pos = pLst.begin() ; pos != pLst.end() ; ++pos)
     {
         CDrawObj& pObj = **pos;
-        SetObjectLockdown(&pObj, bLockState);
+        SetObjectLockdown(pObj, bLockState);
     }
 }
 
 //////////////////////////////////////////////////////////////////////
 // (RECORDS)
 
-void CGamDoc::SetObjectLockdown(CDrawObj* pDObj, BOOL bLockState)
+void CGamDoc::SetObjectLockdown(CDrawObj& pDObj, BOOL bLockState)
 {
-    pDObj->ModifyDObjFlags(dobjFlgLockDown, bLockState);
+    pDObj.ModifyDObjFlags(dobjFlgLockDown, bLockState);
 
     // Record processing
     RecordObjectLockdown(GetGameElementCodeForObject(pDObj), bLockState);

--- a/GP/GamDoc1.cpp
+++ b/GP/GamDoc1.cpp
@@ -131,7 +131,7 @@ void CGamDoc::PlaceObjectOnBoard(CPlayBoard *pPBrd, CDrawObj::OwnerPtr opObj,
         RecordMarkMoveToBoard(pPBrd, pMObj.GetObjectID(), pMObj.m_mid,
             GetMidRect(rctMrk) + sizeDelta, ePos);
     }
-    BOOL bOnBoard = pDwg->HasObject(&pObj);
+    BOOL bOnBoard = pDwg->HasObject(pObj);
     if (ePos == placeDefault && bOnBoard)
     {
         if (!IsQuietPlayback())
@@ -217,7 +217,7 @@ void CGamDoc::PlaceObjectListOnBoard(CPtrList *pLst, CPoint pntUpLeft,
                 GetMidRect(rctMrk) + size, ePos);
         }
 
-        BOOL bOnBoard = pDwg->HasObject(pObj);
+        BOOL bOnBoard = pDwg->HasObject(*pObj);
         if (ePos == placeDefault && bOnBoard)
         {
             if (!IsQuietPlayback())
@@ -745,8 +745,8 @@ void CGamDoc::ReorgObjsInDrawList(CPlayBoard *pPBrd, CPtrList* pList,
     CDrawList* pDwg = pPBrd->GetPieceList();
     ASSERT(pDwg);
 
-    pDwg->ArrangeObjectListInDrawOrder(pList);
-    pDwg->RemoveObjectsInList(pList);
+    pDwg->ArrangeObjectListInDrawOrder(CheckedDeref(pList));
+    pDwg->RemoveObjectsInList(*pList);
     if (bToFront)
     {
         POSITION pos = pList->GetHeadPosition();
@@ -901,7 +901,7 @@ void CGamDoc::ExpungeUnusedPiecesFromBoards()
         CDrawList* pDwg = pPBrd.GetPieceList();
 
         CPtrList listPtr;
-        pDwg->GetPieceObjectPtrList(&listPtr);
+        pDwg->GetPieceObjectPtrList(listPtr);
 
         POSITION pos;
         for (pos = listPtr.GetHeadPosition(); pos != NULL; )

--- a/GP/GamDoc1.cpp
+++ b/GP/GamDoc1.cpp
@@ -63,8 +63,8 @@ void CGamDoc::PlacePieceOnBoard(CPoint pnt, PieceID pid, CPlayBoard *pPBrd)
     if (!IsQuietPlayback())
     {
         CGamDocHint hint;
-        hint.m_pPBoard = pPBrd;
-        hint.m_pDrawObj = &pObj;
+        hint.GetArgs<HINT_UPDATEOBJECT>().m_pPBoard = pPBrd;
+        hint.GetArgs<HINT_UPDATEOBJECT>().m_pDrawObj = &pObj;
         UpdateAllViews(NULL, HINT_UPDATEOBJECT, &hint);
     }
     SetModifiedFlag();
@@ -100,7 +100,7 @@ void CGamDoc::PlacePieceInTray(PieceID pid, CTraySet& pYGrp, size_t nPos)
     if (!IsQuietPlayback())
     {
         CGamDocHint hint;
-        hint.m_pTray = &pYGrp;
+        hint.GetArgs<HINT_TRAYCHANGE>().m_pTray = &pYGrp;
         UpdateAllViews(NULL, HINT_TRAYCHANGE, &hint);
     }
     SetModifiedFlag();
@@ -138,8 +138,8 @@ void CGamDoc::PlaceObjectOnBoard(CPlayBoard *pPBrd, CDrawObj::OwnerPtr opObj,
         {
             // Cause it's former location to be invalidated...
             CGamDocHint hint;
-            hint.m_pPBoard = pPBrd;
-            hint.m_pDrawObj = &pObj;
+            hint.GetArgs<HINT_UPDATEOBJECT>().m_pPBoard = pPBrd;
+            hint.GetArgs<HINT_UPDATEOBJECT>().m_pDrawObj = &pObj;
             UpdateAllViews(NULL, HINT_UPDATEOBJECT, &hint);
         }
     }
@@ -171,8 +171,8 @@ void CGamDoc::PlaceObjectOnBoard(CPlayBoard *pPBrd, CDrawObj::OwnerPtr opObj,
     {
         // Cause object to be drawn
         CGamDocHint hint;
-        hint.m_pPBoard = pPBrd;
-        hint.m_pDrawObj = &pObj;
+        hint.GetArgs<HINT_UPDATEOBJECT>().m_pPBoard = pPBrd;
+        hint.GetArgs<HINT_UPDATEOBJECT>().m_pDrawObj = &pObj;
         UpdateAllViews(NULL, HINT_UPDATEOBJECT, &hint);
     }
     SetModifiedFlag();
@@ -224,8 +224,8 @@ void CGamDoc::PlaceObjectListOnBoard(CPtrList *pLst, CPoint pntUpLeft,
             {
                 // Cause it's former location to be invalidated...
                 CGamDocHint hint;
-                hint.m_pPBoard = pPBrd;
-                hint.m_pDrawObj = pObj;
+                hint.GetArgs<HINT_UPDATEOBJECT>().m_pPBoard = pPBrd;
+                hint.GetArgs<HINT_UPDATEOBJECT>().m_pDrawObj = pObj;
                 UpdateAllViews(NULL, HINT_UPDATEOBJECT, &hint);
             }
         }
@@ -249,8 +249,8 @@ void CGamDoc::PlaceObjectListOnBoard(CPtrList *pLst, CPoint pntUpLeft,
         {
             // Cause object to be drawn
             CGamDocHint hint;
-            hint.m_pPBoard = pPBrd;
-            hint.m_pDrawObj = pObj;
+            hint.GetArgs<HINT_UPDATEOBJECT>().m_pPBoard = pPBrd;
+            hint.GetArgs<HINT_UPDATEOBJECT>().m_pDrawObj = pObj;
             UpdateAllViews(NULL, HINT_UPDATEOBJECT, &hint);
         }
         SetModifiedFlag();
@@ -380,8 +380,8 @@ void CGamDoc::InvertPlayingPieceOnBoard(CPieceObj *pObj, CPlayBoard* pPBrd)
     if (!IsQuietPlayback())
     {
         CGamDocHint hint;
-        hint.m_pPBoard = pPBrd;
-        hint.m_pDrawObj = pObj;
+        hint.GetArgs<HINT_UPDATEOBJECT>().m_pPBoard = pPBrd;
+        hint.GetArgs<HINT_UPDATEOBJECT>().m_pDrawObj = pObj;
         UpdateAllViews(NULL, HINT_UPDATEOBJECT, &hint);
     }
 
@@ -394,8 +394,8 @@ void CGamDoc::InvertPlayingPieceOnBoard(CPieceObj *pObj, CPlayBoard* pPBrd)
     if (!IsQuietPlayback())
     {
         CGamDocHint hint;
-        hint.m_pPBoard = pPBrd;
-        hint.m_pDrawObj = pObj;
+        hint.GetArgs<HINT_UPDATEOBJECT>().m_pPBoard = pPBrd;
+        hint.GetArgs<HINT_UPDATEOBJECT>().m_pDrawObj = pObj;
         UpdateAllViews(NULL, HINT_UPDATEOBJECT, &hint);
     }
     SetModifiedFlag();
@@ -428,7 +428,7 @@ void CGamDoc::InvertPlayingPieceInTray(PieceID pid, BOOL bOkToNotifyTray /* = TR
     if (!IsQuietPlayback() && bOkToNotifyTray)
     {
         CGamDocHint hint;
-        hint.m_pTray = pYGrp;
+        hint.GetArgs<HINT_TRAYCHANGE>().m_pTray = pYGrp;
         UpdateAllViews(NULL, HINT_TRAYCHANGE, &hint);
     }
     SetModifiedFlag();
@@ -442,8 +442,8 @@ void CGamDoc::ChangePlayingPieceFacingOnBoard(CPieceObj *pObj, CPlayBoard* pPBrd
     if (!IsQuietPlayback())
     {
         CGamDocHint hint;
-        hint.m_pPBoard = pPBrd;
-        hint.m_pDrawObj = pObj;
+        hint.GetArgs<HINT_UPDATEOBJECT>().m_pPBoard = pPBrd;
+        hint.GetArgs<HINT_UPDATEOBJECT>().m_pDrawObj = pObj;
         UpdateAllViews(NULL, HINT_UPDATEOBJECT, &hint);
     }
     m_pPTbl->SetPieceFacing(pObj->m_pid, nFacingDegCW);
@@ -455,8 +455,8 @@ void CGamDoc::ChangePlayingPieceFacingOnBoard(CPieceObj *pObj, CPlayBoard* pPBrd
     if (!IsQuietPlayback())
     {
         CGamDocHint hint;
-        hint.m_pPBoard = pPBrd;
-        hint.m_pDrawObj = pObj;
+        hint.GetArgs<HINT_UPDATEOBJECT>().m_pPBoard = pPBrd;
+        hint.GetArgs<HINT_UPDATEOBJECT>().m_pDrawObj = pObj;
         UpdateAllViews(NULL, HINT_UPDATEOBJECT, &hint);
     }
     SetModifiedFlag();
@@ -491,7 +491,7 @@ void CGamDoc::ChangePlayingPieceFacingInTray(PieceID pid, int nFacingDegCW)
     if (!IsQuietPlayback())
     {
         CGamDocHint hint;
-        hint.m_pTray = pYGrp;
+        hint.GetArgs<HINT_TRAYCHANGE>().m_pTray = pYGrp;
         UpdateAllViews(NULL, HINT_TRAYCHANGE, &hint);
     }
     SetModifiedFlag();
@@ -506,8 +506,8 @@ void CGamDoc::ChangeMarkerFacingOnBoard(CMarkObj *pObj, CPlayBoard* pPBrd,
     if (!IsQuietPlayback())
     {
         CGamDocHint hint;
-        hint.m_pPBoard = pPBrd;
-        hint.m_pDrawObj = pObj;
+        hint.GetArgs<HINT_UPDATEOBJECT>().m_pPBoard = pPBrd;
+        hint.GetArgs<HINT_UPDATEOBJECT>().m_pDrawObj = pObj;
         UpdateAllViews(NULL, HINT_UPDATEOBJECT, &hint);
     }
     pObj->SetFacing(nFacingDegCW);
@@ -519,8 +519,8 @@ void CGamDoc::ChangeMarkerFacingOnBoard(CMarkObj *pObj, CPlayBoard* pPBrd,
     if (!IsQuietPlayback())
     {
         CGamDocHint hint;
-        hint.m_pPBoard = pPBrd;
-        hint.m_pDrawObj = pObj;
+        hint.GetArgs<HINT_UPDATEOBJECT>().m_pPBoard = pPBrd;
+        hint.GetArgs<HINT_UPDATEOBJECT>().m_pDrawObj = pObj;
         UpdateAllViews(NULL, HINT_UPDATEOBJECT, &hint);
     }
     SetModifiedFlag();
@@ -551,8 +551,8 @@ void CGamDoc::DeleteObjectsInList(CPtrList *pLst)
             if (!IsQuietPlayback())
             {
                 CGamDocHint hint;
-                hint.m_pPBoard = pPBrd;
-                hint.m_pDrawObj = pObj;
+                hint.GetArgs<HINT_UPDATEOBJECT>().m_pPBoard = pPBrd;
+                hint.GetArgs<HINT_UPDATEOBJECT>().m_pDrawObj = pObj;
                 UpdateAllViews(NULL, HINT_UPDATEOBJECT, &hint);
             }
             SetModifiedFlag();
@@ -662,8 +662,8 @@ CDrawObj& CGamDoc::CreateMarkerObject(CPlayBoard* pPBrd, MarkID mid, CPoint pnt,
     if (!IsQuietPlayback())
     {
         CGamDocHint hint;
-        hint.m_pPBoard = pPBrd;
-        hint.m_pDrawObj = &pObj;
+        hint.GetArgs<HINT_UPDATEOBJECT>().m_pPBoard = pPBrd;
+        hint.GetArgs<HINT_UPDATEOBJECT>().m_pDrawObj = &pObj;
         UpdateAllViews(NULL, HINT_UPDATEOBJECT, &hint);
     }
     SetModifiedFlag();
@@ -696,8 +696,8 @@ CDrawObj& CGamDoc::CreateLineObject(CPlayBoard* pPBrd, CPoint ptBeg,
     if (!IsQuietPlayback())
     {
         CGamDocHint hint;
-        hint.m_pPBoard = pPBrd;
-        hint.m_pDrawObj = &pObj;
+        hint.GetArgs<HINT_UPDATEOBJECT>().m_pPBoard = pPBrd;
+        hint.GetArgs<HINT_UPDATEOBJECT>().m_pDrawObj = &pObj;
         UpdateAllViews(NULL, HINT_UPDATEOBJECT, &hint);
     }
     SetModifiedFlag();
@@ -716,8 +716,8 @@ void CGamDoc::ModifyLineObject(CPlayBoard* pPBrd, CPoint ptBeg,
     {
         // Cause invalidation of current positions....
         CGamDocHint hint;
-        hint.m_pPBoard = pPBrd;
-        hint.m_pDrawObj = pObj;
+        hint.GetArgs<HINT_UPDATEOBJECT>().m_pPBoard = pPBrd;
+        hint.GetArgs<HINT_UPDATEOBJECT>().m_pDrawObj = pObj;
         UpdateAllViews(NULL, HINT_UPDATEOBJECT, &hint);
     }
 
@@ -730,8 +730,8 @@ void CGamDoc::ModifyLineObject(CPlayBoard* pPBrd, CPoint ptBeg,
     {
         // Refresh drawing of object.
         CGamDocHint hint;
-        hint.m_pPBoard = pPBrd;
-        hint.m_pDrawObj = pObj;
+        hint.GetArgs<HINT_UPDATEOBJECT>().m_pPBoard = pPBrd;
+        hint.GetArgs<HINT_UPDATEOBJECT>().m_pDrawObj = pObj;
         UpdateAllViews(NULL, HINT_UPDATEOBJECT, &hint);
     }
     SetModifiedFlag();
@@ -764,8 +764,8 @@ void CGamDoc::ReorgObjsInDrawList(CPlayBoard *pPBrd, CPtrList* pList,
     if (!IsQuietPlayback())
     {
         CGamDocHint hint;
-        hint.m_pPBoard = pPBrd;
-        hint.m_pPtrList = pList;
+        hint.GetArgs<HINT_UPDATEOBJLIST>().m_pPBoard = pPBrd;
+        hint.GetArgs<HINT_UPDATEOBJLIST>().m_pPtrList = pList;
         UpdateAllViews(NULL, HINT_UPDATEOBJLIST, &hint);
     }
     SetModifiedFlag();
@@ -813,8 +813,8 @@ BOOL CGamDoc::RemovePieceFromCurrentLocation(PieceID pid, BOOL bDeleteIfBoard,
         {
             // Cause it's former location to be invalidated...
             CGamDocHint hint;
-            hint.m_pPBoard = pPBoard;
-            hint.m_pDrawObj = pObj;
+            hint.GetArgs<HINT_UPDATEOBJECT>().m_pPBoard = pPBoard;
+            hint.GetArgs<HINT_UPDATEOBJECT>().m_pDrawObj = pObj;
             UpdateAllViews(NULL, HINT_UPDATEOBJECT, &hint);
         }
         if (bDeleteIfBoard)
@@ -829,7 +829,7 @@ BOOL CGamDoc::RemovePieceFromCurrentLocation(PieceID pid, BOOL bDeleteIfBoard,
         if (bTrayHintAllowed && !IsQuietPlayback())
         {
             CGamDocHint hint;
-            hint.m_pTray = pYGrp;
+            hint.GetArgs<HINT_TRAYCHANGE>().m_pTray = pYGrp;
             UpdateAllViews(NULL, HINT_TRAYCHANGE, &hint);
             return FALSE;
         }
@@ -867,8 +867,8 @@ void CGamDoc::RemoveObjectFromCurrentLocation(CDrawObj* pObj)
         {
             // Cause it's former location to be invalidated...
             CGamDocHint hint;
-            hint.m_pPBoard = pPBoard;
-            hint.m_pDrawObj = pObj;
+            hint.GetArgs<HINT_UPDATEOBJECT>().m_pPBoard = pPBoard;
+            hint.GetArgs<HINT_UPDATEOBJECT>().m_pDrawObj = pObj;
             UpdateAllViews(NULL, HINT_UPDATEOBJECT, &hint);
         }
     }
@@ -916,8 +916,8 @@ void CGamDoc::ExpungeUnusedPiecesFromBoards()
                 {
                     // Cause object display area to be invalidated
                     CGamDocHint hint;
-                    hint.m_pPBoard = &pPBrd;
-                    hint.m_pDrawObj = pObj;
+                    hint.GetArgs<HINT_UPDATEOBJECT>().m_pPBoard = &pPBrd;
+                    hint.GetArgs<HINT_UPDATEOBJECT>().m_pDrawObj = pObj;
                     UpdateAllViews(NULL, HINT_UPDATEOBJECT, &hint);
                 }
 

--- a/GP/GamDoc2.cpp
+++ b/GP/GamDoc2.cpp
@@ -199,7 +199,7 @@ void CGamDoc::SaveRecordedMoves()
     m_nSeedCarryOver = (UINT)GetTickCount();
 }
 
-void CGamDoc::AddMovesToGameHistoryTable(CHistRecord* pHist)
+void CGamDoc::AddMovesToGameHistoryTable(OwnerPtr<CHistRecord> pHist)
 {
     // If there are two game state records in the front of
     // the move list, remove the first since the second
@@ -219,7 +219,7 @@ void CGamDoc::AddMovesToGameHistoryTable(CHistRecord* pHist)
 
     if (m_pHistTbl == NULL)
         m_pHistTbl = new CHistoryTable;
-    m_pHistTbl->AddNewHistRecord(pHist);
+    m_pHistTbl->AddNewHistRecord(std::move(pHist));
 
     m_eState = stateRecording;
     m_pMoves = NULL;            // Clear shadow pointer
@@ -258,7 +258,7 @@ BOOL CGamDoc::DiscardCurrentRecording(BOOL bPrompt /* = TRUE */)
     ASSERT(pMove != NULL);
     ASSERT(pMove->GetType() == CMoveRecord::mrecState);
 
-    if (!pMove->GetGameState()->RestoreState())
+    if (!pMove->GetGameState().RestoreState())
     {
         AfxMessageBox(IDS_ERR_FAILEDRESTORE, MB_OK | MB_ICONEXCLAMATION);
         return FALSE;

--- a/GP/GamDoc2.cpp
+++ b/GP/GamDoc2.cpp
@@ -210,8 +210,8 @@ void CGamDoc::AddMovesToGameHistoryTable(OwnerPtr<CHistRecord> pHist)
     {
         CMoveList::iterator pos = ++pHist->m_pMList->begin();
         ASSERT(pos != pHist->m_pMList->end());
-        CMoveRecord* pRcd = pHist->m_pMList->GetAt(pos);
-        if (pRcd->GetType() == CMoveRecord::mrecState)
+        CMoveRecord& pRcd = pHist->m_pMList->GetAt(pos);
+        if (pRcd.GetType() == CMoveRecord::mrecState)
         {
             pHist->m_pMList->pop_front();
         }
@@ -254,11 +254,11 @@ BOOL CGamDoc::DiscardCurrentRecording(BOOL bPrompt /* = TRUE */)
     // Get the first record which contains the starting positions
     // of the recording. Restore it.
 
-    CGameStateRcd* pMove = (CGameStateRcd*)m_pRcdMoves->GetFirstRecord();
-    ASSERT(pMove != NULL);
-    ASSERT(pMove->GetType() == CMoveRecord::mrecState);
+    CMoveRecord& temp = m_pRcdMoves->GetFirstRecord();
+    ASSERT(temp.GetType() == CMoveRecord::mrecState);
+    CGameStateRcd& pMove = static_cast<CGameStateRcd&>(temp);
 
-    if (!pMove->GetGameState().RestoreState())
+    if (!pMove.GetGameState().RestoreState())
     {
         AfxMessageBox(IDS_ERR_FAILEDRESTORE, MB_OK | MB_ICONEXCLAMATION);
         return FALSE;

--- a/GP/GamDoc4.cpp
+++ b/GP/GamDoc4.cpp
@@ -673,10 +673,9 @@ void CGamDoc::FlushAllIndicators()
 
         UpdateAllBoardIndicators(pPBrd);
 
-        CDrawList* pDwg = pPBrd.GetIndicatorList();
-        ASSERT(pDwg != NULL);
+        CDrawList& pDwg = CheckedDeref(pPBrd.GetIndicatorList());
 
-        pDwg->Flush();
+        pDwg.clear();
 
         pPBrd.SetPlotMoveMode(FALSE);
     }
@@ -692,17 +691,14 @@ void CGamDoc::FlushAllIndicators()
 void CGamDoc::UpdateAllBoardIndicators(CPlayBoard& pPBrd)
 {
     if (IsQuietPlayback()) return;
-    CDrawList* pDwg = pPBrd.GetIndicatorList();
-    ASSERT(pDwg != NULL);
+    CDrawList& pDwg = CheckedDeref(pPBrd.GetIndicatorList());
 
-    POSITION pos;
-    for (pos = pDwg->GetHeadPosition(); pos != NULL; )
+    for (CDrawList::iterator pos = pDwg.begin(); pos != pDwg.end(); ++pos)
     {
-        CDrawObj* pObj = (CDrawObj*)pDwg->GetNext(pos);
-        ASSERT(pObj);
+        CDrawObj& pObj = **pos;
         CGamDocHint hint;
         hint.m_pPBoard = &pPBrd;
-        hint.m_pDrawObj = pObj;
+        hint.m_pDrawObj = &pObj;
         UpdateAllViews(NULL, HINT_UPDATEOBJECT, &hint);
     }
 }

--- a/GP/GamDoc4.cpp
+++ b/GP/GamDoc4.cpp
@@ -467,8 +467,8 @@ void CGamDoc::EnsureBoardLocationVisible(CPlayBoard& pPBoard, CPoint point)
     // Use hint to scroll board to make point visible somewhere
     // near the center of the view.
     CGamDocHint hint;
-    hint.m_pPBoard = &pPBoard;
-    hint.m_point = point;
+    hint.GetArgs<HINT_POINTINVIEW>().m_pPBoard = &pPBoard;
+    hint.GetArgs<HINT_POINTINVIEW>().m_point = point;
     UpdateAllViews(NULL, HINT_POINTINVIEW, &hint);
 }
 
@@ -506,8 +506,8 @@ void CGamDoc::SelectObjectOnBoard(CPlayBoard& pPBoard, CDrawObj* pObj)
 
     // Use hint to add object to select list
     CGamDocHint hint;
-    hint.m_pPBoard = &pPBoard;
-    hint.m_pDrawObj = pObj;
+    hint.GetArgs<HINT_SELECTOBJ>().m_pPBoard = &pPBoard;
+    hint.GetArgs<HINT_SELECTOBJ>().m_pDrawObj = pObj;
     UpdateAllViews(NULL, HINT_SELECTOBJ, &hint);
 }
 
@@ -521,8 +521,8 @@ void CGamDoc::SelectObjectListOnBoard(CPlayBoard& pPBoard, CPtrList* pList)
 
     // Use hint to add object to select list
     CGamDocHint hint;
-    hint.m_pPBoard = &pPBoard;
-    hint.m_pPtrList = pList;
+    hint.GetArgs<HINT_SELECTOBJLIST>().m_pPBoard = &pPBoard;
+    hint.GetArgs<HINT_SELECTOBJLIST>().m_pPtrList = pList;
     UpdateAllViews(NULL, HINT_SELECTOBJLIST, &hint);
 }
 
@@ -608,8 +608,8 @@ void CGamDoc::IndicateBoardPlotLine(CPlayBoard* pPBrd, CPoint ptA, CPoint ptB)
     pPBrd->AddIndicatorObject(pObj);
 
     CGamDocHint hint;
-    hint.m_pPBoard = pPBrd;
-    hint.m_pDrawObj = pObj;
+    hint.GetArgs<HINT_UPDATEOBJECT>().m_pPBoard = pPBrd;
+    hint.GetArgs<HINT_UPDATEOBJECT>().m_pDrawObj = pObj;
     UpdateAllViews(NULL, HINT_UPDATEOBJECT, &hint);
 }
 
@@ -629,8 +629,8 @@ void CGamDoc::IndicateBoardPiece(CPlayBoard* pPBrd, CPoint ptCtr, CSize size)
     pPBrd->AddIndicatorObject(pObj);
 
     CGamDocHint hint;
-    hint.m_pPBoard = pPBrd;
-    hint.m_pDrawObj = pObj;
+    hint.GetArgs<HINT_UPDATEOBJECT>().m_pPBoard = pPBrd;
+    hint.GetArgs<HINT_UPDATEOBJECT>().m_pDrawObj = pObj;
     UpdateAllViews(NULL, HINT_UPDATEOBJECT, &hint);
 }
 
@@ -661,8 +661,8 @@ void CGamDoc::FlushAllSelections()
 
     // Use hint to flush select lists.
     CGamDocHint hint;
-    hint.m_pPBoard = NULL;
-    hint.m_pDrawObj = NULL;
+    hint.GetArgs<HINT_SELECTOBJ>().m_pPBoard = NULL;
+    hint.GetArgs<HINT_SELECTOBJ>().m_pDrawObj = NULL;
     UpdateAllViews(NULL, HINT_SELECTOBJ, &hint);
 }
 
@@ -685,11 +685,11 @@ void CGamDoc::FlushAllIndicators()
     }
     // Use hint to flush select lists.
     CGamDocHint hint;
-    hint.m_pPBoard = NULL;
-    hint.m_pDrawObj = NULL;
+    hint.GetArgs<HINT_SELECTOBJ>().m_pPBoard = NULL;
+    hint.GetArgs<HINT_SELECTOBJ>().m_pDrawObj = NULL;
     UpdateAllViews(NULL, HINT_SELECTOBJ, &hint);
     // Use hint to flush tool tip indicators
-    UpdateAllViews(NULL, HINT_CLEARINDTIP, &hint);
+    UpdateAllViews(NULL, HINT_CLEARINDTIP);
 }
 
 void CGamDoc::UpdateAllBoardIndicators(CPlayBoard& pPBrd)
@@ -701,8 +701,8 @@ void CGamDoc::UpdateAllBoardIndicators(CPlayBoard& pPBrd)
     {
         CDrawObj& pObj = **pos;
         CGamDocHint hint;
-        hint.m_pPBoard = &pPBrd;
-        hint.m_pDrawObj = &pObj;
+        hint.GetArgs<HINT_UPDATEOBJECT>().m_pPBoard = &pPBrd;
+        hint.GetArgs<HINT_UPDATEOBJECT>().m_pDrawObj = &pObj;
         UpdateAllViews(NULL, HINT_UPDATEOBJECT, &hint);
     }
 }

--- a/GP/GamDoc4.cpp
+++ b/GP/GamDoc4.cpp
@@ -513,8 +513,9 @@ void CGamDoc::SelectObjectOnBoard(CPlayBoard& pPBoard, CDrawObj* pObj)
 
 /////////////////////////////////////////////////////////////////////////////
 
-void CGamDoc::SelectObjectListOnBoard(CPlayBoard& pPBoard, CPtrList* pList)
+void CGamDoc::SelectObjectListOnBoard(CPlayBoard& pPBoard, const std::vector<CB::not_null<CDrawObj*>>& pList)
 {
+    ASSERT(!"this appears to be dead code");
     if (IsQuietPlayback()) return;
     // If board isn't visible, open it.
     MakeSurePBoardVisible(pPBoard);
@@ -522,7 +523,7 @@ void CGamDoc::SelectObjectListOnBoard(CPlayBoard& pPBoard, CPtrList* pList)
     // Use hint to add object to select list
     CGamDocHint hint;
     hint.GetArgs<HINT_SELECTOBJLIST>().m_pPBoard = &pPBoard;
-    hint.GetArgs<HINT_SELECTOBJLIST>().m_pPtrList = pList;
+    hint.GetArgs<HINT_SELECTOBJLIST>().m_pPtrList = &pList;
     UpdateAllViews(NULL, HINT_SELECTOBJLIST, &hint);
 }
 

--- a/GP/GamDoc4.cpp
+++ b/GP/GamDoc4.cpp
@@ -109,10 +109,10 @@ void CGamDoc::LoadAndActivateMoveFile(LPCSTR pszPathName)
 
         CMoveList::iterator pos = ++pHist->m_pMList->begin();
         ASSERT(pos != pHist->m_pMList->end());
-        CGameStateRcd* pRcd = static_cast<CGameStateRcd*>(pHist->m_pMList->GetAt(pos));
+        CMoveRecord& temp = pHist->m_pMList->GetAt(pos);
         BOOL bUpdatedGameState = FALSE;
 
-        if (pRcd->GetType() != CMoveRecord::mrecState)
+        if (temp.GetType() != CMoveRecord::mrecState)
         {
             AfxMessageBox(IDS_MSG_NOGAMESTATE, MB_OK | MB_ICONINFORMATION);
             m_nFirstMove = size_t(0);           // Restart location (state rec)
@@ -120,10 +120,11 @@ void CGamDoc::LoadAndActivateMoveFile(LPCSTR pszPathName)
         }
         else
         {
+            CGameStateRcd& pRcd = static_cast<CGameStateRcd&>(temp);
             // See if the file's game state matches the current game
             // state. If not, give option to update game to file's state.
-            pRcd->GetGameState().SetDocument(this);
-            if (!pRcd->GetGameState().CompareState())
+            pRcd.GetGameState().SetDocument(this);
+            if (!pRcd.GetGameState().CompareState())
             {
                 // File's positions don't match current games' positions.
                 CSelectStateDialog dlg;
@@ -133,7 +134,7 @@ void CGamDoc::LoadAndActivateMoveFile(LPCSTR pszPathName)
                 if (dlg.m_nState == 0)
                 {
                     // Use the current game state
-                    pRcd->GetGameState().RestoreState();
+                    pRcd.GetGameState().RestoreState();
                     // Make sure we account for possible deletions
                     // of pieces in move file (for crash resistance)
                     GetPieceTable()->PurgeUndefinedPieceIDs();
@@ -257,11 +258,12 @@ BOOL CGamDoc::LoadAndActivateHistory(size_t nHistRec)
 
         CMoveList::iterator pos = ++m_pMoves->begin();
         ASSERT(pos != m_pMoves->end());
-        CGameStateRcd* pRcd = static_cast<CGameStateRcd*>(m_pMoves->GetAt(pos));
-        ASSERT(pRcd->GetType() == CMoveRecord::mrecState);
+        CMoveRecord& temp = m_pMoves->GetAt(pos);
+        ASSERT(temp.GetType() == CMoveRecord::mrecState);
+        CGameStateRcd& pRcd = static_cast<CGameStateRcd&>(temp);
 
         // Use the history game state
-        pRcd->GetGameState().RestoreState();
+        pRcd.GetGameState().RestoreState();
 
         // Make sure we account for possible deletions
         // of pieces in move file (for crash resistance)
@@ -385,11 +387,11 @@ void CGamDoc::FinishHistoryPlayback()
         not destroy pMove, and then let destroying m_pHistMoves
         take care of destroying pMove? */
 
-    CGameStateRcd* pMove = static_cast<CGameStateRcd*>(m_pHistMoves->front().get());
-    ASSERT(pMove != NULL);
-    ASSERT(pMove->GetType() == CMoveRecord::mrecState);
+    CMoveRecord& temp = *m_pHistMoves->front();
+    ASSERT(temp.GetType() == CMoveRecord::mrecState);
+    CGameStateRcd& pMove = static_cast<CGameStateRcd&>(temp);
 
-    if (!pMove->GetGameState().RestoreState())
+    if (!pMove.GetGameState().RestoreState())
     {
         AfxMessageBox(IDS_ERR_FAILEDRESTORE, MB_OK | MB_ICONEXCLAMATION);
     }

--- a/GP/GamDoc5.cpp
+++ b/GP/GamDoc5.cpp
@@ -125,48 +125,48 @@ void CGamDoc::SetGameElementString(GameElement gelem, LPCTSTR pszString)
     }
 }
 
-GameElement CGamDoc::GetGameElementCodeForObject(CDrawObj* pDObj,
+GameElement CGamDoc::GetGameElementCodeForObject(const CDrawObj& pDObj,
     BOOL bBottomSide /* = FALSE */)
 {
-    if (pDObj->GetType() == CDrawObj::drawPieceObj)
+    if (pDObj.GetType() == CDrawObj::drawPieceObj)
     {
-        CPieceObj* pObj = (CPieceObj*)pDObj;
-        PieceID pid = pObj->m_pid;
+        const CPieceObj& pObj = static_cast<const CPieceObj&>(pDObj);
+        PieceID pid = pObj.m_pid;
         int nSide = GetPieceTable()->IsFrontUp(pid) ? 0 : 1;
         if (bBottomSide) nSide ^= 1;        // Toggle the side
         return MakePieceElement(pid, nSide);
     }
-    else if (pDObj->GetType() == CDrawObj::drawMarkObj)
+    else if (pDObj.GetType() == CDrawObj::drawMarkObj)
     {
-        CMarkObj* pObj = (CMarkObj*)pDObj;
-        return MakeObjectIDElement(pObj->GetObjectID());
+        const CMarkObj& pObj = static_cast<const CMarkObj&>(pDObj);
+        return MakeObjectIDElement(pObj.GetObjectID());
     }
     return (GameElement)0;
 }
 
-GameElement CGamDoc::GetVerifiedGameElementCodeForObject(CDrawObj* pDObj,
+GameElement CGamDoc::GetVerifiedGameElementCodeForObject(const CDrawObj& pDObj,
     BOOL bBottomSide /* = FALSE */)
 {
     GameElement elem = (GameElement)-1;
-    if (pDObj->GetType() == CDrawObj::drawPieceObj)
+    if (pDObj.GetType() == CDrawObj::drawPieceObj)
     {
-        CPieceObj* pObj = (CPieceObj*)pDObj;
-        PieceID pid = pObj->m_pid;
+        const CPieceObj& pObj = static_cast<const CPieceObj&>(pDObj);
+        PieceID pid = pObj.m_pid;
         int nSide = GetPieceTable()->IsFrontUp(pid) ? 0 : 1;
         if (bBottomSide) nSide ^= 1;        // Toggle the side
 
         elem = MakePieceElement(pid, nSide);
-        if (!HasGameElementString(elem) || pObj->IsOwnedButNotByCurrentPlayer())
+        if (!HasGameElementString(elem) || pObj.IsOwnedButNotByCurrentPlayer())
             elem = (GameElement)-1;
     }
-    else if (pDObj->GetType() == CDrawObj::drawMarkObj)
+    else if (pDObj.GetType() == CDrawObj::drawMarkObj)
     {
-        CMarkObj* pObj = (CMarkObj*)pDObj;
-        elem = MakeObjectIDElement(pObj->GetObjectID());
+        const CMarkObj& pObj = static_cast<const CMarkObj&>(pDObj);
+        elem = MakeObjectIDElement(pObj.GetObjectID());
         if (!HasGameElementString(elem))
         {
             // Try the actual marker ID for string existance.
-            elem = MakeMarkerElement(pObj->m_mid);
+            elem = MakeMarkerElement(pObj.m_mid);
             if (!HasGameElementString(elem))
                 elem = (GameElement)-1;
         }
@@ -174,22 +174,22 @@ GameElement CGamDoc::GetVerifiedGameElementCodeForObject(CDrawObj* pDObj,
     return elem;
 }
 
-void CGamDoc::GetTipTextForObject(CDrawObj* pDObj, CString &strTip,
+void CGamDoc::GetTipTextForObject(const CDrawObj& pDObj, CString &strTip,
     CString* pStrTitle /* = NULL */)
 {
-    if (pDObj->GetType() == CDrawObj::drawPieceObj)
+    if (pDObj.GetType() == CDrawObj::drawPieceObj)
     {
-        CPieceObj* pObj = (CPieceObj*)pDObj;
-        PieceID pid = pObj->m_pid;
+        const CPieceObj& pObj = static_cast<const CPieceObj&>(pDObj);
+        PieceID pid = pObj.m_pid;
         int nSide = GetPieceTable()->IsFrontUp(pid) ? 0 : 1;
         strTip = GetGameElementString(MakePieceElement(pid, nSide));
     }
-    else if (pDObj->GetType() == CDrawObj::drawMarkObj)
+    else if (pDObj.GetType() == CDrawObj::drawMarkObj)
     {
-        CMarkObj* pObj = (CMarkObj*)pDObj;
-        strTip = GetGameElementString(MakeObjectIDElement(pObj->GetObjectID()));
+        const CMarkObj& pObj = static_cast<const CMarkObj&>(pDObj);
+        strTip = GetGameElementString(MakeObjectIDElement(pObj.GetObjectID()));
         if (strTip.IsEmpty())
-            strTip = GetGameElementString(MakeMarkerElement(pObj->m_mid));
+            strTip = GetGameElementString(MakeMarkerElement(pObj.m_mid));
     }
 }
 
@@ -224,7 +224,7 @@ void CGamDoc::DoEditPieceText(PieceID pid, BOOL bEditTop)
         SetObjectText(elemDown, dlg.m_strText.IsEmpty() ? NULL : (LPCTSTR)dlg.m_strText);
 }
 
-void CGamDoc::DoEditObjectText(CDrawObj* pDObj)
+void CGamDoc::DoEditObjectText(const CDrawObj& pDObj)
 {
     CEditElementTextDialog dlg;
 
@@ -233,9 +233,9 @@ void CGamDoc::DoEditObjectText(CDrawObj* pDObj)
 
     dlg.m_strText = strTip;
 
-    if (pDObj->GetType() == CDrawObj::drawPieceObj)
+    if (pDObj.GetType() == CDrawObj::drawPieceObj)
     {
-        PieceID pid = ((CPieceObj*)pDObj)->m_pid;
+        PieceID pid = static_cast<const CPieceObj&>(pDObj).m_pid;
         if (GetPieceTable()->Is2Sided(pid))
         {
             dlg.m_bDoubleSided = TRUE;
@@ -253,9 +253,9 @@ void CGamDoc::DoEditObjectText(CDrawObj* pDObj)
     AssignNewMoveGroup();
 
     SetObjectText(elem, dlg.m_strText.IsEmpty() ? NULL : (LPCTSTR)dlg.m_strText);
-    if (dlg.m_bSetBothSides && pDObj->GetType() == CDrawObj::drawPieceObj)
+    if (dlg.m_bSetBothSides && pDObj.GetType() == CDrawObj::drawPieceObj)
     {
-        PieceID pid = ((CPieceObj*)pDObj)->m_pid;
+        PieceID pid = static_cast<const CPieceObj&>(pDObj).m_pid;
         if (GetPieceTable()->Is2Sided(pid))
         {
             int nSide = GetPieceTable()->IsFrontUp(pid) ? 0 : 1;

--- a/GP/GamState.h
+++ b/GP/GamState.h
@@ -26,6 +26,7 @@
 #define _GAMSTATE_H
 
 #include "MapStrng.h"
+#include "Trays.h"
 
 class CTrayManager;
 class CPieceTable;

--- a/GP/GeoBoard.cpp
+++ b/GP/GeoBoard.cpp
@@ -155,14 +155,14 @@ CBoard* CGeomorphicBoard::CreateBoard(CGamDoc* pDoc)
             if (pDwgList != NULL)
             {
                 CDrawList* pDwgListNewBase = pBrdNew->GetBaseDrawing(TRUE);
-                pDwgListNewBase->AppendWithOffset(pDwgList, pntOffset);
+                pDwgListNewBase->AppendWithOffset(*pDwgList, pntOffset);
             }
 
             pDwgList = pBrd.GetTopDrawing();
             if (pDwgList != NULL)
             {
                 CDrawList* pDwgListNewTop = pBrdNew->GetTopDrawing(TRUE);
-                pDwgListNewTop->AppendWithOffset(pDwgList, pntOffset);
+                pDwgListNewTop->AppendWithOffset(*pDwgList, pntOffset);
             }
         }
     }

--- a/GP/Gp.h
+++ b/GP/Gp.h
@@ -50,7 +50,7 @@
 #define WM_CENTERBOARDONPOINT   (WM_USER + 211) // WPARAM = POINT* in board coords
 #define WM_SHOWPLAYINGBOARD     (WM_USER + 212) // WPARAM = size_t Playing Board Index
 #define WM_WINSTATE_RESTORE     (WM_USER + 213) // No Args. Posted to project window
-#define WM_SELECT_BOARD_OBJLIST (WM_USER + 214) // WPARAM = CPlayBoard*, LPARAM = CPtrList*
+#define WM_SELECT_BOARD_OBJLIST (WM_USER + 214) // WPARAM = CPlayBoard*, LPARAM = const std::vector<CB::not_null<CDrawObj*>>*
 
 #define WM_MESSAGEBOX           (WM_USER + 215) // WPARAM = Opts. LPARAM = Msg ID or Ptr
 enum

--- a/GP/LBoxSlct.cpp
+++ b/GP/LBoxSlct.cpp
@@ -135,13 +135,13 @@ int  CSelectListBox::OnGetHitItemCodeAtPoint(CPoint point, CRect& rct)
 
     if (!rctLeft.IsRectEmpty() && rctLeft.PtInRect(point))
     {
-        CDrawObj* pObj = (CDrawObj*)MapIndexToItem(nIndex);
+        CDrawObj* pObj = MapIndexToItem(nIndex);
         elem = m_pDoc->GetVerifiedGameElementCodeForObject(pObj);
         rct = rctLeft;
     }
     else if (!rctRight.IsRectEmpty() && rctRight.PtInRect(point))
     {
-        CDrawObj* pObj = (CDrawObj*)MapIndexToItem(nIndex);
+        CDrawObj* pObj = MapIndexToItem(nIndex);
         elem = m_pDoc->GetVerifiedGameElementCodeForObject(pObj, TRUE);
         rct = rctRight;
     }

--- a/GP/LBoxSlct.cpp
+++ b/GP/LBoxSlct.cpp
@@ -136,13 +136,13 @@ int  CSelectListBox::OnGetHitItemCodeAtPoint(CPoint point, CRect& rct)
     if (!rctLeft.IsRectEmpty() && rctLeft.PtInRect(point))
     {
         CDrawObj& pObj = MapIndexToItem(nIndex);
-        elem = m_pDoc->GetVerifiedGameElementCodeForObject(&pObj);
+        elem = m_pDoc->GetVerifiedGameElementCodeForObject(pObj);
         rct = rctLeft;
     }
     else if (!rctRight.IsRectEmpty() && rctRight.PtInRect(point))
     {
         CDrawObj& pObj = MapIndexToItem(nIndex);
-        elem = m_pDoc->GetVerifiedGameElementCodeForObject(&pObj, TRUE);
+        elem = m_pDoc->GetVerifiedGameElementCodeForObject(pObj, TRUE);
         rct = rctRight;
     }
     else
@@ -165,8 +165,8 @@ void CSelectListBox::OnGetTipTextForItemCode(int nItemCode,
 BOOL CSelectListBox::OnDoesItemHaveTipText(size_t nItem)
 {
     CDrawObj& pObj = MapIndexToItem(nItem);
-    GameElement elem1 = m_pDoc->GetVerifiedGameElementCodeForObject(&pObj, FALSE);
-    GameElement elem2 = m_pDoc->GetVerifiedGameElementCodeForObject(&pObj, TRUE);
+    GameElement elem1 = m_pDoc->GetVerifiedGameElementCodeForObject(pObj, FALSE);
+    GameElement elem2 = m_pDoc->GetVerifiedGameElementCodeForObject(pObj, TRUE);
     return elem1 != (GameElement)-1 || elem2 != (GameElement)-1;
 }
 

--- a/GP/LBoxSlct.cpp
+++ b/GP/LBoxSlct.cpp
@@ -70,7 +70,7 @@ BOOL CSelectListBox::OnDragSetup(DragInfo* pDI)
     if (!IsMultiSelect())
     {
         m_multiSelList.clear();
-        m_multiSelList.push_back(GetCurMapItem());
+        m_multiSelList.push_back(&GetCurMapItem());
     }
     pDI->m_dragType = DRAG_SELECTVIEW;
     pDI->GetSubInfo<DRAG_SELECTVIEW>().m_ptrArray = &GetMappedMultiSelectList();
@@ -135,14 +135,14 @@ int  CSelectListBox::OnGetHitItemCodeAtPoint(CPoint point, CRect& rct)
 
     if (!rctLeft.IsRectEmpty() && rctLeft.PtInRect(point))
     {
-        CDrawObj* pObj = MapIndexToItem(nIndex);
-        elem = m_pDoc->GetVerifiedGameElementCodeForObject(pObj);
+        CDrawObj& pObj = MapIndexToItem(nIndex);
+        elem = m_pDoc->GetVerifiedGameElementCodeForObject(&pObj);
         rct = rctLeft;
     }
     else if (!rctRight.IsRectEmpty() && rctRight.PtInRect(point))
     {
-        CDrawObj* pObj = MapIndexToItem(nIndex);
-        elem = m_pDoc->GetVerifiedGameElementCodeForObject(pObj, TRUE);
+        CDrawObj& pObj = MapIndexToItem(nIndex);
+        elem = m_pDoc->GetVerifiedGameElementCodeForObject(&pObj, TRUE);
         rct = rctRight;
     }
     else
@@ -164,9 +164,9 @@ void CSelectListBox::OnGetTipTextForItemCode(int nItemCode,
 
 BOOL CSelectListBox::OnDoesItemHaveTipText(size_t nItem)
 {
-    CDrawObj* pObj = (CDrawObj*)MapIndexToItem(nItem);
-    GameElement elem1 = m_pDoc->GetVerifiedGameElementCodeForObject(pObj, FALSE);
-    GameElement elem2 = m_pDoc->GetVerifiedGameElementCodeForObject(pObj, TRUE);
+    CDrawObj& pObj = MapIndexToItem(nItem);
+    GameElement elem1 = m_pDoc->GetVerifiedGameElementCodeForObject(&pObj, FALSE);
+    GameElement elem2 = m_pDoc->GetVerifiedGameElementCodeForObject(&pObj, TRUE);
     return elem1 != (GameElement)-1 || elem2 != (GameElement)-1;
 }
 
@@ -174,15 +174,15 @@ BOOL CSelectListBox::OnDoesItemHaveTipText(size_t nItem)
 
 void CSelectListBox::OnGetItemDebugString(size_t nIndex, CString& str)
 {
-    CDrawObj* pDObj = (CDrawObj*)MapIndexToItem(nIndex);
-    if (pDObj->GetType() == CDrawObj::drawPieceObj)
+    CDrawObj& pDObj = MapIndexToItem(nIndex);
+    if (pDObj.GetType() == CDrawObj::drawPieceObj)
     {
-        PieceID pid = ((CPieceObj*)pDObj)->m_pid;
+        PieceID pid = static_cast<CPieceObj&>(pDObj).m_pid;
         str.Format("[pid:%d] ", value_preserving_cast<UINT>(static_cast<WORD>(pid)));
     }
-    else if (pDObj->GetType() == CDrawObj::drawMarkObj)
+    else if (pDObj.GetType() == CDrawObj::drawMarkObj)
     {
-        MarkID mid = ((CMarkObj*)pDObj)->m_mid;
+        MarkID mid = static_cast<CMarkObj&>(pDObj).m_mid;
         str.Format("[mid:%d] ", value_preserving_cast<UINT>(static_cast<WORD>(mid)));
     }
 }
@@ -217,14 +217,14 @@ void CSelectListBox::OnItemDraw(CDC* pDC, size_t nIndex, UINT nAction, UINT nSta
 
 TileID CSelectListBox::GetTileID(BOOL bActiveIfApplies, size_t nIndex)
 {
-    CDrawObj* pDObj = (CDrawObj*)MapIndexToItem(nIndex);
+    CDrawObj& pDObj = MapIndexToItem(nIndex);
 
-    if (pDObj->GetType() == CDrawObj::drawPieceObj)
+    if (pDObj.GetType() == CDrawObj::drawPieceObj)
     {
         CPieceTable* pPTbl = m_pDoc->GetPieceTable();
         ASSERT(pPTbl != NULL);
 
-        PieceID pid = ((CPieceObj*)pDObj)->m_pid;
+        PieceID pid = static_cast<CPieceObj&>(pDObj).m_pid;
 
         if (!m_pDoc->IsScenario() && pPTbl->IsPieceOwned(pid) &&
             !pPTbl->IsPieceOwnedBy(pid, m_pDoc->GetCurrentPlayerMask()))
@@ -248,11 +248,11 @@ TileID CSelectListBox::GetTileID(BOOL bActiveIfApplies, size_t nIndex)
             pPTbl->GetInactiveTileID(pid);
 
     }
-    else if (pDObj->GetType() == CDrawObj::drawMarkObj)
+    else if (pDObj.GetType() == CDrawObj::drawMarkObj)
     {
         if (!bActiveIfApplies) return nullTid;      // Inactive side doesn't apply
 
-        MarkID mid = ((CMarkObj*)pDObj)->m_mid;
+        MarkID mid = static_cast<CMarkObj&>(pDObj).m_mid;
         CMarkManager* pMMgr = m_pDoc->GetMarkManager();
         ASSERT(pMMgr != NULL);
         return pMMgr->GetMark(mid).m_tid;

--- a/GP/MapFace.cpp
+++ b/GP/MapFace.cpp
@@ -63,16 +63,11 @@ TileID CTileFacingMap::CreateFacingTileID(ElementState state, TileID baseTileID)
     tile.CreateBitmapOfTile(&bmap);
     dibSrc.BitmapToDIB(&bmap, GetAppPalette());
 
-    CDib* pRDib = Rotate16BitDib(&dibSrc, nAngleDegCW, m_pTMgr->GetTransparentColor());
-    if (pRDib == NULL)
-        AfxThrowMemoryException();
-    std::unique_ptr<CBitmap> pBMapFull = pRDib->DIBToBitmap(GetAppPalette());
-    ASSERT(pBMapFull != NULL);
+    OwnerPtr<CDib> pRDib = Rotate16BitDib(&dibSrc, nAngleDegCW, m_pTMgr->GetTransparentColor());
+    OwnerPtr<CBitmap> pBMapFull = pRDib->DIBToBitmap(GetAppPalette());
     BITMAP bmapInfo;
     pBMapFull->GetObject(sizeof(BITMAP), &bmapInfo);
     CSize sizeFull(bmapInfo.bmWidth, bmapInfo.bmHeight);
-
-    delete pRDib;
 
     // Generate rotated halfScale scale bitmap of tile...
 
@@ -81,15 +76,10 @@ TileID CTileFacingMap::CreateFacingTileID(ElementState state, TileID baseTileID)
     dibSrc.BitmapToDIB(&bmap, GetAppPalette());
 
     pRDib = Rotate16BitDib(&dibSrc, nAngleDegCW, m_pTMgr->GetTransparentColor());
-    if (pRDib == NULL)
-        AfxThrowMemoryException();
-    std::unique_ptr<CBitmap> pBMapHalf = pRDib->DIBToBitmap(GetAppPalette());
+    OwnerPtr<CBitmap> pBMapHalf = pRDib->DIBToBitmap(GetAppPalette());
 
-    ASSERT(pBMapHalf != NULL);
     pBMapHalf->GetObject(sizeof(BITMAP), &bmapInfo);
     CSize sizeHalf(bmapInfo.bmWidth, bmapInfo.bmHeight);
-
-    delete pRDib;
 
     // Fetch color of small scale tile
     m_pTMgr->GetTile(baseTileID, &tile, smallScale);

--- a/GP/MoveHist.cpp
+++ b/GP/MoveHist.cpp
@@ -99,18 +99,18 @@ void CHistRecord::Serialize(CArchive& ar)
         ar >> m_strDescr;
         if (CGamDoc::GetLoadingVersion() >= NumVersion(2, 90))
         {
-            m_pMList.reset();
+            m_pMList = nullptr;
             BYTE fMoveExist;
             ar >> fMoveExist;
             if (fMoveExist)
             {
-                m_pMList.reset(new CMoveList);
+                m_pMList = MakeOwner<CMoveList>();
                 m_pMList->Serialize(ar);
             }
         }
         else
         {
-            m_pMList.reset();
+            m_pMList = nullptr;
             ar >> m_dwFilePos;
             if (CGamDoc::GetLoadingVersion() >= NumVersion(0, 59))
             {

--- a/GP/MoveHist.cpp
+++ b/GP/MoveHist.cpp
@@ -59,9 +59,9 @@ void CHistoryTable::Serialize(CArchive& ar)
         ar >> wSize;
         for (WORD i = 0; i < wSize; i++)
         {
-            CHistRecord* pRcd = new CHistRecord;
+            OwnerPtr<CHistRecord> pRcd = new CHistRecord;
             pRcd->Serialize(ar);
-            AddNewHistRecord(pRcd);
+            AddNewHistRecord(std::move(pRcd));
         }
     }
 }
@@ -72,7 +72,7 @@ CHistRecord::CHistRecord()
 {
     m_nGamFileVersion = NumVersion(fileGamVerMajor, fileGamVerMinor);
     m_dwFilePos = 0;
-    m_pMList = NULL;
+    m_pMList = nullptr;
 }
 
 void CHistRecord::Serialize(CArchive& ar)

--- a/GP/MoveHist.h
+++ b/GP/MoveHist.h
@@ -46,14 +46,14 @@ public:
 
 // The history table stores a record of playback in
 // chronological order.
-// ptr since objects xfer between gamdoc and here
-class CHistoryTable : private std::vector<std::unique_ptr<CHistRecord>>
+// ptr since objects xfer between gamdoc and here (TODO:  maybe switch ptr to obj?)
+class CHistoryTable : private std::vector<OwnerPtr<CHistRecord>>
 {
 public:
     ~CHistoryTable() { Clear(); }
     // ------- //
     size_t GetNumHistRecords() const { return size(); }
-    void AddNewHistRecord(CHistRecord* pHist) { ASSERT(pHist); push_back(std::unique_ptr<CHistRecord>(pHist)); }
+    void AddNewHistRecord(OwnerPtr<CHistRecord> pHist) { push_back(std::move(pHist)); }
     CHistRecord& GetHistRecord(size_t nIndex)
         { return *at(nIndex).get(); }
     // ------- //

--- a/GP/MoveHist.h
+++ b/GP/MoveHist.h
@@ -32,7 +32,7 @@ public:
     CTime   m_timeAbsorbed;         // Time record entered history
     CString m_strTitle;             // User title of move packet
     CString m_strDescr;             // User description of move packet
-    std::unique_ptr<CMoveList> m_pMList;            // Move list for this record (>= Ver2.90)
+    OwnerOrNullPtr<CMoveList> m_pMList;            // Move list for this record (>= Ver2.90)
     DWORD   m_dwFilePos;            // Location of move list in game file (< Ver2.90)
     // We need to save the version of the game file
     // when the moves were absorbed.

--- a/GP/MoveHist.h
+++ b/GP/MoveHist.h
@@ -55,7 +55,7 @@ public:
     size_t GetNumHistRecords() const { return size(); }
     void AddNewHistRecord(OwnerPtr<CHistRecord> pHist) { push_back(std::move(pHist)); }
     CHistRecord& GetHistRecord(size_t nIndex)
-        { return *at(nIndex).get(); }
+        { return *at(nIndex); }
     // ------- //
     void Clear();
     void Serialize(CArchive& ar);

--- a/GP/MoveMgr.cpp
+++ b/GP/MoveMgr.cpp
@@ -623,7 +623,7 @@ void CBoardMarkerMove::DoMove(CGamDoc* pDoc, int nMoveWithinGroup)
     else
     {
         // Need to create since doesn't currently exist
-        pObj = pDoc->CreateMarkerObject(pPBrdDest, m_mid, m_ptCtr, m_dwObjID);
+        pObj = &pDoc->CreateMarkerObject(pPBrdDest, m_mid, m_ptCtr, m_dwObjID);
 
         CRect rct = pObj->GetRect();
         CPoint ptCtr = GetMidRect(rct);
@@ -985,15 +985,14 @@ void CGameStateRcd::DumpToTextFile(CFile& file)
 void CMovePlotList::SavePlotList(CDrawList* pDwg)
 {
     m_tblPlot.RemoveAll();
-    POSITION pos;
-    for (pos = pDwg->GetHeadPosition(); pos != NULL; )
+    for (CDrawList::iterator pos = pDwg->begin(); pos != pDwg->end(); ++pos)
     {
-        CLine* pObj = (CLine*)pDwg->GetNext(pos);
-        ASSERT(pObj);
-        if (pObj->GetType() == CDrawObj::drawLine)
+        CDrawObj& pObj = **pos;
+        if (pObj.GetType() == CDrawObj::drawLine)
         {
-            m_tblPlot.Add((DWORD)MAKELONG(pObj->m_ptBeg.x, pObj->m_ptBeg.y));
-            m_tblPlot.Add((DWORD)MAKELONG(pObj->m_ptEnd.x, pObj->m_ptEnd.y));
+            CLine& pLObj = static_cast<CLine&>(pObj);
+            m_tblPlot.Add((DWORD)MAKELONG(pLObj.m_ptBeg.x, pLObj.m_ptBeg.y));
+            m_tblPlot.Add((DWORD)MAKELONG(pLObj.m_ptEnd.x, pLObj.m_ptEnd.y));
         }
     }
 }

--- a/GP/MoveMgr.cpp
+++ b/GP/MoveMgr.cpp
@@ -695,9 +695,9 @@ void CObjectDelete::DoMove(CGamDoc* pDoc, int nMoveWithinGroup)
 
     if (pPBoard != NULL)
     {
-        CPtrList list;
-        list.AddHead(pObj);
-        pDoc->DeleteObjectsInList(&list);
+        std::vector<CB::not_null<CDrawObj*>> list;
+        list.push_back(pObj);
+        pDoc->DeleteObjectsInTable(list);
     }
 }
 

--- a/GP/MoveMgr.cpp
+++ b/GP/MoveMgr.cpp
@@ -322,7 +322,7 @@ void CPieceSetSide::DoMove(CGamDoc* pDoc, int nMoveWithinGroup)
     CPieceObj* pObj;
 
     if (pDoc->FindPieceCurrentLocation(m_pid, pTray, pPBoard, &pObj))
-        pDoc->InvertPlayingPieceOnBoard(pObj, pPBoard);
+        pDoc->InvertPlayingPieceOnBoard(*pObj, pPBoard);
     else
         pDoc->InvertPlayingPieceInTray(m_pid);
 }
@@ -393,7 +393,7 @@ void CPieceSetFacing::DoMove(CGamDoc* pDoc, int nMoveWithinGroup)
     CPieceObj* pObj;
 
     if (pDoc->FindPieceCurrentLocation(m_pid, pTray, pPBoard, &pObj))
-        pDoc->ChangePlayingPieceFacingOnBoard(pObj, pPBoard, m_nFacingDegCW);
+        pDoc->ChangePlayingPieceFacingOnBoard(*pObj, pPBoard, m_nFacingDegCW);
     else
         pDoc->ChangePlayingPieceFacingInTray(m_pid, m_nFacingDegCW);
 }
@@ -533,7 +533,7 @@ void CMarkerSetFacing::DoMove(CGamDoc* pDoc, int nMoveWithinGroup)
     CPlayBoard* pPBoard = pDoc->FindObjectOnBoard(m_dwObjID, &pObj);
 
     if (pPBoard != NULL)
-        pDoc->ChangeMarkerFacingOnBoard((CMarkObj*)pObj, pPBoard, m_nFacingDegCW);
+        pDoc->ChangeMarkerFacingOnBoard(*static_cast<CMarkObj*>(pObj), pPBoard, m_nFacingDegCW);
     else
         ASSERT(FALSE);          // SHOULDN'T HAPPEN
 }

--- a/GP/MoveMgr.h
+++ b/GP/MoveMgr.h
@@ -25,7 +25,8 @@
 #ifndef _MOVEMGR_H
 #define _MOVEMGR_H
 
-#include <list>
+//#include <list>
+#include "GamState.h"
 
 ///////////////////////////////////////////////////////////////////////
 
@@ -319,12 +320,14 @@ class CGameState;
 class CGameStateRcd : public CMoveRecord
 {
 public:
-    CGameStateRcd() { m_eType = mrecState; m_pState = NULL; }
-    CGameStateRcd(CGameState* pState)
-        { m_eType = mrecState; m_pState = pState; }
-    ~CGameStateRcd();
+    CGameStateRcd() { m_eType = mrecState; }
+    CGameStateRcd(CGameState* pState) :
+        m_pState(pState)
+    { m_eType = mrecState; }
+    ~CGameStateRcd() = default;
     // -------- //
-    CGameState* GetGameState() { return m_pState; }
+    // m_pState should only be null in CMoveList::Serialize
+    CGameState& GetGameState() { return *m_pState; }
 
     virtual void DoMove(CGamDoc* pDoc, int nMoveWithinGroup);
 
@@ -334,7 +337,7 @@ public:
     virtual void DumpToTextFile(CFile& file);
 #endif
 protected:
-    CGameState*     m_pState;
+    OwnerOrNullPtr<CGameState> m_pState;
 };
 
 ///////////////////////////////////////////////////////////////////////
@@ -468,7 +471,7 @@ public:
 
 // Operations
 public:
-    static CMoveList* CloneMoveList(CGamDoc* pDoc, CMoveList& pMoveList);
+    static OwnerPtr<CMoveList> CloneMoveList(CGamDoc* pDoc, CMoveList& pMoveList);
 
     void AssignNewMoveGroup() { m_nSeqNum++; }
     iterator AppendMoveRecord(OwnerPtr<CMoveRecord> pRec);

--- a/GP/MoveMgr.h
+++ b/GP/MoveMgr.h
@@ -507,13 +507,13 @@ public:
     size_t DoMove(CGamDoc* pDoc, size_t nIndex, BOOL bAutoStepHiddenMove = TRUE);
     void IncrementSkipCount(BOOL bKeepInd) { m_nSkipCount++; m_bSkipKeepInd = bKeepInd; }
 
-    CMoveRecord* GetAt(iterator pos)
-        { return pos->get(); }
-    CMoveRecord* GetNext(iterator& pos)
-        { return pos++->get(); }
-    CMoveRecord* GetPrev(iterator& pos)
+    CMoveRecord& GetAt(iterator pos)
+        { return **pos; }
+    CMoveRecord& GetNext(iterator& pos)
+        { return **pos++; }
+    CMoveRecord& GetPrev(iterator& pos)
     {
-        CMoveRecord* retval = pos->get();
+        CMoveRecord& retval = **pos;
         // decrementing MFC head position --> null, so emulate that
         if (pos != begin())
         {
@@ -525,8 +525,8 @@ public:
         }
         return retval;
     }
-    CMoveRecord* GetFirstRecord()
-        { return front().get(); }
+    CMoveRecord& GetFirstRecord()
+        { return *front(); }
 
     void Clear();
     void Serialize(CArchive& ar, BOOL bSaveUndo = TRUE);

--- a/GP/PBoard.cpp
+++ b/GP/PBoard.cpp
@@ -532,10 +532,12 @@ BoardID CPBoardManager::IssueGeoSerialNumber()
 
 bool CPBoardManager::GetPBoardList(std::vector<BoardID>& tblBrds) const
 {
+    ASSERT(tblBrds.empty());
     if (IsEmpty())
         return false;
 
-    for (size_t i = 0; i < GetNumPBoards(); i++)
+    tblBrds.reserve(tblBrds.size() + GetNumPBoards());
+    for (size_t i = size_t(0); i < GetNumPBoards(); i++)
         tblBrds.push_back(GetPBoard(i).GetSerialNumber());
 
     return true;
@@ -544,7 +546,8 @@ bool CPBoardManager::GetPBoardList(std::vector<BoardID>& tblBrds) const
 // Find all existing play boards are not in the caller's list.
 void CPBoardManager::FindPBoardsNotInList(const std::vector<BoardID>& tblBrdSerNum, std::vector<CB::not_null<CPlayBoard*>>& tblNotInList)
 {
-    for (size_t i = 0; i < GetNumPBoards(); i++)
+    ASSERT(tblNotInList.empty());
+    for (size_t i = size_t(0); i < GetNumPBoards(); i++)
     {
         if (std::find(tblBrdSerNum.begin(), tblBrdSerNum.end(), GetPBoard(i).GetSerialNumber()) == tblBrdSerNum.end())
         {

--- a/GP/PBoard.cpp
+++ b/GP/PBoard.cpp
@@ -156,12 +156,12 @@ void CPlayBoard::Draw(CDC* pDC, CRect* pDrawRct, TileScale eScale)
     ASSERT(m_pPceList);
 
     if (m_bIVisible && !m_bIndOnTop)
-        m_pIndList->Draw(pDC, pDrawRct, eScale);
+        m_pIndList->Draw(CheckedDeref(pDC), pDrawRct, eScale);
 
-    m_pPceList->Draw(pDC, pDrawRct, eScale, TRUE, FALSE, !m_bPVisible, m_bLockedDrawnBeneath);
+    m_pPceList->Draw(CheckedDeref(pDC), pDrawRct, eScale, TRUE, FALSE, !m_bPVisible, m_bLockedDrawnBeneath);
 
     if (m_bIVisible && m_bIndOnTop)
-        m_pIndList->Draw(pDC, pDrawRct, eScale);
+        m_pIndList->Draw(CheckedDeref(pDC), pDrawRct, eScale);
 }
 
 //////////////////////////////////////////////////////////////////////
@@ -233,7 +233,7 @@ BOOL CPlayBoard::IsObjectOnBoard(CDrawObj *pObj)
 
 void CPlayBoard::RemoveObject(CDrawObj* pObj)
 {
-    m_pPceList->RemoveObject(pObj);
+    m_pPceList->RemoveObject(CheckedDeref(pObj));
 }
 
 //////////////////////////////////////////////////////////////////////
@@ -302,8 +302,8 @@ CPlayBoard CPlayBoard::Clone(CGamDoc *pDoc)
 
 void CPlayBoard::Restore(CGamDoc *pDoc, CPlayBoard& pBrd)
 {
-    m_pPceList->Restore(pDoc, pBrd.m_pPceList.get());
-    m_pIndList->Restore(pDoc, pBrd.m_pIndList.get());
+    m_pPceList->Restore(pDoc, *pBrd.m_pPceList);
+    m_pIndList->Restore(pDoc, *pBrd.m_pIndList);
     m_bPlotMode = pBrd.m_bPlotMode;
     m_ptPrevPlot = pBrd.m_ptPrevPlot;
     m_nSerialNum = pBrd.m_nSerialNum;
@@ -316,11 +316,11 @@ bool CPlayBoard::Compare(CPlayBoard& pBrd)
         return FALSE;
     if (m_pPceList == NULL || pBrd.m_pPceList == NULL)
         return FALSE;
-    if (!m_pPceList->Compare(pBrd.m_pPceList.get()))
+    if (!m_pPceList->Compare(*pBrd.m_pPceList))
         return FALSE;
     if (m_pIndList == NULL || pBrd.m_pIndList == NULL)
         return FALSE;
-    return m_pIndList->Compare(pBrd.m_pIndList.get());
+    return m_pIndList->Compare(*pBrd.m_pIndList);
 }
 
 void CPlayBoard::Serialize(CArchive& ar)

--- a/GP/PBoard.cpp
+++ b/GP/PBoard.cpp
@@ -542,7 +542,7 @@ bool CPBoardManager::GetPBoardList(std::vector<BoardID>& tblBrds) const
 }
 
 // Find all existing play boards are not in the caller's list.
-void CPBoardManager::FindPBoardsNotInList(const std::vector<BoardID>& tblBrdSerNum, std::vector<CPlayBoard*>& tblNotInList)
+void CPBoardManager::FindPBoardsNotInList(const std::vector<BoardID>& tblBrdSerNum, std::vector<CB::not_null<CPlayBoard*>>& tblNotInList)
 {
     for (size_t i = 0; i < GetNumPBoards(); i++)
     {

--- a/GP/PBoard.cpp
+++ b/GP/PBoard.cpp
@@ -43,15 +43,6 @@ static char THIS_FILE[] = __FILE__;
 
 //////////////////////////////////////////////////////////////////////
 
-void CPlayBoard::UniqueFontID::Reset(FontID f)
-{
-    if (fid != 0)
-    {
-        CGamDoc::GetFontManager()->DeleteFont(fid);
-    }
-    fid = f;
-}
-
 void CPlayBoard::UniqueGeoBoard::Reset(CGeomorphicBoard* p, CGamDoc** gd)
 {
     if (p && !gd)
@@ -365,8 +356,7 @@ void CPlayBoard::Serialize(CArchive& ar)
         ar << (DWORD)m_crTextBoxColor;
 
         CFontTbl* pFontMgr = CGamDoc::GetFontManager();
-        FontID temp = m_fontID.Get();
-        pFontMgr->Archive(ar, temp);
+        pFontMgr->Archive(ar, m_fontID);
 
         ar << (WORD)m_bGridRectCenters;
         ar << (WORD)m_bSnapMovePlot;
@@ -471,10 +461,7 @@ void CPlayBoard::Serialize(CArchive& ar)
         ar >> dwTmp; m_crTextBoxColor = (COLORREF)dwTmp;
 
         CFontTbl* pFontMgr = CGamDoc::GetFontManager();
-        // CFontTbl::Archive assumes temp == 0
-        FontID temp = 0;
-        pFontMgr->Archive(ar, temp);
-        m_fontID.Reset(temp);
+        pFontMgr->Archive(ar, m_fontID);
 
         ar >> wTmp; m_bGridRectCenters = (BOOL)wTmp;
         ar >> wTmp; m_bSnapMovePlot = (BOOL)wTmp;

--- a/GP/PBoard.h
+++ b/GP/PBoard.h
@@ -105,12 +105,12 @@ public:
 public:
     void Draw(CDC* pDC, CRect* pDrawRct, TileScale eScale);
     // ------- //
-    CPieceObj* AddPiece(CPoint pnt, PieceID pid);
+    CPieceObj& AddPiece(CPoint pnt, PieceID pid);
     CPieceObj* FindPieceID(PieceID pid);
     CDrawObj* FindObjectID(ObjectID oid);
     //  void RemovePiece(CPieceObj* pObj);
     // ------- //
-    void AddIndicatorObject(CDrawObj* pObj);
+    void AddIndicatorObject(CDrawObj::OwnerPtr pObj);
     void FlushAllIndicators();
     // ------- //
     BOOL IsObjectOnBoard(CDrawObj *pObj);
@@ -214,8 +214,8 @@ protected:
     CPoint  m_ptPrevPlot;       // Previous selected move point
     BOOL    m_bPlotMode;        // Plot move mode
 
-    std::unique_ptr<CDrawList> m_pPceList;      // Piece draw list
-    std::unique_ptr<CDrawList> m_pIndList;      // Indicator draw list.
+    OwnerOrNullPtr<CDrawList> m_pPceList;      // Piece draw list
+    OwnerOrNullPtr<CDrawList> m_pIndList;      // Indicator draw list.
 
     // For reference only...
     CBoard*     m_pBoard;       // Loaded from Game Box

--- a/GP/PBoard.h
+++ b/GP/PBoard.h
@@ -162,21 +162,6 @@ public:
     COLORREF m_crTextColor;     // Text color
     COLORREF m_crTextBoxColor;  // Text box background color
     // allow default move operations to work right
-private:
-    class UniqueFontID
-    {
-    public:
-        UniqueFontID() noexcept = default;
-        UniqueFontID(const UniqueFontID&) = delete;
-        UniqueFontID& operator=(const UniqueFontID&) = delete;
-        UniqueFontID(UniqueFontID&& other) noexcept { fid = other.fid; other.fid = 0; }
-        UniqueFontID& operator=(UniqueFontID&& other) noexcept { std::swap(fid, other.fid); return *this; }
-        ~UniqueFontID() { Reset(); }
-        void Reset(FontID f = 0);
-        FontID Get() const { return fid; }
-    private:
-        FontID fid = 0;
-    };
 public:
     UniqueFontID m_fontID;          // Text font
 

--- a/GP/PBoard.h
+++ b/GP/PBoard.h
@@ -249,7 +249,7 @@ public:
     void AddBoard(CBoard* pBoard, BOOL bInheritSettings = TRUE);
     void AddBoard(CGeomorphicBoard* pGeoBoard, BOOL bInheritSettings = TRUE);
     void DeletePBoard(size_t nBrd);
-    void FindPBoardsNotInList(const std::vector<BoardID>& tblBrdSerNum, std::vector<CPlayBoard*>& tblNotInList);
+    void FindPBoardsNotInList(const std::vector<BoardID>& tblBrdSerNum, std::vector<CB::not_null<CPlayBoard*>>& tblNotInList);
 
     void ClearAllOwnership();
     void PropagateOwnerMaskToAllPieces(CGamDoc* pDoc);

--- a/GP/PPieces.cpp
+++ b/GP/PPieces.cpp
@@ -200,9 +200,9 @@ BOOL CPieceTable::IsFrontUp(PieceID pid)
     return GetPiece(pid).IsFrontUp();
 }
 
-BOOL CPieceTable::Is2Sided(PieceID pid)
+BOOL CPieceTable::Is2Sided(PieceID pid) const
 {
-    Piece* pPce;
+    const Piece* pPce;
     const PieceDef* pDef;
     GetPieceDefinitionPair(pid, pPce, pDef);
     return pDef->Is2Sided();
@@ -216,22 +216,22 @@ void CPieceTable::ClearAllOwnership()
         m_pPieceTbl[static_cast<PieceID>(i)].SetOwnerMask(0);
 }
 
-BOOL CPieceTable::IsPieceOwned(PieceID pid)
+BOOL CPieceTable::IsPieceOwned(PieceID pid) const
 {
     return GetPiece(pid).IsOwned();
 }
 
-BOOL CPieceTable::IsPieceOwnedBy(PieceID pid, DWORD dwOwnerMask)
+BOOL CPieceTable::IsPieceOwnedBy(PieceID pid, DWORD dwOwnerMask) const
 {
     return GetPiece(pid).IsOwnedBy(dwOwnerMask);
 }
 
-BOOL CPieceTable::IsOwnedButNotByCurrentPlayer(PieceID pid, CGamDoc* pDoc)
+BOOL CPieceTable::IsOwnedButNotByCurrentPlayer(PieceID pid, CGamDoc* pDoc) const
 {
     return IsPieceOwned(pid) && !IsPieceOwnedBy(pid, pDoc->GetCurrentPlayerMask());
 }
 
-DWORD CPieceTable::GetOwnerMask(PieceID pid)
+DWORD CPieceTable::GetOwnerMask(PieceID pid) const
 {
     return GetPiece(pid).GetOwnerMask();
 }
@@ -290,7 +290,7 @@ CSize CPieceTable::GetStackedSize(const std::vector<PieceID>& pTbl, int xDelta, 
 
 TileID CPieceTable::GetFrontTileID(PieceID pid, BOOL bWithFacing)
 {
-    Piece* pPce;
+    const Piece* pPce;
     const PieceDef* pDef;
     GetPieceDefinitionPair(pid, pPce, pDef);
 
@@ -305,7 +305,7 @@ TileID CPieceTable::GetFrontTileID(PieceID pid, BOOL bWithFacing)
 
 TileID CPieceTable::GetBackTileID(PieceID pid, BOOL bWithFacing)
 {
-    Piece* pPce;
+    const Piece* pPce;
     const PieceDef* pDef;
     GetPieceDefinitionPair(pid, pPce, pDef);
 
@@ -332,7 +332,7 @@ BOOL CPieceTable::IsPieceInvisible(PieceID pid)
 
 TileID CPieceTable::GetActiveTileID(PieceID pid, BOOL bWithFacing)
 {
-    Piece* pPce;
+    const Piece* pPce;
     const PieceDef* pDef;
     GetPieceDefinitionPair(pid, pPce, pDef);
     TileID tidBase = pPce->IsFrontUp() ? pDef->GetFrontTID() : pDef->GetBackTID();
@@ -346,7 +346,7 @@ TileID CPieceTable::GetActiveTileID(PieceID pid, BOOL bWithFacing)
 
 TileID CPieceTable::GetInactiveTileID(PieceID pid, BOOL bWithFacing)
 {
-    Piece* pPce;
+    const Piece* pPce;
     const PieceDef* pDef;
     GetPieceDefinitionPair(pid, pPce, pDef);
     TileID tidBase = pPce->IsFrontUp() ? pDef->GetBackTID() : pDef->GetFrontTID();
@@ -381,7 +381,7 @@ void CPieceTable::Clear()
 
 ///////////////////////////////////////////////////////////////////////
 
-Piece& CPieceTable::GetPiece(PieceID pid)
+const Piece& CPieceTable::GetPiece(PieceID pid) const
 {
     ASSERT(m_pPieceTbl != NULL);
     ASSERT(m_pPieceTbl.Valid(pid));
@@ -394,8 +394,8 @@ const PieceDef& CPieceTable::GetPieceDef(PieceID pid) const
     return m_pPMgr->GetPiece(pid);
 }
 
-void CPieceTable::GetPieceDefinitionPair(PieceID pid, Piece*& pPce,
-    const PieceDef*& pDef)
+void CPieceTable::GetPieceDefinitionPair(PieceID pid, const Piece*& pPce,
+    const PieceDef*& pDef) const
 {
     pPce = &GetPiece(pid);
 
@@ -536,7 +536,7 @@ void CPieceTable::DumpToTextFile(CFile& file)
     char szBfr[256];
     for (size_t i = 0; i < m_pPieceTbl.GetSize(); i++)
     {
-        Piece* pPce;
+        const Piece* pPce;
         const PieceDef* pDef;
         GetPieceDefinitionPair(static_cast<PieceID>(i), pPce, pDef);
         wsprintf(szBfr, "PieceID %5.5d: m_nSide=%02X, m_nFacing=%3u, "

--- a/GP/PPieces.h
+++ b/GP/PPieces.h
@@ -54,22 +54,22 @@ class Piece
     friend CPieceTable;     // For debug access
 
 public:
-    BOOL IsUsed()               { return m_nSide != 0xFF; }
+    BOOL IsUsed() const         { return m_nSide != 0xFF; }
     void SetUnused();
 
     void SetSide(int nSide)     { m_nSide = (BYTE)nSide; }
     void InvertSide()           { m_nSide ^= 1; }
-    int  GetSide()              { return (int)m_nSide; }
-    BOOL IsFrontUp()            { return m_nSide == 0; }
-    BOOL IsBackUp()             { return m_nSide == 1; }
+    int  GetSide() const        { return (int)m_nSide; }
+    BOOL IsFrontUp() const      { return m_nSide == 0; }
+    BOOL IsBackUp() const       { return m_nSide == 1; }
 
     void SetFacing(int nFacing) { m_nFacing = (WORD)nFacing; }
-    int  GetFacing()            { return (int)m_nFacing; }
+    int  GetFacing() const      { return (int)m_nFacing; }
 
-    DWORD GetOwnerMask()        { return m_dwOwnerMask; }
+    DWORD GetOwnerMask() const  { return m_dwOwnerMask; }
     void SetOwnerMask(DWORD dwMask) { m_dwOwnerMask = dwMask; }
-    BOOL IsOwned()              { return m_dwOwnerMask != 0; }
-    BOOL IsOwnedBy(DWORD dwMask)  { return (BOOL)(m_dwOwnerMask & dwMask); }
+    BOOL IsOwned() const        { return m_dwOwnerMask != 0; }
+    BOOL IsOwnedBy(DWORD dwMask) const { return (BOOL)(m_dwOwnerMask & dwMask); }
 
     BOOL operator != (const Piece& pce) const
         { return m_nSide != pce.m_nSide || m_nFacing != pce.m_nFacing; }
@@ -118,13 +118,13 @@ public:
     int  GetPieceFacing(PieceID pid);
 
     BOOL IsFrontUp(PieceID pid);
-    BOOL Is2Sided(PieceID pid);
+    BOOL Is2Sided(PieceID pid) const;
     BOOL IsPieceUsed(PieceID pid);
 
-    BOOL IsPieceOwned(PieceID pid);
-    BOOL IsPieceOwnedBy(PieceID pid, DWORD dwOwnerMask);
-    BOOL IsOwnedButNotByCurrentPlayer(PieceID pid, CGamDoc* pDoc);
-    DWORD GetOwnerMask(PieceID pid);
+    BOOL IsPieceOwned(PieceID pid) const;
+    BOOL IsPieceOwnedBy(PieceID pid, DWORD dwOwnerMask) const;
+    BOOL IsOwnedButNotByCurrentPlayer(PieceID pid, CGamDoc* pDoc) const;
+    DWORD GetOwnerMask(PieceID pid) const;
     void SetOwnerMask(PieceID pid, DWORD wwMask);
     void ClearAllOwnership();
 
@@ -171,9 +171,16 @@ protected:
     CPieceManager* m_pPMgr;         // To get access to piece defs.
     CGamDoc*       m_pDoc;          // Used for serialize fixups
     // ------- //
-    Piece& GetPiece(PieceID pid);
+    const Piece& GetPiece(PieceID pid) const;
+    Piece& GetPiece(PieceID pid) { return const_cast<Piece&>(std::as_const(*this).GetPiece(pid)); }
     const PieceDef& GetPieceDef(PieceID pid) const;
-    void GetPieceDefinitionPair(PieceID pid, Piece*& pPce, const PieceDef*& pDef);
+    void GetPieceDefinitionPair(PieceID pid, const Piece*& pPce, const PieceDef*& pDef) const;
+    void GetPieceDefinitionPair(PieceID pid, Piece*& pPce, const PieceDef*& pDef)
+    {
+        const Piece* temp;
+        GetPieceDefinitionPair(pid, temp, pDef);
+        pPce = const_cast<Piece*>(temp);
+    }
 
     TileID GetFacedTileID(PieceID pid, TileID tidBase, int nFacing, int nSide) const;
 };

--- a/GP/PalTray.cpp
+++ b/GP/PalTray.cpp
@@ -611,7 +611,7 @@ LRESULT CTrayPalette::OnDragItem(WPARAM wParam, LPARAM lParam)
         {
             CPtrList m_listPtr;
             CSelList* pSLst = pdi->GetSubInfo<DRAG_SELECTLIST>().m_selectList;
-            pSLst->LoadListWithObjectPtrs(&m_listPtr);
+            pSLst->LoadListWithObjectPtrs(m_listPtr);
             pSLst->PurgeList(FALSE);
             m_pDoc->AssignNewMoveGroup();
             size_t temp = m_pDoc->PlaceObjectListInTray(m_listPtr,

--- a/GP/PalTray.cpp
+++ b/GP/PalTray.cpp
@@ -917,7 +917,7 @@ void CTrayPalette::OnActTurnOver()
     size_t nSel = GetSelectedTray();
     CTrayManager* pYMgr = m_pDoc->GetTrayManager();
     CGamDocHint hint;
-    hint.m_pTray = &pYMgr->GetTraySet(nSel);
+    hint.GetArgs<HINT_TRAYCHANGE>().m_pTray = &pYMgr->GetTraySet(nSel);
     m_pDoc->UpdateAllViews(NULL, HINT_TRAYCHANGE, &hint);
 }
 
@@ -947,7 +947,7 @@ void CTrayPalette::OnActTurnoverAllPieces()
     size_t nSel = GetSelectedTray();
     CTrayManager* pYMgr = m_pDoc->GetTrayManager();
     CGamDocHint hint;
-    hint.m_pTray = &pYMgr->GetTraySet(nSel);
+    hint.GetArgs<HINT_TRAYCHANGE>().m_pTray = &pYMgr->GetTraySet(nSel);
     m_pDoc->UpdateAllViews(NULL, HINT_TRAYCHANGE, &hint);
 }
 

--- a/GP/PalTray.cpp
+++ b/GP/PalTray.cpp
@@ -614,7 +614,7 @@ LRESULT CTrayPalette::OnDragItem(WPARAM wParam, LPARAM lParam)
             pSLst->LoadTableWithObjectPtrs(m_listPtr, CSelList::otAll, FALSE);
             pSLst->PurgeList(FALSE);
             m_pDoc->AssignNewMoveGroup();
-            size_t temp = m_pDoc->PlaceObjectListInTray(m_listPtr,
+            size_t temp = m_pDoc->PlaceObjectTableInTray(m_listPtr,
                 pYGrp, nSel < 0 ? Invalid_v<size_t> : value_preserving_cast<size_t>(nSel));
             nSel = temp == Invalid_v<size_t> ? -1 : value_preserving_cast<int>(temp);
             m_pDoc->UpdateAllViews(NULL, HINT_UPDATESELECTLIST);

--- a/GP/PalTray.cpp
+++ b/GP/PalTray.cpp
@@ -609,9 +609,9 @@ LRESULT CTrayPalette::OnDragItem(WPARAM wParam, LPARAM lParam)
         }
         else        // DRAG_SELECTLIST
         {
-            CPtrList m_listPtr;
+            std::vector<CB::not_null<CDrawObj*>> m_listPtr;
             CSelList* pSLst = pdi->GetSubInfo<DRAG_SELECTLIST>().m_selectList;
-            pSLst->LoadListWithObjectPtrs(m_listPtr);
+            pSLst->LoadTableWithObjectPtrs(m_listPtr, CSelList::otAll, FALSE);
             pSLst->PurgeList(FALSE);
             m_pDoc->AssignNewMoveGroup();
             size_t temp = m_pDoc->PlaceObjectListInTray(m_listPtr,

--- a/GP/SelOPlay.cpp
+++ b/GP/SelOPlay.cpp
@@ -83,7 +83,7 @@ void CHandleList::AddHandle(POINT pntNew)
 
 /////////////////////////////////////////////////////////////////////
 
-void CSelection::DrawTracker(CDC* pDC, TrackMode eMode)
+void CSelection::DrawTracker(CDC& pDC, TrackMode eMode) const
 {
     if (eMode == trkSelected)
         DrawHandles(pDC);
@@ -91,17 +91,17 @@ void CSelection::DrawTracker(CDC* pDC, TrackMode eMode)
         DrawTrackingImage(pDC, eMode);
 }
 
-void CSelection::DrawHandles(CDC* pDC)
+void CSelection::DrawHandles(CDC& pDC) const
 {
     int n = GetHandleCount();
     for (int i = 0; i < n; i++)
     {
         CRect rect = GetHandleRect(i);
-        pDC->PatBlt(rect.left, rect.top, rect.Width(), rect.Height(), DSTINVERT);
+        pDC.PatBlt(rect.left, rect.top, rect.Width(), rect.Height(), DSTINVERT);
     }
 }
 
-int CSelection::HitTestHandles(CPoint point)
+int CSelection::HitTestHandles(CPoint point) const
 {
     int n = GetHandleCount();
     for (int i = 0; i < n; i++)
@@ -123,7 +123,7 @@ void CSelection::InvalidateHandles()
 }
 
 // Returns handle rectangle in logical coords.
-CRect CSelection::GetHandleRect(int nHandleID)
+CRect CSelection::GetHandleRect(int nHandleID) const
 {
     // Get the center of the handle in logical coords
     CPoint point = GetHandleLoc(nHandleID);
@@ -158,18 +158,18 @@ void CSelection::Open()
 //=---------------------------------------------------=//
 // Static methods...
 
-void CSelection::SetupTrackingDraw(CDC* pDC)
+void CSelection::SetupTrackingDraw(CDC& pDC)
 {
-    c_nPrvROP2 = pDC->SetROP2(R2_XORPEN);
-    c_pPrvPen = pDC->SelectObject(&c_penDot);
-    c_pPrvBrush = (CBrush*)pDC->SelectStockObject(NULL_BRUSH);
+    c_nPrvROP2 = pDC.SetROP2(R2_XORPEN);
+    c_pPrvPen = pDC.SelectObject(&c_penDot);
+    c_pPrvBrush = (CBrush*)pDC.SelectStockObject(NULL_BRUSH);
 }
 
-void CSelection::CleanUpTrackingDraw(CDC* pDC)
+void CSelection::CleanUpTrackingDraw(CDC& pDC)
 {
-    pDC->SetROP2(c_nPrvROP2);
-    pDC->SelectObject(c_pPrvPen);
-    pDC->SelectObject(c_pPrvBrush);
+    pDC.SetROP2(c_nPrvROP2);
+    pDC.SelectObject(c_pPrvPen);
+    pDC.SelectObject(c_pPrvBrush);
 }
 
 /////////////////////////////////////////////////////////////////////
@@ -181,15 +181,15 @@ void CSelLine::AddHandles(CHandleList& listHandles)
     listHandles.AddHandle(GetHandleLoc(hitPtB));
 }
 
-void CSelLine::DrawTrackingImage(CDC* pDC, TrackMode eMode)
+void CSelLine::DrawTrackingImage(CDC& pDC, TrackMode eMode) const
 {
     SetupTrackingDraw(pDC);
-    pDC->MoveTo(m_rect.left, m_rect.top);
-    pDC->LineTo(m_rect.right, m_rect.bottom);
+    pDC.MoveTo(m_rect.left, m_rect.top);
+    pDC.LineTo(m_rect.right, m_rect.bottom);
     CleanUpTrackingDraw(pDC);
 }
 
-HCURSOR CSelLine::GetHandleCursor(int nHandleID)
+HCURSOR CSelLine::GetHandleCursor(int nHandleID) const
 {
     LPCSTR id;
     switch (nHandleID)
@@ -205,7 +205,7 @@ HCURSOR CSelLine::GetHandleCursor(int nHandleID)
 }
 
 // Returns handle location in logical coords.
-CPoint CSelLine::GetHandleLoc(int nHandleID)
+CPoint CSelLine::GetHandleLoc(int nHandleID) const
 {
     int x, y;
 
@@ -230,7 +230,7 @@ void CSelLine::MoveHandle(int nHandle, CPoint point)
     }
 }
 
-CRect CSelLine::GetRect()
+CRect CSelLine::GetRect() const
 {
     CRect rct = m_rect;
     rct.NormalizeRect();
@@ -283,15 +283,15 @@ void CSelGeneric::AddHandles(CHandleList& listHandles)
     listHandles.AddHandle(GetHandleLoc(hitBottomLeft));
 }
 
-void CSelGeneric::DrawTrackingImage(CDC* pDC, TrackMode eMode)
+void CSelGeneric::DrawTrackingImage(CDC& pDC, TrackMode eMode) const
 {
     SetupTrackingDraw(pDC);
-    pDC->Rectangle(m_rect);
+    pDC.Rectangle(m_rect);
     CleanUpTrackingDraw(pDC);
 }
 
 // Returns handle location in logical coords.
-CPoint CSelGeneric::GetHandleLoc(int nHandleID)
+CPoint CSelGeneric::GetHandleLoc(int nHandleID) const
 {
     int x, y;
 
@@ -366,7 +366,7 @@ void CSelList::RegenerateHandleList()
     }
 }
 
-void CSelList::MoveHandle(UINT m_nHandle, CPoint point)
+void CSelList::MoveHandle(int m_nHandle, CPoint point)
 {
     // No support for multiselect handles.
     if (GetCount() == 1)
@@ -375,13 +375,13 @@ void CSelList::MoveHandle(UINT m_nHandle, CPoint point)
     CalcEnclosingRect();
 }
 
-CSelection* CSelList::AddObject(CDrawObj* pObj, BOOL bInvalidate)
+CSelection* CSelList::AddObject(CDrawObj& pObj, BOOL bInvalidate)
 {
     // Check if the object is already selected. If it is
     // remove it and then add the new definition.
     if (FindObject(pObj) != NULL)
         RemoveObject(pObj, TRUE);
-    CSelection* pSel = pObj->CreateSelectProxy(*m_pView);
+    CSelection* pSel = pObj.CreateSelectProxy(*m_pView);
     ASSERT(pSel != NULL);
     AddHead(pSel);
     CalcEnclosingRect();
@@ -391,24 +391,24 @@ CSelection* CSelList::AddObject(CDrawObj* pObj, BOOL bInvalidate)
     return pSel;
 }
 
-void CSelList::RemoveObject(CDrawObj* pObj, BOOL bInvalidate)
+void CSelList::RemoveObject(const CDrawObj& pObj, BOOL bInvalidate)
 {
     POSITION pos1, pos2;
     pos1 = GetHeadPosition();
-    if (pObj == m_pobjSnapReference)
+    if (&pObj == m_pobjSnapReference)
         m_pobjSnapReference = NULL;
     while (pos1 != NULL)
     {
         pos2 = pos1;
         CSelection* pSel = (CSelection*)GetNext(pos1);
-        if (pSel->m_pObj == pObj)
+        if (pSel->m_pObj == &pObj)
         {
             if (bInvalidate)
                 pSel->InvalidateHandles();  // So view updates
             RemoveAt(pos2);
             RegenerateHandleList();
-            if (pObj->GetType() == CDrawObj::drawPieceObj ||
-                    pObj->GetType() == CDrawObj::drawMarkObj)
+            if (pObj.GetType() == CDrawObj::drawPieceObj ||
+                    pObj.GetType() == CDrawObj::drawMarkObj)
                 m_pView->NotifySelectListChange();
             delete pSel;
             CalcEnclosingRect();
@@ -418,13 +418,13 @@ void CSelList::RemoveObject(CDrawObj* pObj, BOOL bInvalidate)
     ASSERT(FALSE);                      //// Object wasn't in list ////
 }
 
-BOOL CSelList::IsObjectSelected(const CDrawObj* pObj) const
+BOOL CSelList::IsObjectSelected(const CDrawObj& pObj) const
 {
     POSITION pos = GetHeadPosition();
     while (pos != NULL)
     {
         CSelection* pSel = (CSelection*)GetNext(pos);
-        if (pSel->m_pObj == pObj)
+        if (pSel->m_pObj == &pObj)
             return TRUE;
     }
     return FALSE;
@@ -435,7 +435,7 @@ void CSelList::SetSnapReferenceObject(CDrawObj* pObj)
     m_pobjSnapReference = pObj;
 }
 
-CRect CSelList::GetSnapReferenceRect()
+CRect CSelList::GetSnapReferenceRect() const
 {
     CRect rct;
     rct.SetRectEmpty();
@@ -481,13 +481,13 @@ void CSelList::Offset(CPoint ptDelta)
 // Called by view OnDraw(). This entry makes it possible
 // to turn off handles during a drag operation.
 
-void CSelList::OnDraw(CDC *pDC)
+void CSelList::OnDraw(CDC& pDC)
 {
     if (m_eTrkMode == trkSelected)
         DrawTracker(pDC);
 }
 
-void CSelList::DrawTracker(CDC *pDC, TrackMode eTrkMode)
+void CSelList::DrawTracker(CDC& pDC, TrackMode eTrkMode)
 {
     if (eTrkMode != trkCurrent)
         m_eTrkMode = eTrkMode;
@@ -501,7 +501,7 @@ void CSelList::DrawTracker(CDC *pDC, TrackMode eTrkMode)
         while (pos != NULL)
         {
             POINT pnt = m_listHandles.GetNext(pos);
-            pDC->PatBlt(pnt.x-3, pnt.y-3, 6, 6, DSTINVERT);
+            pDC.PatBlt(pnt.x-3, pnt.y-3, 6, 6, DSTINVERT);
         }
     }
     else
@@ -580,7 +580,7 @@ void CSelList::UpdateObjects(BOOL bInvalidate,
     RegenerateHandleList();
 }
 
-void CSelList::ForAllSelections(void (*pFunc)(CDrawObj* pObj, DWORD dwUser),
+void CSelList::ForAllSelections(void (*pFunc)(CDrawObj& pObj, DWORD dwUser),
     DWORD dwUserVal)
 {
     POSITION pos = GetHeadPosition();
@@ -588,11 +588,11 @@ void CSelList::ForAllSelections(void (*pFunc)(CDrawObj* pObj, DWORD dwUser),
     {
         CSelection* pSel = (CSelection*)GetNext(pos);
         ASSERT(pSel != NULL);
-        pFunc(pSel->m_pObj.get(), dwUserVal);
+        pFunc(*pSel->m_pObj, dwUserVal);
     }
 }
 
-CRect CSelList::GetPiecesEnclosingRect(BOOL bIncludeMarkers /* = TRUE */)
+CRect CSelList::GetPiecesEnclosingRect(BOOL bIncludeMarkers /* = TRUE */) const
 {
     CRect rct;
     rct.SetRectEmpty();
@@ -608,10 +608,10 @@ CRect CSelList::GetPiecesEnclosingRect(BOOL bIncludeMarkers /* = TRUE */)
     return rct;
 }
 
-void CSelList::LoadListWithObjectPtrs(CPtrList* pList,
+void CSelList::LoadListWithObjectPtrs(CPtrList& pList,
     BOOL bPiecesOnly /* = FALSE*/, BOOL bVisualOrder /* = FALSE */)
 {
-    pList->RemoveAll();
+    pList.RemoveAll();
     POSITION pos = GetHeadPosition();
     while (pos != NULL)
     {
@@ -620,10 +620,10 @@ void CSelList::LoadListWithObjectPtrs(CPtrList* pList,
         if (bPiecesOnly)
         {
             if (pSel->m_pObj->GetType() == CDrawObj::drawPieceObj)
-                pList->AddTail(pSel->m_pObj.get());
+                pList.AddTail(pSel->m_pObj.get());
         }
         else
-            pList->AddTail(pSel->m_pObj.get());
+            pList.AddTail(pSel->m_pObj.get());
     }
     // This is a backdoor cheat....Since we know the original view and
     // hence the board associated, we can call the draw list
@@ -763,11 +763,11 @@ void CSelList::DeselectIfDObjFlagsSet(DWORD dwFlagBits)
             tblDeselObjs.push_back(pSel->m_pObj.get());
     }
     // Then deselect them...
-    for (size_t i = 0; i < tblDeselObjs.size(); i++)
-        RemoveObject(tblDeselObjs.at(i), TRUE);
+    for (size_t i = size_t(0); i < tblDeselObjs.size(); i++)
+        RemoveObject(*tblDeselObjs.at(i), TRUE);
 }
 
-CSelection* CSelList::FindObject(CDrawObj* pObj) const
+CSelection* CSelList::FindObject(const CDrawObj& pObj) const
 {
     POSITION pos = GetHeadPosition();
     while (pos != NULL)
@@ -775,7 +775,7 @@ CSelection* CSelList::FindObject(CDrawObj* pObj) const
         POSITION posLast = pos;
         CSelection* pSel = (CSelection*)GetNext(pos);
         ASSERT(pSel != NULL);
-        if (pSel->m_pObj == pObj)
+        if (pSel->m_pObj == &pObj)
             return pSel;
     }
     return NULL;

--- a/GP/SelOPlay.cpp
+++ b/GP/SelOPlay.cpp
@@ -847,7 +847,7 @@ void CSelList::LoadTableWithOwnerStatePieceIDs(std::vector<PieceID>& pTbl, LoadF
 }
 
 // Loads the table with the CDrawObj pointers of playing pieces and markers.
-void CSelList::LoadTableWithObjectPtrs(std::vector<CDrawObj*>& pTbl, BOOL bVisualOrder /* = TRUE */)
+void CSelList::LoadTableWithObjectPtrs(std::vector<CB::not_null<CDrawObj*>>& pTbl, BOOL bVisualOrder /* = TRUE */)
 {
     pTbl.clear();
     POSITION pos = GetHeadPosition();

--- a/GP/SelOPlay.h
+++ b/GP/SelOPlay.h
@@ -81,18 +81,18 @@ public:
     RefPtr<CDrawObj> m_pObj;           // Associated object that is selected
     CRect     m_rect;           // Enclosing rect for selected object
 
-    virtual HCURSOR GetHandleCursor(int nHandle) /* override */
+    virtual HCURSOR GetHandleCursor(int nHandle) const /* override */
         { return AfxGetApp()->LoadStandardCursor(IDC_ARROW); }
-    virtual CRect GetRect() /* override */ { return m_rect; }
+    virtual CRect GetRect() const /* override */ { return m_rect; }
 
 // Operations
 public:
-    virtual int  HitTestHandles(CPoint point) /* override */;
+    virtual int HitTestHandles(CPoint point) const /* override */;
     // ------- //
     virtual void MoveHandle(int m_nHandle, CPoint point) /* override */ {}
     virtual void Offset(CPoint ptDelta) /* override */ { m_rect += ptDelta; }
     // ------- //
-    virtual void DrawTracker(CDC *pDC, TrackMode eMode) /* override */;
+    virtual void DrawTracker(CDC& pDC, TrackMode eMode) const /* override */;
     virtual void InvalidateHandles() /* override */;
     virtual void Invalidate() /* override */;
     virtual void UpdateObject(BOOL bInvalidate = TRUE,
@@ -103,18 +103,18 @@ public:
 
 // Miscellaneous Implementer's Overrides
 protected:
-    virtual CRect GetHandleRect(int nHandleID) /* override */;
-    virtual CPoint GetHandleLoc(int nHandleID) /* override */ = 0;
-    virtual int GetHandleCount() /* override */ = 0;
-    virtual void DrawHandles(CDC* pDC) /* override */;
-    virtual void DrawTrackingImage(CDC* pDC, TrackMode eMode) /* override */ = 0;
+    virtual CRect GetHandleRect(int nHandleID) const /* override */;
+    virtual CPoint GetHandleLoc(int nHandleID) const /* override */ = 0;
+    virtual int GetHandleCount() const /* override */ = 0;
+    virtual void DrawHandles(CDC& pDC) const /* override */;
+    virtual void DrawTrackingImage(CDC& pDC, TrackMode eMode) const /* override */ = 0;
 
 // Implementation
 protected:
     RefPtr<CPlayBoardView> m_pView;            // Selection's view
     // -- Class level support methods -- //
-    static void SetupTrackingDraw(CDC* pDC);
-    static void CleanUpTrackingDraw(CDC* pDC);
+    static void SetupTrackingDraw(CDC& pDC);
+    static void CleanUpTrackingDraw(CDC& pDC);
     // -- Class variables -- //
     static CPen     NEAR c_penDot;
     static int      NEAR c_nPrvROP2;
@@ -134,18 +134,18 @@ public:
 
 // Attributes
 public:
-    virtual CRect GetRect() override;
+    virtual CRect GetRect() const override;
 
 // Overrides
 public:
-    virtual HCURSOR GetHandleCursor(int nHandleID) override;
+    virtual HCURSOR GetHandleCursor(int nHandleID) const override;
     virtual void MoveHandle(int m_nHandle, CPoint point) override;
 
 protected:
     virtual void AddHandles(CHandleList& listHandles) override;
-    virtual void DrawTrackingImage(CDC* pDC, TrackMode eMode) override;
-    virtual CPoint GetHandleLoc(int nHandleID) override;
-    virtual int GetHandleCount() override { return 2; }
+    virtual void DrawTrackingImage(CDC& pDC, TrackMode eMode) const override;
+    virtual CPoint GetHandleLoc(int nHandleID) const override;
+    virtual int GetHandleCount() const override { return 2; }
     virtual void UpdateObject(BOOL bInvalidate = TRUE,
         BOOL bUpdateObjectExtent = TRUE) override;
 };
@@ -164,15 +164,15 @@ public:
 
 // Overrides
 public:
-    virtual HCURSOR GetHandleCursor(int nHandleID) override
+    virtual HCURSOR GetHandleCursor(int nHandleID) const override
         { return AfxGetApp()->LoadStandardCursor(IDC_ARROW); }
     virtual void MoveHandle(int m_nHandle, CPoint point) override {}
 
 protected:
     virtual void AddHandles(CHandleList& listHandles) override;
-    virtual void DrawTrackingImage(CDC* pDC, TrackMode eMode) override;
-    virtual CPoint GetHandleLoc(int nHandleID) override;
-    virtual int GetHandleCount() override { return 4; }
+    virtual void DrawTrackingImage(CDC& pDC, TrackMode eMode) const override;
+    virtual CPoint GetHandleLoc(int nHandleID) const override;
+    virtual int GetHandleCount() const override { return 4; }
     virtual void UpdateObject(BOOL bInvalidate = TRUE,
         BOOL bUpdateObjectExtent = TRUE) override;
 };
@@ -196,7 +196,7 @@ public:
     BOOL IsMultipleSelects() const { return GetCount() > 1; }
     BOOL IsSingleSelect() const { return GetCount() == 1; }
     BOOL IsAnySelects() const { return GetCount() > 0; }
-    BOOL IsObjectSelected(const CDrawObj* pObj) const;
+    BOOL IsObjectSelected(const CDrawObj& pObj) const;
     BOOL HasPieces() const;
     BOOL HasOwnedPieces() const;
     BOOL HasNonOwnedPieces() const;
@@ -206,25 +206,25 @@ public:
     BOOL IsMarkerSelected() const;
     // -------- //
     void SetMouseOffset(CSize size) { m_sizeMseOffset = size; }
-    CSize GetMouseOffset() { return m_sizeMseOffset; }
+    CSize GetMouseOffset() const { return m_sizeMseOffset; }
     // -------- //
     void SetSnapReferenceObject(CDrawObj* pObj);
-    CRect GetSnapReferenceRect();
+    CRect GetSnapReferenceRect() const;
     // -------- //
     CPlayBoardView& GetView() { return *m_pView; }
     void SetTrackingMode(TrackMode eTrkMode) { m_eTrkMode = eTrkMode; }
     TrackMode GetTrackingMode() const { return m_eTrkMode; }
-    CRect GetEnclosingRect() { return m_rctEncl; }
-    CRect GetPiecesEnclosingRect(BOOL bIncludeMarkers = TRUE);
+    CRect GetEnclosingRect() const { return m_rctEncl; }
+    CRect GetPiecesEnclosingRect(BOOL bIncludeMarkers = TRUE) const;
 
 // Operations
 public:
     CSelection* GetHead() { return (CSelection*)CPtrList::GetHead(); }
-    CSelection* AddObject(CDrawObj* pObj, BOOL bInvalidate = FALSE);
-    void RemoveObject(CDrawObj* pObj, BOOL bInvalidate = FALSE);
-    CSelection* FindObject(CDrawObj* pObj) const;
+    CSelection* AddObject(CDrawObj& pObj, BOOL bInvalidate = FALSE);
+    void RemoveObject(const CDrawObj& pObj, BOOL bInvalidate = FALSE);
+    CSelection* FindObject(const CDrawObj& pObj) const;
     // -------- //
-    void LoadListWithObjectPtrs(CPtrList* pList, BOOL bPiecesOnly = FALSE,
+    void LoadListWithObjectPtrs(CPtrList& pList, BOOL bPiecesOnly = FALSE,
         BOOL bVisualOrder = FALSE);
     void LoadTableWithPieceIDs(std::vector<PieceID>& pTbl, BOOL bVisualOrder = TRUE);
     void LoadTableWithObjectPtrs(std::vector<CB::not_null<CDrawObj*>>& pTbl, BOOL bVisualOrder = TRUE);
@@ -242,15 +242,15 @@ public:
     int  HitTestHandles(CPoint point);
     // -------- //
     void Offset(CPoint ptDelta);
-    void MoveHandle(UINT m_nHandle, CPoint point);
+    void MoveHandle(int m_nHandle, CPoint point);
     // -------- //
-    void OnDraw(CDC *pDC);  // Called by view OnDraw()
-    void DrawTracker(CDC *pDC, TrackMode eTrkMode = trkCurrent);
+    void OnDraw(CDC& pDC);  // Called by view OnDraw()
+    void DrawTracker(CDC& pDC, TrackMode eTrkMode = trkCurrent);
     // -------- //
     void UpdateObjects(BOOL bInvalidate = TRUE,
         BOOL bUpdateObjectExtent = TRUE );
     // -------- //
-    void ForAllSelections(void (*pFunc)(CDrawObj* pObj, DWORD dwUser),
+    void ForAllSelections(void (*pFunc)(CDrawObj& pObj, DWORD dwUser),
         DWORD dwUserVal);
 
     void Open();

--- a/GP/SelOPlay.h
+++ b/GP/SelOPlay.h
@@ -179,8 +179,16 @@ protected:
 
 /////////////////////////////////////////////////////////////////////
 
-class CSelList : public CPtrList
+class CSelList : private std::list<OwnerPtr<CSelection>>
 {
+    using BASE = std::list<OwnerPtr<CSelection>>;
+public:
+    using BASE::iterator;
+    using BASE::begin;
+    using BASE::empty;
+    using BASE::end;
+    using BASE::front;
+
 // Constructors
 public:
     CSelList(CPlayBoardView& pView) :
@@ -189,13 +197,15 @@ public:
         m_pobjSnapReference(NULL)
     {
     }
+    CSelList(const CSelList&) = delete;
+    CSelList& operator=(const CSelList&) = delete;
     ~CSelList() { PurgeList(FALSE); }
 
 // Attributes
 public:
-    BOOL IsMultipleSelects() const { return GetCount() > 1; }
-    BOOL IsSingleSelect() const { return GetCount() == 1; }
-    BOOL IsAnySelects() const { return GetCount() > 0; }
+    BOOL IsMultipleSelects() const { return size() > size_t(1); }
+    BOOL IsSingleSelect() const { return size() == size_t(1); }
+    BOOL IsAnySelects() const { return !empty(); }
     BOOL IsObjectSelected(const CDrawObj& pObj) const;
     BOOL HasPieces() const;
     BOOL HasOwnedPieces() const;
@@ -219,10 +229,9 @@ public:
 
 // Operations
 public:
-    CSelection* GetHead() { return (CSelection*)CPtrList::GetHead(); }
-    CSelection* AddObject(CDrawObj& pObj, BOOL bInvalidate = FALSE);
+    CSelection& AddObject(CDrawObj& pObj, BOOL bInvalidate = FALSE);
     void RemoveObject(const CDrawObj& pObj, BOOL bInvalidate = FALSE);
-    CSelection* FindObject(const CDrawObj& pObj) const;
+    const CSelection* FindObject(const CDrawObj& pObj) const;
     // -------- //
     enum ObjTypes { otInvalid, otPieces, otPiecesMarks, otAll };
     void LoadTableWithObjectPtrs(std::vector<CB::not_null<CDrawObj*>>& pTbl, ObjTypes objTypes,
@@ -236,10 +245,10 @@ public:
     void InvalidateList(BOOL bUpdate = FALSE);
     void PurgeList(BOOL bInvalidate = TRUE);
     // -------- //
-    void CountDObjFlags(DWORD dwFlagBits, int& nSet, int& nCleared);
+    void CountDObjFlags(DWORD dwFlagBits, int& nSet, int& nCleared) const;
     void DeselectIfDObjFlagsSet(DWORD dwFlagBits);
     // -------- //
-    int  HitTestHandles(CPoint point);
+    int  HitTestHandles(CPoint point) const;
     // -------- //
     void Offset(CPoint ptDelta);
     void MoveHandle(int m_nHandle, CPoint point);

--- a/GP/SelOPlay.h
+++ b/GP/SelOPlay.h
@@ -224,10 +224,10 @@ public:
     void RemoveObject(const CDrawObj& pObj, BOOL bInvalidate = FALSE);
     CSelection* FindObject(const CDrawObj& pObj) const;
     // -------- //
-    void LoadListWithObjectPtrs(CPtrList& pList, BOOL bPiecesOnly = FALSE,
-        BOOL bVisualOrder = FALSE);
+    enum ObjTypes { otInvalid, otPieces, otPiecesMarks, otAll };
+    void LoadTableWithObjectPtrs(std::vector<CB::not_null<CDrawObj*>>& pTbl, ObjTypes objTypes,
+        BOOL bVisualOrder);
     void LoadTableWithPieceIDs(std::vector<PieceID>& pTbl, BOOL bVisualOrder = TRUE);
-    void LoadTableWithObjectPtrs(std::vector<CB::not_null<CDrawObj*>>& pTbl, BOOL bVisualOrder = TRUE);
     // -------- //
     enum LoadFilter { LF_NOTOWNED, LF_OWNED, LF_BOTH };
     void LoadTableWithOwnerStatePieceIDs(std::vector<PieceID>& pTbl, LoadFilter eWantOwned, BOOL bVisualOrder = TRUE);

--- a/GP/SelOPlay.h
+++ b/GP/SelOPlay.h
@@ -72,12 +72,13 @@ class CSelection
 {
 // Constructors
 public:
-    CSelection(CPlayBoardView* pView, CDrawObj* pObj)
-        { m_pView = pView; m_pObj = pObj; }
+    CSelection(CPlayBoardView& pView, CDrawObj& pObj) :
+        m_pView(&pView), m_pObj(&pObj)
+    {}
 
 // Attributes
 public:
-    CDrawObj* m_pObj;           // Associated object that is selected
+    RefPtr<CDrawObj> m_pObj;           // Associated object that is selected
     CRect     m_rect;           // Enclosing rect for selected object
 
     virtual HCURSOR GetHandleCursor(int nHandle)
@@ -110,7 +111,7 @@ protected:
 
 // Implementation
 protected:
-    CPlayBoardView* m_pView;            // Selection's view
+    RefPtr<CPlayBoardView> m_pView;            // Selection's view
     // -- Class level support methods -- //
     static void SetupTrackingDraw(CDC* pDC);
     static void CleanUpTrackingDraw(CDC* pDC);
@@ -128,8 +129,8 @@ class CSelLine : public CSelection
 {
 // Constructors
 public:
-    CSelLine(CPlayBoardView* pView, CLine* pObj) : CSelection(pView, pObj)
-        { pObj->GetLine(m_rect.left, m_rect.top, m_rect.right, m_rect.bottom); }
+    CSelLine(CPlayBoardView& pView, CLine& pObj) : CSelection(pView, pObj)
+        { pObj.GetLine(m_rect.left, m_rect.top, m_rect.right, m_rect.bottom); }
 
 // Attributes
 public:
@@ -158,8 +159,8 @@ class CSelGeneric : public CSelection
 {
 // Constructors
 public:
-    CSelGeneric(CPlayBoardView* pView, CDrawObj* pObj) : CSelection(pView, pObj)
-        { m_rect = pObj->GetRect(); }
+    CSelGeneric(CPlayBoardView& pView, CDrawObj& pObj) : CSelection(pView, pObj)
+        { m_rect = pObj.GetRect(); }
 
 // Overrides
 public:
@@ -182,8 +183,12 @@ class CSelList : public CPtrList
 {
 // Constructors
 public:
-    CSelList(CPlayBoardView* pView) { m_pView = pView; m_pobjSnapReference = NULL; }
-    CSelList() { m_pView = NULL; m_eTrkMode = trkSelected; }
+    CSelList(CPlayBoardView& pView) :
+        m_pView(&pView),
+        m_eTrkMode(trkSelected),
+        m_pobjSnapReference(NULL)
+    {
+    }
     ~CSelList() { PurgeList(FALSE); }
 
 // Attributes
@@ -206,8 +211,7 @@ public:
     void SetSnapReferenceObject(CDrawObj* pObj);
     CRect GetSnapReferenceRect();
     // -------- //
-    void SetView(CPlayBoardView* pView) { m_pView = pView; }
-    CPlayBoardView* GetView() { return m_pView; }
+    CPlayBoardView& GetView() { return *m_pView; }
     void SetTrackingMode(TrackMode eTrkMode) { m_eTrkMode = eTrkMode; }
     TrackMode GetTrackingMode() const { return m_eTrkMode; }
     CRect GetEnclosingRect() { return m_rctEncl; }
@@ -259,7 +263,7 @@ protected:
 
 // Implementation - vars
 protected:
-    CPlayBoardView* m_pView;        // Selection's view
+    RefPtr<CPlayBoardView> m_pView;        // Selection's view
     TrackMode       m_eTrkMode;     // Current list tracking mode.
     CRect           m_rctEncl;      // Enclosing rect.
     CSize           m_sizeMseOffset;// Mouse offset from upper left m_rctEncl

--- a/GP/SelOPlay.h
+++ b/GP/SelOPlay.h
@@ -223,7 +223,7 @@ public:
     void LoadListWithObjectPtrs(CPtrList* pList, BOOL bPiecesOnly = FALSE,
         BOOL bVisualOrder = FALSE);
     void LoadTableWithPieceIDs(std::vector<PieceID>& pTbl, BOOL bVisualOrder = TRUE);
-    void LoadTableWithObjectPtrs(std::vector<CDrawObj*>& pTbl, BOOL bVisualOrder = TRUE);
+    void LoadTableWithObjectPtrs(std::vector<CB::not_null<CDrawObj*>>& pTbl, BOOL bVisualOrder = TRUE);
     // -------- //
     enum LoadFilter { LF_NOTOWNED, LF_OWNED, LF_BOTH };
     void LoadTableWithOwnerStatePieceIDs(std::vector<PieceID>& pTbl, LoadFilter eWantOwned, BOOL bVisualOrder = TRUE);

--- a/GP/SelOPlay.h
+++ b/GP/SelOPlay.h
@@ -81,33 +81,33 @@ public:
     RefPtr<CDrawObj> m_pObj;           // Associated object that is selected
     CRect     m_rect;           // Enclosing rect for selected object
 
-    virtual HCURSOR GetHandleCursor(int nHandle)
+    virtual HCURSOR GetHandleCursor(int nHandle) /* override */
         { return AfxGetApp()->LoadStandardCursor(IDC_ARROW); }
-    virtual CRect GetRect() { return m_rect; }
+    virtual CRect GetRect() /* override */ { return m_rect; }
 
 // Operations
 public:
-    virtual int  HitTestHandles(CPoint point);
+    virtual int  HitTestHandles(CPoint point) /* override */;
     // ------- //
-    virtual void MoveHandle(int m_nHandle, CPoint point) {}
-    virtual void Offset(CPoint ptDelta) { m_rect += ptDelta; }
+    virtual void MoveHandle(int m_nHandle, CPoint point) /* override */ {}
+    virtual void Offset(CPoint ptDelta) /* override */ { m_rect += ptDelta; }
     // ------- //
-    virtual void DrawTracker(CDC *pDC, TrackMode eMode);
-    virtual void InvalidateHandles();
-    virtual void Invalidate();
+    virtual void DrawTracker(CDC *pDC, TrackMode eMode) /* override */;
+    virtual void InvalidateHandles() /* override */;
+    virtual void Invalidate() /* override */;
     virtual void UpdateObject(BOOL bInvalidate = TRUE,
-        BOOL bUpdateObjectExtent = TRUE) {}
-    virtual void Open();
-    virtual void Close() {}
-    virtual void AddHandles(CHandleList& listHandles) = 0;
+        BOOL bUpdateObjectExtent = TRUE) /* override */ {}
+    virtual void Open() /* override */;
+    virtual void Close() /* override */ {}
+    virtual void AddHandles(CHandleList& listHandles) /* override */ = 0;
 
 // Miscellaneous Implementer's Overrides
 protected:
-    virtual CRect GetHandleRect(int nHandleID);
-    virtual CPoint GetHandleLoc(int nHandleID) = 0;
-    virtual int GetHandleCount() = 0;
-    virtual void DrawHandles(CDC* pDC);
-    virtual void DrawTrackingImage(CDC* pDC, TrackMode eMode) = 0;
+    virtual CRect GetHandleRect(int nHandleID) /* override */;
+    virtual CPoint GetHandleLoc(int nHandleID) /* override */ = 0;
+    virtual int GetHandleCount() /* override */ = 0;
+    virtual void DrawHandles(CDC* pDC) /* override */;
+    virtual void DrawTrackingImage(CDC* pDC, TrackMode eMode) /* override */ = 0;
 
 // Implementation
 protected:
@@ -134,20 +134,20 @@ public:
 
 // Attributes
 public:
-    virtual CRect GetRect();
+    virtual CRect GetRect() override;
 
 // Overrides
 public:
-    virtual HCURSOR GetHandleCursor(int nHandleID);
-    virtual void MoveHandle(int m_nHandle, CPoint point);
+    virtual HCURSOR GetHandleCursor(int nHandleID) override;
+    virtual void MoveHandle(int m_nHandle, CPoint point) override;
 
 protected:
-    virtual void AddHandles(CHandleList& listHandles);
-    virtual void DrawTrackingImage(CDC* pDC, TrackMode eMode);
-    virtual CPoint GetHandleLoc(int nHandleID);
-    virtual int GetHandleCount() { return 2; }
+    virtual void AddHandles(CHandleList& listHandles) override;
+    virtual void DrawTrackingImage(CDC* pDC, TrackMode eMode) override;
+    virtual CPoint GetHandleLoc(int nHandleID) override;
+    virtual int GetHandleCount() override { return 2; }
     virtual void UpdateObject(BOOL bInvalidate = TRUE,
-        BOOL bUpdateObjectExtent = TRUE);
+        BOOL bUpdateObjectExtent = TRUE) override;
 };
 
 /////////////////////////////////////////////////////////////////////
@@ -164,17 +164,17 @@ public:
 
 // Overrides
 public:
-    virtual HCURSOR GetHandleCursor(int nHandleID)
+    virtual HCURSOR GetHandleCursor(int nHandleID) override
         { return AfxGetApp()->LoadStandardCursor(IDC_ARROW); }
-    virtual void MoveHandle(int m_nHandle, CPoint point) {}
+    virtual void MoveHandle(int m_nHandle, CPoint point) override {}
 
 protected:
-    virtual void AddHandles(CHandleList& listHandles);
-    virtual void DrawTrackingImage(CDC* pDC, TrackMode eMode);
-    virtual CPoint GetHandleLoc(int nHandleID);
-    virtual int GetHandleCount() { return 4; }
+    virtual void AddHandles(CHandleList& listHandles) override;
+    virtual void DrawTrackingImage(CDC* pDC, TrackMode eMode) override;
+    virtual CPoint GetHandleLoc(int nHandleID) override;
+    virtual int GetHandleCount() override { return 4; }
     virtual void UpdateObject(BOOL bInvalidate = TRUE,
-        BOOL bUpdateObjectExtent = TRUE);
+        BOOL bUpdateObjectExtent = TRUE) override;
 };
 
 /////////////////////////////////////////////////////////////////////

--- a/GP/ToolPlay.cpp
+++ b/GP/ToolPlay.cpp
@@ -151,7 +151,7 @@ void CPSelectTool::OnLButtonDown(CPlayBoardView* pView, UINT nFlags,
     }
     // Object is under mouse. See if also selected. If not,
     // add to list.
-    if (!pSLst->IsObjectSelected(pObj))
+    if (!pSLst->IsObjectSelected(*pObj))
     {
         if ((nFlags & MK_SHIFT) == 0)       // Shift click adds to list
             pSLst->PurgeList(TRUE);         // Clear current select list
@@ -159,7 +159,7 @@ void CPSelectTool::OnLButtonDown(CPlayBoardView* pView, UINT nFlags,
             pView->SelectAllUnderPoint(point);
         else
         {
-            pSLst->AddObject(pObj, TRUE);
+            pSLst->AddObject(*pObj, TRUE);
             if (pObj->GetType() == CDrawObj::drawPieceObj ||
                     pObj->GetType() == CDrawObj::drawMarkObj)
                 pView->NotifySelectListChange();
@@ -178,7 +178,7 @@ void CPSelectTool::OnLButtonDown(CPlayBoardView* pView, UINT nFlags,
     // wont start until it expires.
     if ((nFlags & MK_SHIFT) != 0)
     {
-        pSLst->RemoveObject(pObj, TRUE);
+        pSLst->RemoveObject(*pObj, TRUE);
         return;
     }
     CPlayTool::OnLButtonDown(pView, nFlags, point);
@@ -254,11 +254,11 @@ void CPSelectTool::OnMouseMove(CPlayBoardView* pView, UINT nFlags, CPoint point)
         CClientDC dc(pView);
         pView->OnPrepareScaledDC(&dc, TRUE);
 
-        pSLst->DrawTracker(&dc, trkSizing); // Erase previous tracker
+        pSLst->DrawTracker(dc, trkSizing); // Erase previous tracker
 
         MoveSelections(pSLst, point);
 
-        pSLst->DrawTracker(&dc, trkSizing); // Erase previous tracker
+        pSLst->DrawTracker(dc, trkSizing); // Erase previous tracker
     }
     c_ptLast = point;               // Save new 'last' position
 }
@@ -327,7 +327,7 @@ void CPSelectTool::OnTimer(CPlayBoardView* pView, UINT nIDEvent)
 
         CClientDC dc(pView);
         pView->OnPrepareScaledDC(&dc, TRUE);
-        pSLst->DrawTracker(&dc, trkSelected);   // Turn off handles
+        pSLst->DrawTracker(dc, trkSelected);   // Turn off handles
 
         CPoint point;
         GetCursorPos(&point);
@@ -395,7 +395,7 @@ void CPSelectTool::StartSizingOperation(CPlayBoardView* pView, UINT nFlags,
     CPlayTool::OnLButtonDown(pView, nFlags, point);
     CClientDC dc(pView);
     pView->OnPrepareScaledDC(&dc, TRUE);
-    pSLst->DrawTracker(&dc, trkSizing);
+    pSLst->DrawTracker(dc, trkSizing);
 }
 
 void CPSelectTool::DrawSelectionRect(CDC* pDC, CRect* pRct)
@@ -467,7 +467,7 @@ BOOL CPSelectTool::ProcessAutoScroll(CPlayBoardView* pView)
                 DrawSelectionRect(&dc, &rect);
             }
             else
-                pSLst->DrawTracker(&dc);    // Turn off tracker
+                pSLst->DrawTracker(dc);    // Turn off tracker
 
             pView->OnScroll(nScrollID, 0, TRUE);
             pView->UpdateWindow();          // Redraw image content.
@@ -493,7 +493,7 @@ BOOL CPSelectTool::ProcessAutoScroll(CPlayBoardView* pView)
             {
                 MoveSelections(pSLst, point);// Offset the tracking data
                 c_ptLast = point;            // Save new 'last' position
-                pSLst->DrawTracker(&dc);    // Turn off tracker
+                pSLst->DrawTracker(dc);    // Turn off tracker
             }
             return TRUE;
         }
@@ -641,7 +641,7 @@ void CPShapeTool::OnLButtonDown(CPlayBoardView* pView, UINT nFlags, CPoint point
     int nDragHandle;
     pView->AdjustPoint(point);
     m_pObj = CreateDrawObj(pView, point, nDragHandle);
-    pSLst->AddObject(m_pObj, TRUE);
+    pSLst->AddObject(*m_pObj, TRUE);
     s_plySelectTool.StartSizingOperation(pView, nFlags, point, nDragHandle);
 }
 
@@ -735,7 +735,7 @@ void CPPlotTool::OnLButtonDown(CPlayBoardView* pView, UINT nFlags,
     {
         // Draw a line for each piece to the opening location
         CPtrList listObjs;
-        pView->GetSelectList()->LoadListWithObjectPtrs(&listObjs, FALSE);
+        pView->GetSelectList()->LoadListWithObjectPtrs(listObjs, FALSE);
         POSITION pos = listObjs.GetHeadPosition();
         while (pos != NULL)
         {

--- a/GP/ToolPlay.cpp
+++ b/GP/ToolPlay.cpp
@@ -734,15 +734,14 @@ void CPPlotTool::OnLButtonDown(CPlayBoardView* pView, UINT nFlags,
     if (pntPrev == CPoint(-1, -1))
     {
         // Draw a line for each piece to the opening location
-        CPtrList listObjs;
-        pView->GetSelectList()->LoadListWithObjectPtrs(listObjs, FALSE);
-        POSITION pos = listObjs.GetHeadPosition();
-        while (pos != NULL)
+        std::vector<CB::not_null<CDrawObj*>> listObjs;
+        pView->GetSelectList()->LoadTableWithObjectPtrs(listObjs, CSelList::otAll, FALSE);
+        for (auto pos = listObjs.begin() ; pos != listObjs.end() ; ++pos)
         {
-            CPieceObj* pObj = (CPieceObj*)listObjs.GetNext(pos);
-            ASSERT(pObj->GetType() == CDrawObj::drawPieceObj ||
-                pObj->GetType() == CDrawObj::drawMarkObj);
-            CRect rct = pObj->GetRect();
+            CDrawObj& pObj = **pos;
+            ASSERT(pObj.GetType() == CDrawObj::drawPieceObj ||
+                pObj.GetType() == CDrawObj::drawMarkObj);
+            CRect rct = pObj.GetRect();
             CPoint pnt = GetMidRect(rct);
             pDoc->IndicateBoardPlotLine(pPBrd, pnt, point);
         }

--- a/GP/ToolPlay.cpp
+++ b/GP/ToolPlay.cpp
@@ -49,7 +49,7 @@ const int scrollZone = 16;      // From INI?
 /////////////////////////////////////////////////////////////////
 // Class variables
 
-CPtrList CPlayTool::c_toolLib;          // Tool library
+std::vector<CPlayTool*> CPlayTool::c_toolLib;          // Tool library
 
 CPoint CPlayTool::c_ptDown;             // Mouse down location
 CPoint CPlayTool::c_ptLast;             // Last mouse location
@@ -64,22 +64,22 @@ static CPPlotTool       s_plyMovePlotTool;
 ////////////////////////////////////////////////////////////////////////
 // CPlayTool - Basic tool support (abstract class)
 
-CPlayTool::CPlayTool(PToolType eType)
+CPlayTool::CPlayTool(PToolType eType) :
+    m_eToolType(eType)
 {
-    m_eToolType = eType;
-    c_toolLib.AddTail(this);
+    size_t i = static_cast<size_t>(eType);
+    c_toolLib.resize(std::max(i + size_t(1), c_toolLib.size()));
+    ASSERT(!c_toolLib[i]);
+    c_toolLib[i] = this;
 }
 
-CPlayTool* CPlayTool::GetTool(PToolType eToolType)
+CPlayTool& CPlayTool::GetTool(PToolType eToolType)
 {
-    POSITION pos = c_toolLib.GetHeadPosition();
-    while (pos != NULL)
-    {
-        CPlayTool* pTool = (CPlayTool*)c_toolLib.GetNext(pos);
-        if (pTool->m_eToolType == eToolType)
-            return pTool;
-    }
-    return NULL;
+    size_t i = static_cast<size_t>(eToolType);
+    ASSERT(i < c_toolLib.size());
+    CPlayTool& retval = CheckedDeref(c_toolLib[i]);
+    ASSERT(retval.m_eToolType == eToolType);
+    return retval;
 }
 
 void CPlayTool::OnLButtonDown(CPlayBoardView* pView, UINT nFlags, CPoint point)

--- a/GP/ToolPlay.cpp
+++ b/GP/ToolPlay.cpp
@@ -374,11 +374,11 @@ BOOL CPSelectTool::OnSetCursor(CPlayBoardView* pView, UINT nHitTest)
     {
         // Check if cursor is over a handle. If it is,
         // get handle cursor.
-        CSelection* pSelObj = (CSelection*)pSLst->GetHead();
-        int nHandle = pSelObj->HitTestHandles(point);
+        CSelection& pSelObj = *pSLst->front();
+        int nHandle = pSelObj.HitTestHandles(point);
         if (nHandle >= 0)
         {
-            SetCursor(pSelObj->GetHandleCursor(nHandle));
+            SetCursor(pSelObj.GetHandleCursor(nHandle));
             return TRUE;
         }
     }

--- a/GP/ToolPlay.h
+++ b/GP/ToolPlay.h
@@ -49,11 +49,11 @@ public:
 
 // Attributes
 public:
-    PToolType m_eToolType;
+    const PToolType m_eToolType;
 
 // Operations
 public:
-    static CPlayTool* GetTool(PToolType eType);
+    static CPlayTool& GetTool(PToolType eType);
     // ----------- //
     virtual void OnLButtonDown(CPlayBoardView* pView, UINT nFlags, CPoint point);
     virtual void OnLButtonDblClk(CPlayBoardView* pView, UINT nFlags, CPoint point) {}
@@ -64,9 +64,10 @@ public:
         { return FALSE; }
 
 // Implementation
-public:
+private:
     // -- Class variables -- //
-    static CPtrList c_toolLib;
+    static std::vector<CPlayTool*> c_toolLib;
+protected:
     // Drag related vars....
     static CPoint c_ptDown;         // Document coords.
     static CPoint c_ptLast;

--- a/GP/VwPbrd.cpp
+++ b/GP/VwPbrd.cpp
@@ -361,7 +361,7 @@ LRESULT CPlayBoardView::OnMessageWindowState(WPARAM wParam, LPARAM lParam)
             for (size_t i = 0; i < tblObjPtrs.size(); i++)
             {
                 CDrawObj& pObj = *tblObjPtrs.at(i);
-                ar << value_preserving_cast<DWORD>(GetDocument()->GetGameElementCodeForObject(&pObj));
+                ar << value_preserving_cast<DWORD>(GetDocument()->GetGameElementCodeForObject(pObj));
             }
         }
         else
@@ -710,7 +710,7 @@ NASTY_GOTO_TARGET:
 
             if (dlg.DoModal() == IDOK)
             {
-                GameElement elem = pDoc->GetGameElementCodeForObject(&pObj);
+                GameElement elem = pDoc->GetGameElementCodeForObject(pObj);
                 pDoc->SetObjectText(elem, dlg.m_strText.IsEmpty() ? NULL :
                     (LPCTSTR)dlg.m_strText);
             }
@@ -1757,9 +1757,9 @@ LRESULT CPlayBoardView::OnMessageRotateRelative(WPARAM wParam, LPARAM lParam)
 
         CDrawObj& pDObj = **pos;
         if (pDObj.GetType() == CDrawObj::drawPieceObj)
-            pDoc->ChangePlayingPieceFacingOnBoard(&static_cast<CPieceObj&>(pDObj), m_pPBoard, nAngle);
+            pDoc->ChangePlayingPieceFacingOnBoard(static_cast<CPieceObj&>(pDObj), m_pPBoard, nAngle);
         else if (pDObj.GetType() == CDrawObj::drawMarkObj)
-            pDoc->ChangeMarkerFacingOnBoard(&static_cast<CMarkObj&>(pDObj), m_pPBoard, nAngle);
+            pDoc->ChangeMarkerFacingOnBoard(static_cast<CMarkObj&>(pDObj), m_pPBoard, nAngle);
         if (m_bWheelRotation &&
             (pDObj.GetType() == CDrawObj::drawPieceObj || pDObj.GetType() == CDrawObj::drawMarkObj))
         {
@@ -1840,12 +1840,12 @@ void CPlayBoardView::DoRotateRelative(BOOL bWheelRotation)
         CDrawObj& pDObj = **pos;
         if (pDObj.GetType() == CDrawObj::drawPieceObj)
         {
-            pDoc->ChangePlayingPieceFacingOnBoard(&static_cast<CPieceObj&>(pDObj),
+            pDoc->ChangePlayingPieceFacingOnBoard(static_cast<CPieceObj&>(pDObj),
                 m_pPBoard, m_tblCurAngles[i]);
         }
         else if (pDObj.GetType() == CDrawObj::drawMarkObj)
         {
-            pDoc->ChangeMarkerFacingOnBoard(&static_cast<CMarkObj&>(pDObj), m_pPBoard,
+            pDoc->ChangeMarkerFacingOnBoard(static_cast<CMarkObj&>(pDObj), m_pPBoard,
                 m_tblCurAngles[i]);
         }
         if (m_bWheelRotation &&
@@ -1875,11 +1875,11 @@ void CPlayBoardView::DoRotateRelative(BOOL bWheelRotation)
 
             if (pDObj.GetType() == CDrawObj::drawPieceObj)
             {
-                pDoc->ChangePlayingPieceFacingOnBoard(&static_cast<CPieceObj&>(pDObj), m_pPBoard, nAngle);
+                pDoc->ChangePlayingPieceFacingOnBoard(static_cast<CPieceObj&>(pDObj), m_pPBoard, nAngle);
             }
             else if (pDObj.GetType() == CDrawObj::drawMarkObj)
             {
-                pDoc->ChangeMarkerFacingOnBoard(&static_cast<CMarkObj&>(pDObj), m_pPBoard, nAngle);
+                pDoc->ChangeMarkerFacingOnBoard(static_cast<CMarkObj&>(pDObj), m_pPBoard, nAngle);
             }
             if (m_bWheelRotation &&
                 (pDObj.GetType() == CDrawObj::drawPieceObj || pDObj.GetType() == CDrawObj::drawMarkObj))
@@ -2110,7 +2110,7 @@ void CPlayBoardView::OnEditElementText()
     ASSERT(m_selList.IsSingleSelect() && (m_selList.HasMarkers() || m_selList.HasPieces()));
 
     CDrawObj& pDObj = *m_selList.GetHead()->m_pObj;
-    GetDocument()->DoEditObjectText(&pDObj);
+    GetDocument()->DoEditObjectText(pDObj);
     NotifySelectListChange();       // Make sure indicators are updated
 }
 

--- a/GP/VwPbrd.cpp
+++ b/GP/VwPbrd.cpp
@@ -355,13 +355,13 @@ LRESULT CPlayBoardView::OnMessageWindowState(WPARAM wParam, LPARAM lParam)
         // Save the select list
         if (m_selList.GetCount() > 0)
         {
-            std::vector<CDrawObj*> tblObjPtrs;
+            std::vector<CB::not_null<CDrawObj*>> tblObjPtrs;
             m_selList.LoadTableWithObjectPtrs(tblObjPtrs);
             ar << value_preserving_cast<DWORD>(tblObjPtrs.size());
             for (size_t i = 0; i < tblObjPtrs.size(); i++)
             {
-                CDrawObj* pObj = tblObjPtrs.at(i);
-                ar << value_preserving_cast<DWORD>(GetDocument()->GetGameElementCodeForObject(pObj));
+                CDrawObj& pObj = *tblObjPtrs.at(i);
+                ar << value_preserving_cast<DWORD>(GetDocument()->GetGameElementCodeForObject(&pObj));
             }
         }
         else
@@ -1387,7 +1387,7 @@ void CPlayBoardView::DoAutostackOfSelectedObjects(int xStagger, int yStagger)
 
     CPoint pntCenter(MidPnt(rct.left, rct.right), MidPnt(rct.top, rct.bottom));
 
-    std::vector<CDrawObj*> tblObjs;
+    std::vector<CB::not_null<CDrawObj*>> tblObjs;
     m_selList.LoadTableWithObjectPtrs(tblObjs);
 
     m_selList.PurgeList(TRUE);              // Purge former selections
@@ -1428,7 +1428,7 @@ void CPlayBoardView::OnActShuffleSelectedObjects()
 
     CPoint pntCenter(MidPnt(rct.left, rct.right), MidPnt(rct.top, rct.bottom));
 
-    std::vector<CDrawObj*> tblObjs;
+    std::vector<CB::not_null<CDrawObj*>> tblObjs;
     m_selList.LoadTableWithObjectPtrs(tblObjs);
 
     m_selList.PurgeList(TRUE);              // Purge former selections
@@ -1441,7 +1441,7 @@ void CPlayBoardView::OnActShuffleSelectedObjects()
     pDoc->SetRandomNumberSeed(nRandSeed);
 
     // Create a shuffled table of objects...
-    std::vector<CDrawObj*> tblRandObjs;
+    std::vector<CB::not_null<CDrawObj*>> tblRandObjs;
     tblRandObjs.reserve(tblObjs.size());
     for (int i = 0; i < value_preserving_cast<int>(tblObjs.size()); i++)
         tblRandObjs.push_back(tblObjs[value_preserving_cast<size_t>(pnIndices[i])]);

--- a/GP/VwPbrd.cpp
+++ b/GP/VwPbrd.cpp
@@ -274,9 +274,9 @@ void CPlayBoardView::OnUpdate(CView* pSender, LPARAM lHint, CObject* pHint)
         POSITION pos = m_selList.GetHeadPosition();
         while (pos != NULL)
         {
-            CDrawObj* pObj = ((CSelection*)m_selList.GetNext(pos))->m_pObj;
-            if (m_pPBoard->IsObjectOnBoard(pObj))
-                listSelectedObjs.AddTail(pObj);
+            CDrawObj& pObj = *static_cast<CSelection*>(m_selList.GetNext(pos))->m_pObj;
+            if (m_pPBoard->IsObjectOnBoard(&pObj))
+                listSelectedObjs.AddTail(&pObj);
         }
         m_selList.PurgeList();          // Clear former selection indications
         // Reselect any object that are still on the board.
@@ -964,7 +964,7 @@ void CPlayBoardView::OnEndPrinting(CDC* /*pDC*/, CPrintInfo* /*pInfo*/)
 /////////////////////////////////////////////////////////////////////////////
 
 #ifdef _DEBUG
-CGamDoc* CPlayBoardView::GetDocument() // non-debug version is inline
+const CGamDoc* CPlayBoardView::GetDocument() const // non-debug version is inline
 {
     ASSERT(m_pDocument->IsKindOf(RUNTIME_CLASS(CGamDoc)));
     return (CGamDoc*)m_pDocument;
@@ -2109,8 +2109,8 @@ void CPlayBoardView::OnEditElementText()
 {
     ASSERT(m_selList.IsSingleSelect() && (m_selList.HasMarkers() || m_selList.HasPieces()));
 
-    CDrawObj* pDObj = m_selList.GetHead()->m_pObj;
-    GetDocument()->DoEditObjectText(pDObj);
+    CDrawObj& pDObj = *m_selList.GetHead()->m_pObj;
+    GetDocument()->DoEditObjectText(&pDObj);
     NotifySelectListChange();       // Make sure indicators are updated
 }
 

--- a/GP/VwPbrd.cpp
+++ b/GP/VwPbrd.cpp
@@ -151,9 +151,9 @@ END_MESSAGE_MAP()
 /////////////////////////////////////////////////////////////////////////////
 // CPlayBoardView construction/destruction
 
-CPlayBoardView::CPlayBoardView()
+CPlayBoardView::CPlayBoardView() :
+    m_selList(*this)
 {
-    m_selList.SetView(this);
     m_pPBoard = NULL;
     m_nZoom = fullScale;
     m_nCurToolID = ID_PTOOL_SELECT;

--- a/GP/VwPbrd.cpp
+++ b/GP/VwPbrd.cpp
@@ -792,7 +792,7 @@ LRESULT CPlayBoardView::DoDragSelectList(WPARAM wParam, DragInfo* pdi)
         pSLst->PurgeList(FALSE);            // Purge source list
 
         pDoc->AssignNewMoveGroup();
-        pDoc->PlaceObjectListOnBoard(listObjs, rctObjs.TopLeft(), m_pPBoard);
+        pDoc->PlaceObjectTableOnBoard(listObjs, rctObjs.TopLeft(), m_pPBoard);
 
         m_selList.PurgeList(TRUE);          // Purge former selections
 
@@ -1201,7 +1201,7 @@ void CPlayBoardView::OnEditClear()
     m_selList.LoadTableWithObjectPtrs(listPtr, CSelList::otAll, FALSE);
     m_selList.PurgeList(TRUE);                  // Purge selections
     GetDocument()->AssignNewMoveGroup();
-    GetDocument()->DeleteObjectsInList(listPtr);
+    GetDocument()->DeleteObjectsInTable(listPtr);
 }
 
 void CPlayBoardView::OnUpdateEditClear(CCmdUI* pCmdUI)
@@ -1484,7 +1484,7 @@ void CPlayBoardView::OnActToFront()
     m_selList.PurgeList(TRUE);          // Purge former selections
 
     GetDocument()->AssignNewMoveGroup();
-    GetDocument()->PlaceObjectListOnBoard(listObjs, rct.TopLeft(),
+    GetDocument()->PlaceObjectTableOnBoard(listObjs, rct.TopLeft(),
         m_pPBoard, placeTop);
 
     SelectAllObjectsInTable(listObjs);  // Reselect pieces
@@ -1510,7 +1510,7 @@ void CPlayBoardView::OnActToBack()
     m_selList.PurgeList(TRUE);          // Purge former selections
 
     GetDocument()->AssignNewMoveGroup();
-    GetDocument()->PlaceObjectListOnBoard(listObjs, rct.TopLeft(),
+    GetDocument()->PlaceObjectTableOnBoard(listObjs, rct.TopLeft(),
         m_pPBoard, placeBack);
 
     SelectAllObjectsInTable(listObjs);  // Reselect pieces
@@ -1532,7 +1532,7 @@ void CPlayBoardView::OnActTurnOver()
     m_selList.PurgeList(TRUE);          // Purge former selections
 
     GetDocument()->AssignNewMoveGroup();
-    GetDocument()->InvertPlayingPieceListOnBoard(listObjs, m_pPBoard);
+    GetDocument()->InvertPlayingPieceTableOnBoard(listObjs, m_pPBoard);
 
     SelectAllObjectsInTable(listObjs);  // Reselect pieces
 }
@@ -1599,7 +1599,7 @@ void CPlayBoardView::OnActPlotDone()
 
         // Note that PlaceObjectListOnBoard() automatically detects the
         // plotted move case and records that fact.
-        GetDocument()->PlaceObjectListOnBoard(listObjs, ptPrev, m_pPBoard);
+        GetDocument()->PlaceObjectTableOnBoard(listObjs, ptPrev, m_pPBoard);
         m_selList.PurgeList(TRUE);          // Purge former selections
         SelectAllObjectsInTable(listObjs);  // Select on this board.
     }
@@ -1701,7 +1701,7 @@ void CPlayBoardView::OnRotatePiece(UINT nID)
     m_selList.PurgeList(TRUE);          // Purge former selections
 
     GetDocument()->AssignNewMoveGroup();
-    GetDocument()->ChangePlayingPieceFacingListOnBoard(listObjs, m_pPBoard,
+    GetDocument()->ChangePlayingPieceFacingTableOnBoard(listObjs, m_pPBoard,
         5 * nFacing5DegCW);             // Convert to degrees
 
     SelectAllObjectsInTable(listObjs);  // Reselect pieces
@@ -2141,7 +2141,7 @@ void CPlayBoardView::OnActLockObject()
     m_selList.LoadTableWithObjectPtrs(listObjs, CSelList::otAll, FALSE);
 
     GetDocument()->AssignNewMoveGroup();
-    GetDocument()->SetObjectLockdownList(listObjs, bLockState);
+    GetDocument()->SetObjectLockdownTable(listObjs, bLockState);
 
     if (m_pPBoard->GetLocksEnforced() && bLockState)
         m_selList.PurgeList(TRUE);          // Purge former selections

--- a/GP/VwPbrd.cpp
+++ b/GP/VwPbrd.cpp
@@ -679,10 +679,10 @@ LRESULT CPlayBoardView::DoDragMarker(WPARAM wParam, DragInfo* pdi)
             for (i = dlg.m_nMarkerCount - 1; i >= 0; i--)
             {
                 CSize size = pMMgr->GetMarkSize(tblMarks[value_preserving_cast<size_t>(i)]);
-                CDrawObj* pObj = pDoc->CreateMarkerObject(m_pPBoard, tblMarks[value_preserving_cast<size_t>(i)],
+                CDrawObj& pObj = pDoc->CreateMarkerObject(m_pPBoard, tblMarks[value_preserving_cast<size_t>(i)],
                     CPoint(x - size.cx / 2, y), ObjectID());
                 x -= size.cx + MARKER_DROP_GAP_X;
-                m_selList.AddObject(pObj, TRUE);
+                m_selList.AddObject(&pObj, TRUE);
             }
             NotifySelectListChange();
             return 0;
@@ -698,7 +698,7 @@ NASTY_GOTO_TARGET:
         pnt = GetMidRect(rct);
 
         pDoc->AssignNewMoveGroup();
-        CDrawObj* pObj = pDoc->CreateMarkerObject(m_pPBoard, mid, pnt, ObjectID());
+        CDrawObj& pObj = pDoc->CreateMarkerObject(m_pPBoard, mid, pnt, ObjectID());
 
         // If marker is set to prompt for text on drop, show the
         // dialog.
@@ -710,7 +710,7 @@ NASTY_GOTO_TARGET:
 
             if (dlg.DoModal() == IDOK)
             {
-                GameElement elem = pDoc->GetGameElementCodeForObject(pObj);
+                GameElement elem = pDoc->GetGameElementCodeForObject(&pObj);
                 pDoc->SetObjectText(elem, dlg.m_strText.IsEmpty() ? NULL :
                     (LPCTSTR)dlg.m_strText);
             }

--- a/GP/VwPbrd.cpp
+++ b/GP/VwPbrd.cpp
@@ -1026,15 +1026,10 @@ void CPlayBoardView::OnLButtonDown(UINT nFlags, CPoint point)
     }
 
     PToolType eToolType = MapToolType(m_nCurToolID);
-    CPlayTool* pTool = CPlayTool::GetTool(eToolType);
+    CPlayTool& pTool = CPlayTool::GetTool(eToolType);
     // Allow pieces to be selected even during playback
-    if (pTool != NULL)
-    {
-        ClientToWorkspace(point);
-        pTool->OnLButtonDown(this, nFlags, point);
-    }
-    else
-        CScrollView::OnLButtonDown(nFlags, point);
+    ClientToWorkspace(point);
+    pTool.OnLButtonDown(this, nFlags, point);
 }
 
 void CPlayBoardView::OnMouseMove(UINT nFlags, CPoint point)
@@ -1047,12 +1042,12 @@ void CPlayBoardView::OnMouseMove(UINT nFlags, CPoint point)
 
     DoToolTipHitProcessing(point);
 
-    PToolType eToolType = MapToolType(m_nCurToolID);
-    CPlayTool* pTool = CPlayTool::GetTool(eToolType);
-    if (!GetDocument()->IsPlaying() && pTool != NULL)
+    if (!GetDocument()->IsPlaying())
     {
+        PToolType eToolType = MapToolType(m_nCurToolID);
+        CPlayTool& pTool = CPlayTool::GetTool(eToolType);
         ClientToWorkspace(point);
-        pTool->OnMouseMove(this, nFlags, point);
+        pTool.OnMouseMove(this, nFlags, point);
     }
     else
         CScrollView::OnMouseMove(nFlags, point);
@@ -1067,15 +1062,10 @@ void CPlayBoardView::OnLButtonUp(UINT nFlags, CPoint point)
     }
 
     PToolType eToolType = MapToolType(m_nCurToolID);
-    CPlayTool* pTool = CPlayTool::GetTool(eToolType);
+    CPlayTool& pTool = CPlayTool::GetTool(eToolType);
     // Allow pieces to be selected even during playback
-    if (pTool != NULL)
-    {
-        ClientToWorkspace(point);
-        pTool->OnLButtonUp(this, nFlags, point);
-    }
-    else
-        CScrollView::OnLButtonUp(nFlags, point);
+    ClientToWorkspace(point);
+    pTool.OnLButtonUp(this, nFlags, point);
 }
 
 void CPlayBoardView::OnLButtonDblClk(UINT nFlags, CPoint point)
@@ -1086,12 +1076,12 @@ void CPlayBoardView::OnLButtonDblClk(UINT nFlags, CPoint point)
         return;
     }
 
-    PToolType eToolType = MapToolType(m_nCurToolID);
-    CPlayTool* pTool = CPlayTool::GetTool(eToolType);
-    if (!GetDocument()->IsPlaying() && pTool != NULL)
+    if (!GetDocument()->IsPlaying())
     {
+        PToolType eToolType = MapToolType(m_nCurToolID);
+        CPlayTool& pTool = CPlayTool::GetTool(eToolType);
         ClientToWorkspace(point);
-        pTool->OnLButtonDblClk(this, nFlags, point);
+        pTool.OnLButtonDblClk(this, nFlags, point);
     }
     else
         CScrollView::OnLButtonDblClk(nFlags, point);
@@ -1114,10 +1104,12 @@ void CPlayBoardView::OnTimer(UINT nIDEvent)
     }
     else
     {
-        PToolType eToolType = MapToolType(m_nCurToolID);
-        CPlayTool* pTool = CPlayTool::GetTool(eToolType);
-        if (!GetDocument()->IsPlaying() && pTool != NULL)
-            pTool->OnTimer(this, nIDEvent);
+        if (!GetDocument()->IsPlaying())
+        {
+            PToolType eToolType = MapToolType(m_nCurToolID);
+            CPlayTool& pTool = CPlayTool::GetTool(eToolType);
+            pTool.OnTimer(this, nIDEvent);
+        }
         else
             CScrollView::OnTimer(nIDEvent);
     }
@@ -1131,8 +1123,8 @@ BOOL CPlayBoardView::OnSetCursor(CWnd* pWnd, UINT nHitTest, UINT message)
     PToolType eToolType = MapToolType(m_nCurToolID);
     if (pWnd == this && eToolType != ptypeUnknown)
     {
-        CPlayTool* pTool = CPlayTool::GetTool(eToolType);
-        if (pTool != NULL && pTool->OnSetCursor(this, nHitTest))
+        CPlayTool& pTool = CPlayTool::GetTool(eToolType);
+        if (pTool.OnSetCursor(this, nHitTest))
             return TRUE;
     }
     if (GetDocument()->IsRecordingCompoundMove())

--- a/GP/VwPbrd.cpp
+++ b/GP/VwPbrd.cpp
@@ -252,15 +252,13 @@ void CPlayBoardView::OnUpdate(CView* pSender, LPARAM lHint, CObject* pHint)
     }
     else if (lHint == HINT_SELECTOBJLIST && ph->GetArgs<HINT_SELECTOBJLIST>().m_pPBoard == m_pPBoard)
     {
-        ASSERT(ph->GetArgs<HINT_SELECTOBJLIST>().m_pPtrList != NULL);
+        const std::vector<CB::not_null<CDrawObj*>>& pPtrList = CheckedDeref(ph->GetArgs<HINT_SELECTOBJLIST>().m_pPtrList);
         m_selList.PurgeList(TRUE);
 
-        POSITION pos;
-        for (pos = ph->GetArgs<HINT_SELECTOBJLIST>().m_pPtrList->GetHeadPosition(); pos != NULL; )
+        for (size_t i = size_t(0) ; i < pPtrList.size() ; ++i)
         {
-            CDrawObj* pDObj = (CDrawObj*)ph->GetArgs<HINT_SELECTOBJLIST>().m_pPtrList->GetNext(pos);
-            ASSERT(pDObj != NULL);
-            m_selList.AddObject(*pDObj, TRUE);
+            CDrawObj& pDObj = *pPtrList[i];
+            m_selList.AddObject(pDObj, TRUE);
             NotifySelectListChange();
         }
     }

--- a/GP/VwPbrd.cpp
+++ b/GP/VwPbrd.cpp
@@ -206,9 +206,9 @@ void CPlayBoardView::OnInitialUpdate()
 void CPlayBoardView::OnUpdate(CView* pSender, LPARAM lHint, CObject* pHint)
 {
     CGamDocHint* ph = (CGamDocHint*)pHint;
-    if (lHint == HINT_POINTINVIEW && ph->m_pPBoard == m_pPBoard)
+    if (lHint == HINT_POINTINVIEW && ph->GetArgs<HINT_POINTINVIEW>().m_pPBoard == m_pPBoard)
     {
-        ScrollWorkspacePointIntoView(ph->m_point);
+        ScrollWorkspacePointIntoView(ph->GetArgs<HINT_POINTINVIEW>().m_point);
     }
     else if (lHint == HINT_BOARDCHANGE)
     {
@@ -220,18 +220,18 @@ void CPlayBoardView::OnUpdate(CView* pSender, LPARAM lHint, CObject* pHint)
             pFrm->PostMessage(WM_CLOSE, 0, 0L);
         }
     }
-    else if (lHint == HINT_UPDATEOBJECT && ph->m_pPBoard == m_pPBoard)
+    else if (lHint == HINT_UPDATEOBJECT && ph->GetArgs<HINT_UPDATEOBJECT>().m_pPBoard == m_pPBoard)
     {
         CRect rct;
-        rct = ph->m_pDrawObj->GetEnclosingRect();   // In board coords.
+        rct = ph->GetArgs<HINT_UPDATEOBJECT>().m_pDrawObj->GetEnclosingRect();   // In board coords.
         InvalidateWorkspaceRect(&rct);
     }
-    else if (lHint == HINT_UPDATEOBJLIST && ph->m_pPBoard == m_pPBoard)
+    else if (lHint == HINT_UPDATEOBJLIST && ph->GetArgs<HINT_UPDATEOBJLIST>().m_pPBoard == m_pPBoard)
     {
         POSITION pos;
-        for (pos = ph->m_pPtrList->GetHeadPosition(); pos != NULL; )
+        for (pos = ph->GetArgs<HINT_UPDATEOBJLIST>().m_pPtrList->GetHeadPosition(); pos != NULL; )
         {
-            CDrawObj* pDObj = (CDrawObj*)ph->m_pPtrList->GetNext(pos);
+            CDrawObj* pDObj = (CDrawObj*)ph->GetArgs<HINT_UPDATEOBJLIST>().m_pPtrList->GetNext(pos);
             ASSERT(pDObj != NULL);
             CRect rct = pDObj->GetEnclosingRect();  // In board coords.
             InvalidateWorkspaceRect(&rct);
@@ -239,27 +239,27 @@ void CPlayBoardView::OnUpdate(CView* pSender, LPARAM lHint, CObject* pHint)
     }
     else if (lHint == HINT_SELECTOBJ)
     {
-        if (ph->m_pPBoard != NULL && ph->m_pPBoard != m_pPBoard)
+        if (ph->GetArgs<HINT_SELECTOBJ>().m_pPBoard != NULL && ph->GetArgs<HINT_SELECTOBJ>().m_pPBoard != m_pPBoard)
             return;                     // Ignore in this case
-        if (ph->m_pDrawObj == NULL)     // NULL means deselect all
+        if (ph->GetArgs<HINT_SELECTOBJ>().m_pDrawObj == NULL)     // NULL means deselect all
         {
             m_selList.PurgeList(TRUE);
             return;
         }
-        m_selList.AddObject(ph->m_pDrawObj, TRUE);
-        if (ph->m_pDrawObj->GetType() == CDrawObj::drawPieceObj ||
-                ph->m_pDrawObj->GetType() == CDrawObj::drawMarkObj)
+        m_selList.AddObject(ph->GetArgs<HINT_SELECTOBJ>().m_pDrawObj, TRUE);
+        if (ph->GetArgs<HINT_SELECTOBJ>().m_pDrawObj->GetType() == CDrawObj::drawPieceObj ||
+                ph->GetArgs<HINT_SELECTOBJ>().m_pDrawObj->GetType() == CDrawObj::drawMarkObj)
             NotifySelectListChange();
     }
-    else if (lHint == HINT_SELECTOBJLIST && ph->m_pPBoard == m_pPBoard)
+    else if (lHint == HINT_SELECTOBJLIST && ph->GetArgs<HINT_SELECTOBJLIST>().m_pPBoard == m_pPBoard)
     {
-        ASSERT(ph->m_pPtrList != NULL);
+        ASSERT(ph->GetArgs<HINT_SELECTOBJLIST>().m_pPtrList != NULL);
         m_selList.PurgeList(TRUE);
 
         POSITION pos;
-        for (pos = ph->m_pPtrList->GetHeadPosition(); pos != NULL; )
+        for (pos = ph->GetArgs<HINT_SELECTOBJLIST>().m_pPtrList->GetHeadPosition(); pos != NULL; )
         {
-            CDrawObj* pDObj = (CDrawObj*)ph->m_pPtrList->GetNext(pos);
+            CDrawObj* pDObj = (CDrawObj*)ph->GetArgs<HINT_SELECTOBJLIST>().m_pPtrList->GetNext(pos);
             ASSERT(pDObj != NULL);
             m_selList.AddObject(pDObj, TRUE);
             NotifySelectListChange();
@@ -291,7 +291,7 @@ void CPlayBoardView::OnUpdate(CView* pSender, LPARAM lHint, CObject* pHint)
         EndWaitCursor();
     }
     else if (lHint == HINT_ALWAYSUPDATE ||
-        (lHint == HINT_UPDATEBOARD && ph->m_pPBoard == m_pPBoard))
+        (lHint == HINT_UPDATEBOARD && ph->GetArgs<HINT_UPDATEBOARD>().m_pPBoard == m_pPBoard))
     {
         Invalidate(FALSE);
         BeginWaitCursor();
@@ -309,8 +309,8 @@ void CPlayBoardView::OnUpdate(CView* pSender, LPARAM lHint, CObject* pHint)
 void CPlayBoardView::NotifySelectListChange()
 {
     CGamDocHint hint;
-    hint.m_pPBoard = m_pPBoard;
-    hint.m_pSelList = &m_selList;
+    hint.GetArgs<HINT_UPDATESELECT>().m_pPBoard = m_pPBoard;
+    hint.GetArgs<HINT_UPDATESELECT>().m_pSelList = &m_selList;
     GetDocument()->UpdateAllViews(this, HINT_UPDATESELECT, &hint);
 }
 
@@ -1342,7 +1342,7 @@ void CPlayBoardView::OnViewBoardRotate180()
 {
    m_pPBoard->SetRotateBoard180(!m_pPBoard->IsBoardRotated180());
    CGamDocHint hint;
-   hint.m_pPBoard = m_pPBoard;
+   hint.GetArgs<HINT_UPDATEBOARD>().m_pPBoard = m_pPBoard;
    GetDocument()->UpdateAllViews(NULL, HINT_UPDATEBOARD, &hint);
 }
 
@@ -1931,7 +1931,7 @@ void CPlayBoardView::OnViewPieces()
 {
     GetPlayBoard()->SetPiecesVisible(!GetPlayBoard()->GetPiecesVisible());
     CGamDocHint hint;
-    hint.m_pPBoard = m_pPBoard;
+    hint.GetArgs<HINT_UPDATEBOARD>().m_pPBoard = m_pPBoard;
     GetDocument()->UpdateAllViews(NULL, HINT_UPDATEBOARD, &hint);
 }
 
@@ -2096,7 +2096,7 @@ void CPlayBoardView::OnViewDrawIndOnTop()
 {
     GetPlayBoard()->SetIndicatorsOnTop(!GetPlayBoard()->GetIndicatorsOnTop());
     CGamDocHint hint;
-    hint.m_pPBoard = m_pPBoard;
+    hint.GetArgs<HINT_UPDATEBOARD>().m_pPBoard = m_pPBoard;
     GetDocument()->UpdateAllViews(NULL, HINT_UPDATEBOARD, &hint);
 }
 
@@ -2218,7 +2218,7 @@ void CPlayBoardView::OnActTakeOwnership()
     pDoc->SetPieceOwnershipTable(tblPieces, pDoc->GetCurrentPlayerMask());
 
     CGamDocHint hint;
-    hint.m_pPBoard = m_pPBoard;
+    hint.GetArgs<HINT_UPDATEBOARD>().m_pPBoard = m_pPBoard;
     pDoc->UpdateAllViews(NULL, HINT_UPDATEBOARD, &hint);
 
     NotifySelectListChange();
@@ -2268,7 +2268,7 @@ void CPlayBoardView::OnActReleaseOwnership()
     pDoc->SetPieceOwnershipTable(tblPieces, 0);
 
     CGamDocHint hint;
-    hint.m_pPBoard = m_pPBoard;
+    hint.GetArgs<HINT_UPDATEBOARD>().m_pPBoard = m_pPBoard;
     pDoc->UpdateAllViews(NULL, HINT_UPDATEBOARD, &hint);
 
     NotifySelectListChange();
@@ -2326,7 +2326,7 @@ void CPlayBoardView::OnActSetOwner()
     pDoc->SetPieceOwnershipTable(tblPieces, dwNewOwnerMask);
 
     CGamDocHint hint;
-    hint.m_pPBoard = m_pPBoard;
+    hint.GetArgs<HINT_UPDATEBOARD>().m_pPBoard = m_pPBoard;
     pDoc->UpdateAllViews(NULL, HINT_UPDATEBOARD, &hint);
 
     NotifySelectListChange();

--- a/GP/VwPbrd.h
+++ b/GP/VwPbrd.h
@@ -83,7 +83,7 @@ public:
     void SelectWithinRect(CRect rctNet, BOOL bInclIntersects = FALSE);
     void SelectAllUnderPoint(CPoint point);
     CDrawObj* ObjectHitTest(CPoint point);
-    void SelectAllObjectsInList(CPtrList* pLst);
+    void SelectAllObjectsInList(const std::vector<CB::not_null<CDrawObj*>>& pLst);
     void SelectAllObjectsInTable(const std::vector<CB::not_null<CDrawObj*>>& pTbl);
     void SelectMarkersInGroup(size_t nGroup);
     void SelectAllMarkers();

--- a/GP/VwPbrd.h
+++ b/GP/VwPbrd.h
@@ -83,7 +83,7 @@ public:
     void SelectAllUnderPoint(CPoint point);
     CDrawObj* ObjectHitTest(CPoint point);
     void SelectAllObjectsInList(CPtrList* pLst);
-    void SelectAllObjectsInTable(const std::vector<CDrawObj*>& pTbl);
+    void SelectAllObjectsInTable(const std::vector<CB::not_null<CDrawObj*>>& pTbl);
     void SelectMarkersInGroup(size_t nGroup);
     void SelectAllMarkers();
 

--- a/GP/VwPbrd.h
+++ b/GP/VwPbrd.h
@@ -51,7 +51,8 @@ protected: // create from serialization only
 
 // Attributes
 public:
-    CGamDoc* GetDocument();
+    const CGamDoc* GetDocument() const;
+    CGamDoc* GetDocument() { return const_cast<CGamDoc*>(std::as_const(*this).GetDocument()); }
     CPlayBoard* GetPlayBoard() { return m_pPBoard; }
 
 // Operations
@@ -94,10 +95,10 @@ public:
 
 // Coordinate scaling...
 public:
-    void WorkspaceToClient(CPoint& point);
-    void WorkspaceToClient(CRect& rect);
-    void ClientToWorkspace(CPoint& point);
-    void ClientToWorkspace(CRect& rect);
+    void WorkspaceToClient(CPoint& point) const;
+    void WorkspaceToClient(CRect& rect) const;
+    void ClientToWorkspace(CPoint& point) const;
+    void ClientToWorkspace(CRect& rect) const;
     void InvalidateWorkspaceRect(const CRect* pRect, BOOL bErase = FALSE);
 
 // View support
@@ -284,7 +285,7 @@ public:
 };
 
 #ifndef _DEBUG  // debug version in vwmbrd.cpp
-inline CGamDoc* CPlayBoardView::GetDocument()
+inline const CGamDoc* CPlayBoardView::GetDocument() const
    { return (CGamDoc*)m_pDocument; }
 #endif
 

--- a/GP/VwPbrd.h
+++ b/GP/VwPbrd.h
@@ -70,7 +70,7 @@ public:
     CSelList* GetSelectList() { return &m_selList; }
     CPoint GetWorkspaceDim();
 
-    void AddDrawObject(CDrawObj* pObj);
+    void AddDrawObject(CDrawObj::OwnerPtr pObj);
     void MoveObjsInSelectList(BOOL bToFront, BOOL bInvalidate = TRUE);
 
     void PrepareScaledDC(CDC *pDC, CRect* pRct = NULL, BOOL bHonor180Flip = FALSE);

--- a/GP/VwPbrd.h
+++ b/GP/VwPbrd.h
@@ -153,7 +153,7 @@ protected:
     BOOL        m_bWheelRotation;   // Indicates the type of rotation being done
     CPoint      m_pntWheelMid;      // The wheel rotation point
     CUIntArray  m_tblCurAngles;     // Original angles of pieces
-    CPtrList    m_tblCurPieces;     // Pieces being rotated
+    std::vector<CB::not_null<CDrawObj*>> m_tblCurPieces;     // Pieces being rotated
     CUIntArray  m_tblXMidPnt;       // X coord of piece midpoint
     CUIntArray  m_tblYMidPnt;       // Y coord of piece midpoint
 

--- a/GP/VwPbrd1.cpp
+++ b/GP/VwPbrd1.cpp
@@ -100,11 +100,11 @@ void CPlayBoardView::DoToolTipHitProcessing(CPoint pointClient)
             CString strTip;
             CString strTitle;
             if (pDoc->IsShowingObjectTips())
-                pDoc->GetTipTextForObject(pDObj, strTip, &strTitle);
+                pDoc->GetTipTextForObject(*pDObj, strTip, &strTitle);
 
             // All this stuff is used to annotate tips with owner names
             // when player accounts are active.
-            if (pDoc->HasPlayers() && pDObj != NULL && pDObj->GetType() == CDrawObj::drawPieceObj)
+            if (pDoc->HasPlayers() && pDObj->GetType() == CDrawObj::drawPieceObj)
             {
                 CPieceObj* pPObj = (CPieceObj*)pDObj;
                 if (pPObj->IsOwned() &&

--- a/GP/VwPbrd1.cpp
+++ b/GP/VwPbrd1.cpp
@@ -437,8 +437,8 @@ void CPlayBoardView::MoveObjsInSelectList(BOOL bToFront, BOOL bInvalidate)
     while (pos != NULL)
     {
         CSelection* pSel = (CSelection*)m_selList.GetNext(pos);
-        pDwg->RemoveObject(pSel->m_pObj);
-        m_tmpLst.AddTail(pSel->m_pObj);
+        pDwg->RemoveObject(pSel->m_pObj.get());
+        m_tmpLst.AddTail(pSel->m_pObj.get());
     }
     if (bToFront)
     {

--- a/GP/VwPbrd1.cpp
+++ b/GP/VwPbrd1.cpp
@@ -287,23 +287,21 @@ void CPlayBoardView::SelectAllUnderPoint(CPoint point)
 
     BOOL bPieceSelected = FALSE;
 
-    CPtrList selLst;
+    std::vector<CB::not_null<CDrawObj*>> selLst;
     pDwg->DrillDownHitTest(point, selLst);
 
-    POSITION pos;
-    for (pos = selLst.GetHeadPosition(); pos != NULL; )
+    for (size_t i = size_t(0) ; i < selLst.size() ; ++i)
     {
-        CDrawObj* pObj = (CDrawObj*)selLst.GetNext(pos);
-        ASSERT(pObj != NULL);
-        if (!m_selList.IsObjectSelected(*pObj))
+        CDrawObj& pObj = *selLst[i];
+        if (!m_selList.IsObjectSelected(pObj))
         {
             BOOL bOwnedByCurrentPlayer = TRUE;
-            if (pObj->GetType() == CDrawObj::drawPieceObj)
+            if (pObj.GetType() == CDrawObj::drawPieceObj)
             {
-                CPieceObj* pPObj = (CPieceObj*)pObj;
+                CPieceObj& pPObj = static_cast<CPieceObj&>(pObj);
                 DWORD dwCurrentPlayer = GetDocument()->GetCurrentPlayerMask();
                 bOwnedByCurrentPlayer =
-                    !pPObj->IsOwned() || pPObj->IsOwnedBy(dwCurrentPlayer);
+                    !pPObj.IsOwned() || pPObj.IsOwnedBy(dwCurrentPlayer);
             }
 
             // Only add to the list if the object is either unlocked or locks
@@ -311,11 +309,11 @@ void CPlayBoardView::SelectAllUnderPoint(CPoint point)
             // than the current player.
             if (bOwnedByCurrentPlayer &&
                 (!m_pPBoard->GetLocksEnforced() ||
-                 !(pObj->GetDObjFlags() & dobjFlgLockDown)))
+                 !(pObj.GetDObjFlags() & dobjFlgLockDown)))
             {
-                m_selList.AddObject(*pObj, TRUE);
-                bPieceSelected |= pObj->GetType() == CDrawObj::drawPieceObj ||
-                    pObj->GetType() == CDrawObj::drawMarkObj;
+                m_selList.AddObject(pObj, TRUE);
+                bPieceSelected |= pObj.GetType() == CDrawObj::drawPieceObj ||
+                    pObj.GetType() == CDrawObj::drawMarkObj;
             }
         }
     }
@@ -323,19 +321,17 @@ void CPlayBoardView::SelectAllUnderPoint(CPoint point)
         NotifySelectListChange();
 }
 
-void CPlayBoardView::SelectAllObjectsInList(CPtrList* pLst)
+void CPlayBoardView::SelectAllObjectsInList(const std::vector<CB::not_null<CDrawObj*>>& pLst)
 {
-    POSITION pos;
     BOOL bPieceSelected = FALSE;
-    for (pos = pLst->GetHeadPosition(); pos != NULL; )
+    for (size_t i = size_t(0) ; i < pLst.size() ; ++i)
     {
-        CDrawObj* pObj = (CDrawObj*)pLst->GetNext(pos);
-        ASSERT(pObj != NULL);
-        if (!m_selList.IsObjectSelected(*pObj))
+        CDrawObj& pObj = *pLst[i];
+        if (!m_selList.IsObjectSelected(pObj))
         {
-            m_selList.AddObject(*pObj, TRUE);
-            bPieceSelected |= pObj->GetType() == CDrawObj::drawPieceObj ||
-                pObj->GetType() == CDrawObj::drawMarkObj;
+            m_selList.AddObject(pObj, TRUE);
+            bPieceSelected |= pObj.GetType() == CDrawObj::drawPieceObj ||
+                pObj.GetType() == CDrawObj::drawMarkObj;
         }
     }
     if (bPieceSelected)

--- a/GP/VwPbrd1.cpp
+++ b/GP/VwPbrd1.cpp
@@ -237,7 +237,7 @@ void CPlayBoardView::SelectWithinRect(CRect rctNet, BOOL bInclIntersects)
     for (CDrawList::iterator pos = pDwg.begin(); pos != pDwg.end(); ++pos)
     {
         CDrawObj& pObj = **pos;
-        if (!m_selList.IsObjectSelected(&pObj))
+        if (!m_selList.IsObjectSelected(pObj))
         {
             if ((!bInclIntersects &&
                 ((pObj.GetEnclosingRect() | rctNet) == rctNet)) ||
@@ -269,7 +269,7 @@ void CPlayBoardView::SelectWithinRect(CRect rctNet, BOOL bInclIntersects)
                 // (the last three conditions were checked above.)
                 if (pDoc->IsScenario() || bOwnedByCurrentPlayer)
                 {
-                    m_selList.AddObject(&pObj, TRUE);
+                    m_selList.AddObject(pObj, TRUE);
                     bPieceSelected |= pObj.GetType() == CDrawObj::drawPieceObj ||
                         pObj.GetType() == CDrawObj::drawMarkObj;
                 }
@@ -288,14 +288,14 @@ void CPlayBoardView::SelectAllUnderPoint(CPoint point)
     BOOL bPieceSelected = FALSE;
 
     CPtrList selLst;
-    pDwg->DrillDownHitTest(point, &selLst);
+    pDwg->DrillDownHitTest(point, selLst);
 
     POSITION pos;
     for (pos = selLst.GetHeadPosition(); pos != NULL; )
     {
         CDrawObj* pObj = (CDrawObj*)selLst.GetNext(pos);
         ASSERT(pObj != NULL);
-        if (!m_selList.IsObjectSelected(pObj))
+        if (!m_selList.IsObjectSelected(*pObj))
         {
             BOOL bOwnedByCurrentPlayer = TRUE;
             if (pObj->GetType() == CDrawObj::drawPieceObj)
@@ -313,7 +313,7 @@ void CPlayBoardView::SelectAllUnderPoint(CPoint point)
                 (!m_pPBoard->GetLocksEnforced() ||
                  !(pObj->GetDObjFlags() & dobjFlgLockDown)))
             {
-                m_selList.AddObject(pObj, TRUE);
+                m_selList.AddObject(*pObj, TRUE);
                 bPieceSelected |= pObj->GetType() == CDrawObj::drawPieceObj ||
                     pObj->GetType() == CDrawObj::drawMarkObj;
             }
@@ -331,9 +331,9 @@ void CPlayBoardView::SelectAllObjectsInList(CPtrList* pLst)
     {
         CDrawObj* pObj = (CDrawObj*)pLst->GetNext(pos);
         ASSERT(pObj != NULL);
-        if (!m_selList.IsObjectSelected(pObj))
+        if (!m_selList.IsObjectSelected(*pObj))
         {
-            m_selList.AddObject(pObj, TRUE);
+            m_selList.AddObject(*pObj, TRUE);
             bPieceSelected |= pObj->GetType() == CDrawObj::drawPieceObj ||
                 pObj->GetType() == CDrawObj::drawMarkObj;
         }
@@ -349,9 +349,9 @@ void CPlayBoardView::SelectAllObjectsInTable(const std::vector<CB::not_null<CDra
     for (size_t i = 0; i < pTbl.size(); i++)
     {
         CDrawObj& pObj = *pTbl.at(i);
-        if (!m_selList.IsObjectSelected(&pObj))
+        if (!m_selList.IsObjectSelected(pObj))
         {
-            m_selList.AddObject(&pObj, TRUE);
+            m_selList.AddObject(pObj, TRUE);
             bPieceSelected |= pObj.GetType() == CDrawObj::drawPieceObj ||
                 pObj.GetType() == CDrawObj::drawMarkObj;
         }
@@ -373,10 +373,10 @@ void CPlayBoardView::SelectAllMarkers()
         CDrawObj& pObj = **pos;
         if (m_pPBoard->GetLocksEnforced() && (pObj.GetDObjFlags() & dobjFlgLockDown))
             continue;           // Ignore this object since it's locked
-        if (!m_selList.IsObjectSelected(&pObj))
+        if (!m_selList.IsObjectSelected(pObj))
         {
             if (pObj.GetType() == CDrawObj::drawMarkObj)
-                m_selList.AddObject(&pObj, TRUE);
+                m_selList.AddObject(pObj, TRUE);
         }
     }
     NotifySelectListChange();
@@ -396,12 +396,12 @@ void CPlayBoardView::SelectMarkersInGroup(size_t nGroup)
         CDrawObj& pObj = **pos;
         if (m_pPBoard->GetLocksEnforced() && (pObj.GetDObjFlags() & dobjFlgLockDown))
             continue;           // Ignore this object since it's locked
-        if (!m_selList.IsObjectSelected(&pObj))
+        if (!m_selList.IsObjectSelected(pObj))
         {
             if (pObj.GetType() == CDrawObj::drawMarkObj)
             {
                 if (pMgr.IsMarkerInGroup(nGroup, static_cast<CMarkObj&>(pObj).m_mid))
-                    m_selList.AddObject(&pObj, TRUE);
+                    m_selList.AddObject(pObj, TRUE);
             }
         }
     }
@@ -437,7 +437,7 @@ void CPlayBoardView::MoveObjsInSelectList(BOOL bToFront, BOOL bInvalidate)
     while (pos != NULL)
     {
         CSelection* pSel = (CSelection*)m_selList.GetNext(pos);
-        pDwg->RemoveObject(pSel->m_pObj.get());
+        pDwg->RemoveObject(*pSel->m_pObj);
         m_tmpLst.AddTail(pSel->m_pObj.get());
     }
     if (bToFront)

--- a/GP/VwPbrd1.cpp
+++ b/GP/VwPbrd1.cpp
@@ -431,26 +431,27 @@ void CPlayBoardView::MoveObjsInSelectList(BOOL bToFront, BOOL bInvalidate)
     // selected. Remove and add them to a local list. Then take
     // the objects and add them to the front or back. The reason for
     // the temp list is to maintain ordering of selected objects.
-    CPtrList m_tmpLst;
+    std::vector<CB::not_null<CDrawObj*>> m_tmpLst;
 
-    POSITION pos = m_selList.GetHeadPosition();
-    while (pos != NULL)
+    for (CSelList::iterator pos = m_selList.begin() ; pos != m_selList.end() ; ++pos)
     {
-        CSelection* pSel = (CSelection*)m_selList.GetNext(pos);
-        pDwg->RemoveObject(*pSel->m_pObj);
-        m_tmpLst.AddTail(pSel->m_pObj.get());
+        CSelection& pSel = **pos;
+        pDwg->RemoveObject(*pSel.m_pObj);
+        m_tmpLst.push_back(pSel.m_pObj.get());
     }
     if (bToFront)
     {
-        pos = m_tmpLst.GetHeadPosition();
-        while (pos != NULL)
-            pDwg->AddToFront(CDrawObj::OwnerPtr((CDrawObj*)m_tmpLst.GetNext(pos)));
+        for (auto pos = m_tmpLst.begin() ; pos != m_tmpLst.end() ; ++pos)
+        {
+            pDwg->AddToFront(pos->get());
+        }
     }
     else
     {
-        pos = m_tmpLst.GetTailPosition();
-        while (pos != NULL)
-            pDwg->AddToBack(CDrawObj::OwnerPtr((CDrawObj*)m_tmpLst.GetPrev(pos)));
+        for (auto pos = m_tmpLst.rbegin() ; pos != m_tmpLst.rend() ; ++pos)
+        {
+            pDwg->AddToBack(pos->get());
+        }
     }
     if (bInvalidate)
         m_selList.InvalidateList();

--- a/GP/VwPbrd1.cpp
+++ b/GP/VwPbrd1.cpp
@@ -342,19 +342,18 @@ void CPlayBoardView::SelectAllObjectsInList(CPtrList* pLst)
         NotifySelectListChange();
 }
 
-void CPlayBoardView::SelectAllObjectsInTable(const std::vector<CDrawObj*>& pTbl)
+void CPlayBoardView::SelectAllObjectsInTable(const std::vector<CB::not_null<CDrawObj*>>& pTbl)
 {
     BOOL bPieceSelected = FALSE;
 
     for (size_t i = 0; i < pTbl.size(); i++)
     {
-        CDrawObj* pObj = pTbl.at(i);
-        ASSERT(pObj != NULL);
-        if (!m_selList.IsObjectSelected(pObj))
+        CDrawObj& pObj = *pTbl.at(i);
+        if (!m_selList.IsObjectSelected(&pObj))
         {
-            m_selList.AddObject(pObj, TRUE);
-            bPieceSelected |= pObj->GetType() == CDrawObj::drawPieceObj ||
-                pObj->GetType() == CDrawObj::drawMarkObj;
+            m_selList.AddObject(&pObj, TRUE);
+            bPieceSelected |= pObj.GetType() == CDrawObj::drawPieceObj ||
+                pObj.GetType() == CDrawObj::drawMarkObj;
         }
     }
     if (bPieceSelected)

--- a/GP/VwPbrd1.cpp
+++ b/GP/VwPbrd1.cpp
@@ -472,7 +472,7 @@ CPoint CPlayBoardView::GetWorkspaceDim()
 
 /////////////////////////////////////////////////////////////////////////////
 
-void CPlayBoardView::WorkspaceToClient(CPoint& point)
+void CPlayBoardView::WorkspaceToClient(CPoint& point) const
 {
     CPoint dpnt = GetDeviceScrollPosition();
     CSize wsize, vsize;
@@ -484,7 +484,7 @@ void CPlayBoardView::WorkspaceToClient(CPoint& point)
     point -= (CSize)dpnt;
 }
 
-void CPlayBoardView::WorkspaceToClient(CRect& rect)
+void CPlayBoardView::WorkspaceToClient(CRect& rect) const
 {
     CPoint dpnt = GetDeviceScrollPosition();
     CSize wsize, vsize;
@@ -508,7 +508,7 @@ void CPlayBoardView::InvalidateWorkspaceRect(const CRect* pRect, BOOL bErase)
     InvalidateRect(&rct, bErase);
 }
 
-void CPlayBoardView::ClientToWorkspace(CPoint& point)
+void CPlayBoardView::ClientToWorkspace(CPoint& point) const
 {
     CPoint dpnt = GetDeviceScrollPosition();
     point += (CSize)dpnt;
@@ -520,7 +520,7 @@ void CPlayBoardView::ClientToWorkspace(CPoint& point)
         point = CPoint(wsize.cx - point.x, wsize.cy - point.y);
 }
 
-void CPlayBoardView::ClientToWorkspace(CRect& rect)
+void CPlayBoardView::ClientToWorkspace(CRect& rect) const
 {
     CPoint dpnt = GetDeviceScrollPosition();
     rect += dpnt;

--- a/GP/VwPrjgs1.cpp
+++ b/GP/VwPrjgs1.cpp
@@ -180,7 +180,7 @@ void CGsnProjView::DoTrayProperty()
         }
 
         CGamDocHint hint;
-        hint.m_pTray = NULL;
+        hint.GetArgs<HINT_TRAYCHANGE>().m_pTray = NULL;
         pDoc->UpdateAllViews(NULL, HINT_TRAYCHANGE, &hint);
         pDoc->SetModifiedFlag();
     }
@@ -206,7 +206,7 @@ void CGsnProjView::DoTrayEdit()
 
     // Notify all visible trays
     CGamDocHint hint;
-    hint.m_pTray = NULL;
+    hint.GetArgs<HINT_TRAYCHANGE>().m_pTray = NULL;
     pDoc->UpdateAllViews(NULL, HINT_TRAYCHANGE, &hint);
     pDoc->SetModifiedFlag();
 }
@@ -233,7 +233,7 @@ void CGsnProjView::DoTrayDelete()
     }
     pYMgr->DeleteTraySet(nGrp);
     CGamDocHint hint;
-    hint.m_pTray = NULL;
+    hint.GetArgs<HINT_TRAYCHANGE>().m_pTray = NULL;
     pDoc->UpdateAllViews(NULL, HINT_TRAYCHANGE, &hint);
     pDoc->SetModifiedFlag();
 }

--- a/GP/VwSelpce.cpp
+++ b/GP/VwSelpce.cpp
@@ -141,7 +141,7 @@ void CSelectedPieceView::OnUpdate(CView* pSender, LPARAM lHint, CObject* pHint)
             m_tblSel.clear();
             return;
         }
-        pSLst->LoadTableWithObjectPtrs(m_tblSel);
+        pSLst->LoadTableWithObjectPtrs(m_tblSel, CSelList::otPiecesMarks, TRUE);
 
         m_listSel.SetItemMap(&m_tblSel);
     }

--- a/GP/VwSelpce.cpp
+++ b/GP/VwSelpce.cpp
@@ -237,12 +237,12 @@ void CSelectedPieceView::ModifySelectionsBasedOnListItems(BOOL bRemoveSelectedIt
         if (bRemoveSelectedItems && nSelItem == tblListBoxSel.GetSize())
         {
             // Not a listbox selection so add it to new select list.
-            listDObj.AddTail(m_listSel.MapIndexToItem(value_preserving_cast<size_t>(nItem)));
+            listDObj.AddTail(&m_listSel.MapIndexToItem(value_preserving_cast<size_t>(nItem)));
         }
         else if (!bRemoveSelectedItems && nSelItem < tblListBoxSel.GetSize())
         {
             // It is a listbox selection so add it to new select list.
-            listDObj.AddTail(m_listSel.MapIndexToItem(value_preserving_cast<size_t>(nItem)));
+            listDObj.AddTail(&m_listSel.MapIndexToItem(value_preserving_cast<size_t>(nItem)));
         }
     }
     CPlayBoardFrame* pFrame = (CPlayBoardFrame*)GetParentFrame();

--- a/GP/VwSelpce.cpp
+++ b/GP/VwSelpce.cpp
@@ -130,10 +130,10 @@ void CSelectedPieceView::OnInitialUpdate()
 void CSelectedPieceView::OnUpdate(CView* pSender, LPARAM lHint, CObject* pHint)
 {
     CGamDocHint* ph = (CGamDocHint*)pHint;
-    if (lHint == HINT_UPDATESELECT && ph->m_pPBoard == m_pPBoard)
+    if (lHint == HINT_UPDATESELECT && ph->GetArgs<HINT_UPDATESELECT>().m_pPBoard == m_pPBoard)
     {
-        ASSERT(ph->m_pSelList != NULL);
-        CSelList* pSLst = ph->m_pSelList;
+        ASSERT(ph->GetArgs<HINT_UPDATESELECT>().m_pSelList != NULL);
+        CSelList* pSLst = ph->GetArgs<HINT_UPDATESELECT>().m_pSelList;
 
         if (!pSLst->HasPieces() && !pSLst->HasMarkers())
         {

--- a/GP/VwSelpce.cpp
+++ b/GP/VwSelpce.cpp
@@ -224,7 +224,7 @@ void CSelectedPieceView::ModifySelectionsBasedOnListItems(BOOL bRemoveSelectedIt
 
     // Create a list containing all items that are *not* selected.
     // Rather than try to be real clever I'll just brute force the search.
-    CPtrList listDObj;
+    std::vector<CB::not_null<CDrawObj*>> listDObj;
     for (int nItem = 0; nItem < m_listSel.GetCount(); nItem++)
     {
         // Loop and see if item is in selected list.
@@ -237,12 +237,12 @@ void CSelectedPieceView::ModifySelectionsBasedOnListItems(BOOL bRemoveSelectedIt
         if (bRemoveSelectedItems && nSelItem == tblListBoxSel.GetSize())
         {
             // Not a listbox selection so add it to new select list.
-            listDObj.AddTail(&m_listSel.MapIndexToItem(value_preserving_cast<size_t>(nItem)));
+            listDObj.push_back(&m_listSel.MapIndexToItem(value_preserving_cast<size_t>(nItem)));
         }
         else if (!bRemoveSelectedItems && nSelItem < tblListBoxSel.GetSize())
         {
             // It is a listbox selection so add it to new select list.
-            listDObj.AddTail(&m_listSel.MapIndexToItem(value_preserving_cast<size_t>(nItem)));
+            listDObj.push_back(&m_listSel.MapIndexToItem(value_preserving_cast<size_t>(nItem)));
         }
     }
     CPlayBoardFrame* pFrame = (CPlayBoardFrame*)GetParentFrame();

--- a/GP/VwSelpce.h
+++ b/GP/VwSelpce.h
@@ -49,7 +49,7 @@ protected:
     CPlayBoard*     m_pPBoard;      // Board that contains selections
 
     CSelectListBox  m_listSel;
-    std::vector<CDrawObj*> m_tblSel;
+    std::vector<CB::not_null<CDrawObj*>> m_tblSel;
     CToolTipCtrl    m_toolTip;
 
 // Implementation

--- a/GP/VwTbrd.cpp
+++ b/GP/VwTbrd.cpp
@@ -94,24 +94,24 @@ void CTinyBoardView::OnInitialUpdate()
 void CTinyBoardView::OnUpdate(CView* pSender, LPARAM lHint, CObject* pHint)
 {
     CGamDocHint* ph = (CGamDocHint*)pHint;
-    if (lHint == HINT_UPDATEOBJECT && ph->m_pPBoard == m_pPBoard)
+    if (lHint == HINT_UPDATEOBJECT && ph->GetArgs<HINT_UPDATEOBJECT>().m_pPBoard == m_pPBoard)
     {
         CRect rct;
-        rct = ph->m_pDrawObj->GetEnclosingRect();   // In board coords.
+        rct = ph->GetArgs<HINT_UPDATEOBJECT>().m_pDrawObj->GetEnclosingRect();   // In board coords.
         InvalidateWorkspaceRect(&rct);
     }
-    else if (lHint == HINT_UPDATEOBJLIST && ph->m_pPBoard == m_pPBoard)
+    else if (lHint == HINT_UPDATEOBJLIST && ph->GetArgs<HINT_UPDATEOBJLIST>().m_pPBoard == m_pPBoard)
     {
         POSITION pos;
-        for (pos = ph->m_pPtrList->GetHeadPosition(); pos != NULL; )
+        for (pos = ph->GetArgs<HINT_UPDATEOBJLIST>().m_pPtrList->GetHeadPosition(); pos != NULL; )
         {
-            CDrawObj* pDObj = (CDrawObj*)ph->m_pPtrList->GetNext(pos);
+            CDrawObj* pDObj = (CDrawObj*)ph->GetArgs<HINT_UPDATEOBJLIST>().m_pPtrList->GetNext(pos);
             ASSERT(pDObj != NULL);
             CRect rct = pDObj->GetEnclosingRect();  // In board coords.
             InvalidateWorkspaceRect(&rct);
         }
     }
-    else if (lHint == HINT_UPDATEBOARD && ph->m_pPBoard == m_pPBoard)
+    else if (lHint == HINT_UPDATEBOARD && ph->GetArgs<HINT_UPDATEBOARD>().m_pPBoard == m_pPBoard)
     {
         if (m_pBMap != NULL) delete m_pBMap;
         m_pBMap = NULL;

--- a/GP/VwTbrd.cpp
+++ b/GP/VwTbrd.cpp
@@ -102,12 +102,11 @@ void CTinyBoardView::OnUpdate(CView* pSender, LPARAM lHint, CObject* pHint)
     }
     else if (lHint == HINT_UPDATEOBJLIST && ph->GetArgs<HINT_UPDATEOBJLIST>().m_pPBoard == m_pPBoard)
     {
-        POSITION pos;
-        for (pos = ph->GetArgs<HINT_UPDATEOBJLIST>().m_pPtrList->GetHeadPosition(); pos != NULL; )
+        const std::vector<CB::not_null<CDrawObj*>>& pPtrList = *ph->GetArgs<HINT_UPDATEOBJLIST>().m_pPtrList;
+        for (size_t i = size_t(0); i < pPtrList.size(); ++i)
         {
-            CDrawObj* pDObj = (CDrawObj*)ph->GetArgs<HINT_UPDATEOBJLIST>().m_pPtrList->GetNext(pos);
-            ASSERT(pDObj != NULL);
-            CRect rct = pDObj->GetEnclosingRect();  // In board coords.
+            CDrawObj& pDObj = *pPtrList[i];
+            CRect rct = pDObj.GetEnclosingRect();  // In board coords.
             InvalidateWorkspaceRect(&rct);
         }
     }

--- a/GP/WStateGp.cpp
+++ b/GP/WStateGp.cpp
@@ -33,21 +33,21 @@
 
 enum { gpFrmProject = 0, gpFrmPlayBoard = 1 };
 
-CWnd* CGpWinStateMgr::OnGetFrameForWinStateElement(CWinStateElement* pWse)
+CWnd* CGpWinStateMgr::OnGetFrameForWinStateElement(const CWinStateElement& pWse)
 {
-    ASSERT(pWse->m_wWinCode == wincodeViewFrame);
+    ASSERT(pWse.m_wWinCode == wincodeViewFrame);
     CGamDoc* pDoc = GetDocument();
 
-    if (pWse->m_wUserCode1 == gpFrmProject)
+    if (pWse.m_wUserCode1 == gpFrmProject)
     {
         CWnd* pWnd = GetDocumentFrameHavingRuntimeClass(RUNTIME_CLASS(CProjFrame));
         ASSERT(pWnd != NULL);           // Must be open.
         return pWnd;
     }
-    else if (pWse->m_wUserCode1 == gpFrmPlayBoard)
+    else if (pWse.m_wUserCode1 == gpFrmPlayBoard)
     {
         // The second user code is the board's serial number.
-        CPlayBoard& pPBoard = CheckedDeref(pDoc->GetPBoardManager()->GetPBoardBySerial(static_cast<BoardID>(pWse->m_wUserCode2)));
+        CPlayBoard& pPBoard = CheckedDeref(pDoc->GetPBoardManager()->GetPBoardBySerial(static_cast<BoardID>(pWse.m_wUserCode2)));
         CView* pView = pDoc->FindPBoardView(pPBoard);
         if (pView == NULL)
         {
@@ -63,15 +63,15 @@ CWnd* CGpWinStateMgr::OnGetFrameForWinStateElement(CWinStateElement* pWse)
         return NULL;
 }
 
-void CGpWinStateMgr::OnAnnotateWinStateElement(CWinStateElement *pWse, CWnd *pWnd)
+void CGpWinStateMgr::OnAnnotateWinStateElement(CWinStateElement& pWse, CWnd *pWnd)
 {
     if (pWnd->IsKindOf(RUNTIME_CLASS(CProjFrame)))
-        pWse->m_wUserCode1 = gpFrmProject;
+        pWse.m_wUserCode1 = gpFrmProject;
     else if (pWnd->IsKindOf(RUNTIME_CLASS(CPlayBoardFrame)))
     {
         CPlayBoardFrame* pFrame = (CPlayBoardFrame*)pWnd;
-        pWse->m_wUserCode1 = gpFrmPlayBoard;
-        pWse->m_wUserCode2 = static_cast<WORD>(pFrame->m_pPBoard->GetSerialNumber());
+        pWse.m_wUserCode1 = gpFrmPlayBoard;
+        pWse.m_wUserCode2 = static_cast<WORD>(pFrame->m_pPBoard->GetSerialNumber());
     }
 }
 

--- a/GP/WStateGp.h
+++ b/GP/WStateGp.h
@@ -36,8 +36,8 @@ public:
 protected:
     CGamDoc* GetDocument() { return (CGamDoc*)m_pDoc; }
 
-    virtual CWnd* OnGetFrameForWinStateElement(CWinStateElement *pWse);
-    virtual void OnAnnotateWinStateElement(CWinStateElement *pState, CWnd *pWnd);
+    virtual CWnd* OnGetFrameForWinStateElement(const CWinStateElement& pWse) override;
+    virtual void OnAnnotateWinStateElement(CWinStateElement& pState, CWnd *pWnd) override;
 };
 
 #endif

--- a/GShr/Board.cpp
+++ b/GShr/Board.cpp
@@ -350,7 +350,7 @@ void CBoardBase::DrawDrawingList(CDrawList* pDwg, CDC* pDC, CRect* pDrawRct,
 {
     if (pDwg == NULL)
         return;
-    pDwg->Draw(pDC, pDrawRct, eScale, bApplyVisible, bDrawPass2Objects);
+    pDwg->Draw(CheckedDeref(pDC), pDrawRct, eScale, bApplyVisible, bDrawPass2Objects);
 }
 
 // ----------------------------------------------------- //

--- a/GShr/Board.cpp
+++ b/GShr/Board.cpp
@@ -572,11 +572,11 @@ void CBoardManager::Serialize(CArchive& ar)
         ar >> m_wReserved3;
         ar >> m_wReserved4;
         ar >> wTmp;
-        resize(value_preserving_cast<size_t>(wTmp));
-        for (size_t i = 0; i < size(); i++)
+        reserve(wTmp);
+        for (size_t i = 0; i < wTmp; i++)
         {
-            (*this)[i].reset(new CBoard);
-            (*this)[i]->Serialize(ar);
+            push_back(MakeOwner<CBoard>());
+            back()->Serialize(ar);
         }
     }
 }

--- a/GShr/Board.h
+++ b/GShr/Board.h
@@ -210,7 +210,7 @@ public:
     bool IsEmpty() const { return empty(); }
     const CBoard& GetBoard(size_t i) const
     {
-        return CheckedDeref(at(i).get());
+        return *at(i);
     }
     CBoard& GetBoard(size_t i)
     {

--- a/GShr/Board.h
+++ b/GShr/Board.h
@@ -197,7 +197,7 @@ protected:
 /* N.B.:  this holds CBoard* instead of CBoard because CBoard
     derives from CBoardBase, which is designed as a polymorphic
     class */
-class CBoardManager : private std::vector<std::unique_ptr<CBoard>>
+class CBoardManager : private std::vector<OwnerPtr<CBoard>>
 {
     friend class CGamDoc;
 public:
@@ -230,13 +230,9 @@ public:
 
 // Operations
 public:
-    void Add(CBoard* pBoard)
+    void Add(OwnerPtr<CBoard> pBoard)
     {
-        if (!pBoard)
-        {
-            AfxThrowInvalidArgException();
-        }
-        push_back(std::unique_ptr<CBoard>(pBoard));
+        push_back(std::move(pBoard));
     }
     // -------- //
     void DeleteBoard(size_t nBoard) { DestroyElement(nBoard); }
@@ -253,7 +249,7 @@ public:
         { erase(begin() + value_preserving_cast<ptrdiff_t>(iElementIdx)); }
     const CBoard* operator[](size_t nIndex) const
         { return at(nIndex).get(); }
-    std::unique_ptr<CBoard>& operator[](size_t nIndex)
+    OwnerPtr<CBoard>& operator[](size_t nIndex)
         { return at(nIndex); }
     // ------- //
     void Serialize(CArchive& ar);

--- a/GShr/BrdCell.cpp
+++ b/GShr/BrdCell.cpp
@@ -263,7 +263,7 @@ void CBoardArray::FillCell(CDC *pDC, int row, int col, TileScale eScale)
         {
             CBitmap *pBMap = pCF->GetMask();
             if (pBMap != NULL && m_bTransparentCells)
-                tile.TransBlt(pDC, rct.left, rct.top, pCF->GetMaskMemoryInfo());
+                tile.TransBlt(*pDC, rct.left, rct.top, pCF->GetMaskMemoryInfo());
             else if (pBMap != NULL)
             {
                 g_gt.mDC1.SelectObject(pBMap);
@@ -271,14 +271,14 @@ void CBoardArray::FillCell(CDC *pDC, int row, int col, TileScale eScale)
                 pDC->SetBkColor(RGB(255, 255, 255));
                 pDC->SetTextColor(RGB(0, 0, 0));
 
-                tile.BitBlt(pDC, rct.left, rct.top, SRCINVERT);
+                tile.BitBlt(*pDC, rct.left, rct.top, SRCINVERT);
                 pDC->BitBlt(rct.left, rct.top, rct.right, rct.bottom,
                     &g_gt.mDC1, 0, 0, SRCAND);
-                tile.BitBlt(pDC, rct.left, rct.top, SRCINVERT);
+                tile.BitBlt(*pDC, rct.left, rct.top, SRCINVERT);
                 g_gt.SelectSafeObjectsForDC1();
             }
             else
-                tile.BitBlt(pDC, rct.left, rct.top, SRCCOPY);
+                tile.BitBlt(*pDC, rct.left, rct.top, SRCCOPY);
         }
         else    // Handle small scale tiles here.
         {

--- a/GShr/CDib.cpp
+++ b/GShr/CDib.cpp
@@ -161,7 +161,7 @@ void CDib::SetDibHandle(HANDLE hDib)
     }
 }
 
-BOOL CDib::BitmapToDIB(const CBitmap* pBM, CPalette* pPal, int nBPP/* = 16*/)
+BOOL CDib::BitmapToDIB(const CBitmap* pBM, const CPalette* pPal, int nBPP/* = 16*/)
 {
     ClearDib();
     if (pBM->m_hObject != NULL)
@@ -183,7 +183,7 @@ BOOL CDib::BitmapToDIB(const CBitmap* pBM, CPalette* pPal, int nBPP/* = 16*/)
     return m_hDib != NULL;
 }
 
-OwnerPtr<CBitmap> CDib::DIBToBitmap(CPalette *pPal, BOOL bDibSect /* = TRUE */)
+OwnerPtr<CBitmap> CDib::DIBToBitmap(const CPalette *pPal, BOOL bDibSect /* = TRUE */)
 {
     if (bDibSect)
     {

--- a/GShr/CDib.cpp
+++ b/GShr/CDib.cpp
@@ -141,7 +141,7 @@ void CDib::SetDibHandle(HANDLE hDib)
     m_lpDib = (LPSTR)GlobalLock((HGLOBAL)m_hDib);
 }
 
-BOOL CDib::BitmapToDIB(CBitmap* pBM, CPalette* pPal, int nBPP/* = 16*/)
+BOOL CDib::BitmapToDIB(const CBitmap* pBM, CPalette* pPal, int nBPP/* = 16*/)
 {
     ClearDib();
     if (pBM->m_hObject != NULL)

--- a/GShr/CDib.h
+++ b/GShr/CDib.h
@@ -36,14 +36,13 @@ public:
     ~CDib() { ClearDib(); }
     void ClearDib();
     // ---------- /
-    BOOL CreateDIB(DWORD dwWidth, DWORD dwHeight, WORD wBPP = 16);
+    void CreateDIB(DWORD dwWidth, DWORD dwHeight, WORD wBPP = 16);
     // ---------- /
-    BOOL ReadDIBFile(CFile& file);
+    void ReadDIBFile(CFile& file);
     BOOL WriteDIBFile(CFile& file);
-    BOOL WriteDIBtoPNGFile(LPCSTR pszName);
-    BOOL CloneDIB(CDib *pDib);
+    void CloneDIB(CDib *pDib);
     BOOL BitmapToDIB(const CBitmap* pBM, CPalette* pPal = NULL, int nBPP = 16);
-    std::unique_ptr<CBitmap> DIBToBitmap(CPalette *pPal, BOOL bDibSect = TRUE);
+    OwnerPtr<CBitmap> DIBToBitmap(CPalette *pPal, BOOL bDibSect = TRUE);
     BOOL AppendDIB(CDib *pDib);
     BOOL RemoveDIBSlice(int y, int ht);
     void AddColorsToPaletteEntryTable(LPPALETTEENTRY pLP, int nSize,

--- a/GShr/CDib.h
+++ b/GShr/CDib.h
@@ -42,7 +42,7 @@ public:
     BOOL WriteDIBFile(CFile& file);
     BOOL WriteDIBtoPNGFile(LPCSTR pszName);
     BOOL CloneDIB(CDib *pDib);
-    BOOL BitmapToDIB(CBitmap* pBM, CPalette* pPal = NULL, int nBPP = 16);
+    BOOL BitmapToDIB(const CBitmap* pBM, CPalette* pPal = NULL, int nBPP = 16);
     std::unique_ptr<CBitmap> DIBToBitmap(CPalette *pPal, BOOL bDibSect = TRUE);
     BOOL AppendDIB(CDib *pDib);
     BOOL RemoveDIBSlice(int y, int ht);

--- a/GShr/CDib.h
+++ b/GShr/CDib.h
@@ -41,8 +41,8 @@ public:
     void ReadDIBFile(CFile& file);
     BOOL WriteDIBFile(CFile& file);
     void CloneDIB(CDib *pDib);
-    BOOL BitmapToDIB(const CBitmap* pBM, CPalette* pPal = NULL, int nBPP = 16);
-    OwnerPtr<CBitmap> DIBToBitmap(CPalette *pPal, BOOL bDibSect = TRUE);
+    BOOL BitmapToDIB(const CBitmap* pBM, const CPalette* pPal = NULL, int nBPP = 16);
+    OwnerPtr<CBitmap> DIBToBitmap(const CPalette *pPal, BOOL bDibSect = TRUE);
     BOOL AppendDIB(CDib *pDib);
     BOOL RemoveDIBSlice(int y, int ht);
     void AddColorsToPaletteEntryTable(LPPALETTEENTRY pLP, int nSize,

--- a/GShr/CyberBoard.h
+++ b/GShr/CyberBoard.h
@@ -354,6 +354,38 @@ namespace CB
     }
 }
 
+template<typename T>
+using OwnerPtr = CB::not_null<CB::propagate_const<std::unique_ptr<T>>>;
+
+// like c++14 std::make_unique<>
+template<typename T, typename... Args>
+OwnerPtr<T> MakeOwner(Args&&... args)
+{
+    return OwnerPtr<T>(new T(std::forward<Args>(args)...));
+}
+
+template<typename T>
+class OwnerOrNullPtr : public CB::propagate_const<std::unique_ptr<T>>
+{
+    using BASE = CB::propagate_const<std::unique_ptr<T>>;
+
+public:
+    using BASE::BASE;
+    using BASE::operator=;
+
+    OwnerOrNullPtr() = default;
+
+    template<typename U>
+    OwnerOrNullPtr(OwnerPtr<U>&& pu) : BASE(CB::get_underlying(std::move(pu))) {}
+
+    template<typename U>
+    OwnerOrNullPtr& operator=(OwnerPtr<U>&& pu)
+    {
+        *this = CB::get_underlying(std::move(pu));
+        return *this;
+    }
+};
+
 /////////////////////////////////////////////////////////////////////////////
 
 /* Invalid_v<T> is used as the "no-value" value for type T.

--- a/GShr/CyberBoard.h
+++ b/GShr/CyberBoard.h
@@ -59,15 +59,6 @@ namespace CB
         }
     }
 
-    template<typename RIGHT>
-    void Copy(CPtrList& left, const RIGHT& right)
-    {
-        left.RemoveAll();
-        for (RIGHT::const_iterator it = right.begin() ; it != right.end() ; ++it) {
-            left.AddTail(&**it);
-        }
-    }
-
     template<typename LEFT, typename RIGHT>
     void Move(LEFT& left, RIGHT&& right)
     {

--- a/GShr/CyberBoard.h
+++ b/GShr/CyberBoard.h
@@ -44,6 +44,43 @@
 
 /////////////////////////////////////////////////////////////////////////////
 
+namespace CB
+{
+    // adapters for different container types
+    // TODO:  add support for std::vector::reserve?
+    // TODO:  avoid need for these since they're runtime overhead
+    template<typename LEFT, typename RIGHT>
+    void Copy(LEFT& left, const RIGHT& right)
+    {
+        left.clear();
+        for (RIGHT::const_iterator it = right.begin() ; it != right.end() ; ++it)
+        {
+            left.push_back(*it);
+        }
+    }
+
+    template<typename RIGHT>
+    void Copy(CPtrList& left, const RIGHT& right)
+    {
+        left.RemoveAll();
+        for (RIGHT::const_iterator it = right.begin() ; it != right.end() ; ++it) {
+            left.AddTail(&**it);
+        }
+    }
+
+    template<typename LEFT, typename RIGHT>
+    void Move(LEFT& left, RIGHT&& right)
+    {
+        left.clear();
+        for (RIGHT::iterator it = right.begin() ; it != right.end() ; ++it)
+        {
+            left.push_back(std::move(*it));
+        }
+    }
+}
+
+/////////////////////////////////////////////////////////////////////////////
+
 /* Invalid_v<T> is used as the "no-value" value for type T.
     It will probably be set to std::numeric_limits<T>::max(). */
 

--- a/GShr/CyberBoard.h
+++ b/GShr/CyberBoard.h
@@ -386,6 +386,16 @@ public:
     }
 };
 
+/* Like pointers, references do not propagate const.
+    However, unlike operator->(), it is not possible to declare
+    operator.(), so a wrapper like propagate_const can't be
+    created for refs.  Therefore, let's define RefPtr,
+    i.e., a pointer that is not-null, has a constant value,
+    and doesn't own the target, to approximate a ref, and
+    use propagate_const on it.  */
+template<typename T>
+using RefPtr = CB::not_null<CB::propagate_const<T* const>>;
+
 /////////////////////////////////////////////////////////////////////////////
 
 /* Invalid_v<T> is used as the "no-value" value for type T.

--- a/GShr/CyberBoard.h
+++ b/GShr/CyberBoard.h
@@ -221,28 +221,24 @@ namespace CB
             CheckValid();
         }
 
-        /* N.B.:  causes u to violate not_null, but moved-from
+        /* N.B.:  causes pu to violate not_null, but moved-from
                 objects are in an undefined state, so let's
                 allow this */
         template<typename PU>
         not_null(not_null<PU>&& pu) :
             p(std::forward<PU>(get_underlying(std::move(pu))))
         {
-            // see get()
-            //CheckValid();
+            CheckValid();
         }
 
-        /* ctor check means we can probably skip CheckValid when
-            reading, but dirty cast or move tricks could still
-            clear p.  Opinions? */
         deref_ptr_const_type* get() const
         {
-            //CheckValid();
+            CheckValid();
             return &*p;
         }
         deref_ptr_type* get()
         {
-            //CheckValid();
+            CheckValid();
             return &*p;
         }
 
@@ -427,9 +423,6 @@ constexpr T Invalid_v = Invalid<T>::value;
 
 /////////////////////////////////////////////////////////////////////////////
 
-/* TODO:  The checks could be removed to improve release
-    build performance if we trust ourselves to always
-    catch any mistakes in testing.  */
 template<typename T>
 decltype(*std::declval<T>()) CheckedDeref(T& p)
 {

--- a/GShr/CyberBoard.h
+++ b/GShr/CyberBoard.h
@@ -99,8 +99,21 @@ constexpr T Invalid_v = Invalid<T>::value;
 
 /////////////////////////////////////////////////////////////////////////////
 
+/* TODO:  The checks could be removed to improve release
+    build performance if we trust ourselves to always
+    catch any mistakes in testing.  */
 template<typename T>
-T& CheckedDeref(T* p)
+decltype(*std::declval<T>()) CheckedDeref(T& p)
+{
+    ASSERT(p);
+    if (!p) {
+        AfxThrowInvalidArgException();
+    }
+    return *p;
+}
+
+template<typename T>
+decltype(*std::declval<const T>()) CheckedDeref(const T& p)
 {
     ASSERT(p);
     if (!p) {

--- a/GShr/CyberBoard.h
+++ b/GShr/CyberBoard.h
@@ -102,14 +102,6 @@ namespace CB
         template<typename PU>
         propagate_const(PU* pu) : p(pu) {}
 
-#if 1   // TODO:  remove
-        template<typename PU>
-        propagate_const(PU&& pu) :
-            p(std::forward<PU>(pu))
-        {
-        }
-#endif
-
         template<typename PU>
         propagate_const(propagate_const<PU>&& pu) : p(std::move(get_underlying(pu))) {}
 
@@ -237,15 +229,6 @@ namespace CB
         {
             CheckValid();
         }
-
-#if 1   // TODO:  remove
-        template<typename PU, typename std::enable_if_t<!std::is_convertible_v<PU, not_null>, bool> = true>
-        not_null(PU&& pu) :
-            p(std::forward<PU>(pu))
-        {
-            CheckValid();
-        }
-#endif
 
         /* N.B.:  causes u to violate not_null, but moved-from
                 objects are in an undefined state, so let's

--- a/GShr/DragDrop.h
+++ b/GShr/DragDrop.h
@@ -125,7 +125,7 @@ struct DragInfo
     template<>
     struct SubInfo<DRAG_SELECTVIEW>
     {
-        std::vector<CDrawObj*>* m_ptrArray;
+        const std::vector<CB::propagate_const<CDrawObj*>>* m_ptrArray;
         CGamDoc* m_gamDoc;
     };
     // TODO:  when upgrade to c++ 17, use std::variant

--- a/GShr/DragDrop.h
+++ b/GShr/DragDrop.h
@@ -125,7 +125,7 @@ struct DragInfo
     template<>
     struct SubInfo<DRAG_SELECTVIEW>
     {
-        const std::vector<CB::propagate_const<CDrawObj*>>* m_ptrArray;
+        const std::vector<CB::not_null<CB::propagate_const<CDrawObj*>>>* m_ptrArray;
         CGamDoc* m_gamDoc;
     };
     // TODO:  when upgrade to c++ 17, use std::variant

--- a/GShr/DrawObj.cpp
+++ b/GShr/DrawObj.cpp
@@ -845,8 +845,7 @@ void CBitmapImage::Serialize(CArchive& ar)
         ar >> dib;
         if (dib.m_hDib != NULL)
         {
-            std::unique_ptr<CBitmap> pBMap = dib.DIBToBitmap(GetAppPalette());
-            ASSERT(pBMap != NULL);
+            ::OwnerPtr<CBitmap> pBMap = dib.DIBToBitmap(GetAppPalette());
             m_bitmap.Attach(pBMap->Detach());
         }
     }

--- a/GShr/DrawObj.cpp
+++ b/GShr/DrawObj.cpp
@@ -308,9 +308,9 @@ void CRectObj::ForceIntoZone(CRect* pRctZone)
         m_rctExtent += pntOffset;
 }
 
-CSelection* CRectObj::CreateSelectProxy(CBrdEditView* pView)
+CSelection* CRectObj::CreateSelectProxy(CBrdEditView& pView)
 {
-    return new CSelRect(pView, this);
+    return new CSelRect(pView, *this);
 }
 #endif
 
@@ -369,9 +369,9 @@ void CEllipse::Draw(CDC *pDC, TileScale)
 }
 
 #ifndef     GPLAY
-CSelection* CEllipse::CreateSelectProxy(CBrdEditView* pView)
+CSelection* CEllipse::CreateSelectProxy(CBrdEditView& pView)
 {
-    return new CSelEllipse(pView, this);
+    return new CSelEllipse(pView, *this);
 }
 #endif
 
@@ -480,9 +480,9 @@ void CPolyObj::ForceIntoZone(CRect* pRctZone)
 #endif
 
 #ifndef     GPLAY
-CSelection* CPolyObj::CreateSelectProxy(CBrdEditView* pView)
+CSelection* CPolyObj::CreateSelectProxy(CBrdEditView& pView)
 {
-    return new CSelPoly(pView, this);
+    return new CSelPoly(pView, *this);
 }
 #endif
 
@@ -609,12 +609,12 @@ void CLine::ForceIntoZone(CRect* pRctZone)
 #endif
 
 #ifdef GPLAY
-CSelection* CLine::CreateSelectProxy(CPlayBoardView* pView)
+CSelection* CLine::CreateSelectProxy(CPlayBoardView& pView)
 #else
-CSelection* CLine::CreateSelectProxy(CBrdEditView* pView)
+CSelection* CLine::CreateSelectProxy(CBrdEditView& pView)
 #endif
 {
-    return new CSelLine(pView, this);
+    return new CSelLine(pView, *this);
 }
 
 //DFM19991221
@@ -792,9 +792,9 @@ void CBitmapImage::ForceIntoZone(CRect* pRctZone)
 #endif
 
 #ifndef GPLAY
-CSelection* CBitmapImage::CreateSelectProxy(CBrdEditView* pView)
+CSelection* CBitmapImage::CreateSelectProxy(CBrdEditView& pView)
 {
-    return new CSelGeneric(pView, this);
+    return new CSelGeneric(pView, *this);
 }
 #endif
 
@@ -900,9 +900,9 @@ void CTileImage::ForceIntoZone(CRect* pRctZone)
 #endif
 
 #ifndef GPLAY
-CSelection* CTileImage::CreateSelectProxy(CBrdEditView* pView)
+CSelection* CTileImage::CreateSelectProxy(CBrdEditView& pView)
 {
-    return new CSelGeneric(pView, this);
+    return new CSelGeneric(pView, *this);
 }
 #endif
 
@@ -1017,9 +1017,9 @@ void CText::OffsetObject(CPoint offset)
 }
 
 #ifndef GPLAY
-CSelection* CText::CreateSelectProxy(CBrdEditView* pView)
+CSelection* CText::CreateSelectProxy(CBrdEditView& pView)
 {
-    return new CSelGeneric(pView, this);
+    return new CSelGeneric(pView, *this);
 }
 #endif
 
@@ -1188,9 +1188,9 @@ BOOL CPieceObj::HitTest(CPoint pt)
     return rct.PtInRect(pt);
 }
 
-CSelection* CPieceObj::CreateSelectProxy(CPlayBoardView* pView)
+CSelection* CPieceObj::CreateSelectProxy(CPlayBoardView& pView)
 {
-    return new CSelGeneric(pView, this);
+    return new CSelGeneric(pView, *this);
 }
 
 CDrawObj::OwnerPtr CPieceObj::Clone(CGamDoc* pDoc)
@@ -1295,9 +1295,9 @@ BOOL CMarkObj::HitTest(CPoint pt)
     return rct.PtInRect(pt);
 }
 
-CSelection* CMarkObj::CreateSelectProxy(CPlayBoardView* pView)
+CSelection* CMarkObj::CreateSelectProxy(CPlayBoardView& pView)
 {
-    return new CSelGeneric(pView, this);
+    return new CSelGeneric(pView, *this);
 }
 
 CDrawObj::OwnerPtr CMarkObj::Clone(CGamDoc* pDoc)

--- a/GShr/DrawObj.cpp
+++ b/GShr/DrawObj.cpp
@@ -1582,12 +1582,12 @@ void CDrawList::ArrangePieceTableInVisualOrder(std::vector<PieceID>& pTbl) const
     pTbl = std::move(tmpTbl);
 }
 
-void CDrawList::ArrangeObjectPtrTableInDrawOrder(std::vector<CDrawObj*>& pTbl) const
+void CDrawList::ArrangeObjectPtrTableInDrawOrder(std::vector<CB::not_null<CDrawObj*>>& pTbl) const
 {
     // Loop through the drawing list looking for objects that are
     // selected. Add them to a local list. When done, purge the caller's
     // list and transfer temp list to the callers list.
-    std::vector<CDrawObj*> tmpTbl;
+    std::vector<CB::not_null<CDrawObj*>> tmpTbl;
     tmpTbl.reserve(pTbl.size());
 
     for (const_iterator pos = begin(); pos != end(); ++pos)
@@ -1607,12 +1607,12 @@ void CDrawList::ArrangeObjectPtrTableInDrawOrder(std::vector<CDrawObj*>& pTbl) c
     pTbl = std::move(tmpTbl);
 }
 
-void CDrawList::ArrangeObjectPtrTableInVisualOrder(std::vector<CDrawObj*>& pTbl) const
+void CDrawList::ArrangeObjectPtrTableInVisualOrder(std::vector<CB::not_null<CDrawObj*>>& pTbl) const
 {
     // Loop through the drawing list looking for objects that are
     // selected. Add them to a local list. When done, purge the caller's
     // list and transfer temp list to the callers list.
-    std::vector<CDrawObj*> tmpTbl;
+    std::vector<CB::not_null<CDrawObj*>> tmpTbl;
     tmpTbl.reserve(pTbl.size());
 
     for (const_reverse_iterator pos = rbegin(); pos != rend(); ++pos)

--- a/GShr/DrawObj.cpp
+++ b/GShr/DrawObj.cpp
@@ -308,9 +308,9 @@ void CRectObj::ForceIntoZone(const CRect& pRctZone)
         m_rctExtent += pntOffset;
 }
 
-CSelection* CRectObj::CreateSelectProxy(CBrdEditView& pView)
+OwnerPtr<CSelection> CRectObj::CreateSelectProxy(CBrdEditView& pView)
 {
-    return new CSelRect(pView, *this);
+    return MakeOwner<CSelRect>(pView, *this);
 }
 #endif
 
@@ -369,9 +369,9 @@ void CEllipse::Draw(CDC& pDC, TileScale)
 }
 
 #ifndef     GPLAY
-CSelection* CEllipse::CreateSelectProxy(CBrdEditView& pView)
+OwnerPtr<CSelection> CEllipse::CreateSelectProxy(CBrdEditView& pView)
 {
-    return new CSelEllipse(pView, *this);
+    return MakeOwner<CSelEllipse>(pView, *this);
 }
 #endif
 
@@ -468,9 +468,9 @@ void CPolyObj::ForceIntoZone(const CRect& pRctZone)
 #endif
 
 #ifndef     GPLAY
-CSelection* CPolyObj::CreateSelectProxy(CBrdEditView& pView)
+OwnerPtr<CSelection> CPolyObj::CreateSelectProxy(CBrdEditView& pView)
 {
-    return new CSelPoly(pView, *this);
+    return MakeOwner<CSelPoly>(pView, *this);
 }
 #endif
 
@@ -594,12 +594,12 @@ void CLine::ForceIntoZone(const CRect& pRctZone)
 #endif
 
 #ifdef GPLAY
-CSelection* CLine::CreateSelectProxy(CPlayBoardView& pView)
+OwnerPtr<CSelection> CLine::CreateSelectProxy(CPlayBoardView& pView)
 #else
-CSelection* CLine::CreateSelectProxy(CBrdEditView& pView)
+OwnerPtr<CSelection> CLine::CreateSelectProxy(CBrdEditView& pView)
 #endif
 {
-    return new CSelLine(pView, *this);
+    return MakeOwner<CSelLine>(pView, *this);
 }
 
 //DFM19991221
@@ -781,9 +781,9 @@ void CBitmapImage::ForceIntoZone(const CRect& pRctZone)
 #endif
 
 #ifndef GPLAY
-CSelection* CBitmapImage::CreateSelectProxy(CBrdEditView& pView)
+OwnerPtr<CSelection> CBitmapImage::CreateSelectProxy(CBrdEditView& pView)
 {
-    return new CSelGeneric(pView, *this);
+    return MakeOwner<CSelGeneric>(pView, *this);
 }
 #endif
 
@@ -889,9 +889,9 @@ void CTileImage::ForceIntoZone(const CRect& pRctZone)
 #endif
 
 #ifndef GPLAY
-CSelection* CTileImage::CreateSelectProxy(CBrdEditView& pView)
+OwnerPtr<CSelection> CTileImage::CreateSelectProxy(CBrdEditView& pView)
 {
-    return new CSelGeneric(pView, *this);
+    return MakeOwner<CSelGeneric>(pView, *this);
 }
 #endif
 
@@ -1006,9 +1006,9 @@ void CText::OffsetObject(CPoint offset)
 }
 
 #ifndef GPLAY
-CSelection* CText::CreateSelectProxy(CBrdEditView& pView)
+OwnerPtr<CSelection> CText::CreateSelectProxy(CBrdEditView& pView)
 {
-    return new CSelGeneric(pView, *this);
+    return MakeOwner<CSelGeneric>(pView, *this);
 }
 #endif
 
@@ -1177,9 +1177,9 @@ BOOL CPieceObj::HitTest(CPoint pt)
     return rct.PtInRect(pt);
 }
 
-CSelection* CPieceObj::CreateSelectProxy(CPlayBoardView& pView)
+OwnerPtr<CSelection> CPieceObj::CreateSelectProxy(CPlayBoardView& pView)
 {
-    return new CSelGeneric(pView, *this);
+    return MakeOwner<CSelGeneric>(pView, *this);
 }
 
 CDrawObj::OwnerPtr CPieceObj::Clone(CGamDoc* pDoc) const
@@ -1288,9 +1288,9 @@ BOOL CMarkObj::HitTest(CPoint pt)
     return rct.PtInRect(pt);
 }
 
-CSelection* CMarkObj::CreateSelectProxy(CPlayBoardView& pView)
+OwnerPtr<CSelection> CMarkObj::CreateSelectProxy(CPlayBoardView& pView)
 {
-    return new CSelGeneric(pView, *this);
+    return MakeOwner<CSelGeneric>(pView, *this);
 }
 
 CDrawObj::OwnerPtr CMarkObj::Clone(CGamDoc* pDoc) const

--- a/GShr/DrawObj.cpp
+++ b/GShr/DrawObj.cpp
@@ -1130,7 +1130,7 @@ void CPieceObj::SetOwnerMask(DWORD dwMask)
     pPTbl->SetOwnerMask(m_pid, dwMask);
 }
 
-BOOL CPieceObj::IsOwned()
+BOOL CPieceObj::IsOwned() const
 {
     ASSERT(m_pDoc != NULL);
     CPieceTable* pPTbl = m_pDoc->GetPieceTable();
@@ -1138,7 +1138,7 @@ BOOL CPieceObj::IsOwned()
     return pPTbl->IsPieceOwned(m_pid);
 }
 
-BOOL CPieceObj::IsOwnedBy(DWORD dwMask)
+BOOL CPieceObj::IsOwnedBy(DWORD dwMask) const
 {
     ASSERT(m_pDoc != NULL);
     CPieceTable* pPTbl = m_pDoc->GetPieceTable();
@@ -1146,7 +1146,7 @@ BOOL CPieceObj::IsOwnedBy(DWORD dwMask)
     return pPTbl->IsPieceOwnedBy(m_pid, dwMask);
 }
 
-BOOL CPieceObj::IsOwnedButNotByCurrentPlayer()
+BOOL CPieceObj::IsOwnedButNotByCurrentPlayer() const
 {
     ASSERT(m_pDoc != NULL);
     CPieceTable* pPTbl = m_pDoc->GetPieceTable();

--- a/GShr/DrawObj.h
+++ b/GShr/DrawObj.h
@@ -92,25 +92,25 @@ public:
 
     void SetScaleVisibility(int fTileScale)
         { m_dwDObjFlags = ChangeBits(m_dwDObjFlags, fTileScale, dobjFlgLayerMask); }
-    int GetScaleVisibility() { return (int)(GetDObjFlags() & dobjFlgLayerMask); }
-    DWORD GetDObjFlags() { return m_dwDObjFlags; }
+    int GetScaleVisibility() const { return (int)(GetDObjFlags() & dobjFlgLayerMask); }
+    DWORD GetDObjFlags() const { return m_dwDObjFlags; }
     void  SetDObjFlags(DWORD dwFlags) { m_dwDObjFlags |= dwFlags; }
     void  ClearDObjFlags(DWORD dwFlags) { m_dwDObjFlags &= ~dwFlags; }
     void  ModifyDObjFlags(DWORD dwFlags, BOOL bState)
         { if (bState) SetDObjFlags(dwFlags); else ClearDObjFlags(dwFlags); }
 
     virtual CRect& GetRect() /* override */ { return m_rctExtent; }
-    virtual const void SetRect(const CRect& rct) /* override */ { m_rctExtent = rct; }
+    virtual void SetRect(const CRect& rct) /* override */ { m_rctExtent = rct; }
 
-    virtual CRect GetEnclosingRect() /* override */ { return m_rctExtent; }
+    virtual CRect GetEnclosingRect() const /* override */ { return m_rctExtent; }
     virtual BOOL HitTest(CPoint pt) /* override */ { return FALSE; }
 #ifdef GPLAY
-    virtual ObjectID GetObjectID() /* override */;
+    virtual ObjectID GetObjectID() const /* override */;
     virtual void MoveObject(CPoint ptUpLeft) /* override */;
 #endif
     virtual void OffsetObject(CPoint offset) /* override */;
     // ----- //
-    virtual BOOL IsVisible(RECT* pClipRct) /* override */;
+    virtual BOOL IsVisible(const RECT& pClipRct) const /* override */;
     virtual CDrawObjType GetType() const /* override */ = 0;
     // ----- //
     // Some functions that may or may not mean anything to the
@@ -123,7 +123,7 @@ public:
 
 // Operations
 public:
-    virtual void Draw(CDC* pDC, TileScale eScale) /* override */ = 0;
+    virtual void Draw(CDC& pDC, TileScale eScale) /* override */ = 0;
     // Support required by selection objects
 #ifdef GPLAY
     virtual CSelection* CreateSelectProxy(CPlayBoardView& pView) /* override */ { return NULL; }
@@ -132,28 +132,28 @@ public:
 #endif
     // ------- //
 #ifndef GPLAY
-    virtual void ForceIntoZone(CRect* pRctZone) /* override */ = 0;
+    virtual void ForceIntoZone(const CRect& pRctZone) /* override */ = 0;
 #endif
-    virtual OwnerPtr Clone() /* override */ { AfxThrowInvalidArgException(); }
+    virtual OwnerPtr Clone() const /* override */ { AfxThrowInvalidArgException(); }
 #ifdef GPLAY
-    virtual OwnerPtr Clone(CGamDoc* pDoc) /* override */ { AfxThrowInvalidArgException(); }
-    virtual BOOL Compare(CDrawObj* pObj) /* override */ { AfxThrowInvalidArgException(); }
+    virtual OwnerPtr Clone(CGamDoc* pDoc) const /* override */ { AfxThrowInvalidArgException(); }
+    virtual BOOL Compare(const CDrawObj& pObj) const /* override */ { AfxThrowInvalidArgException(); }
 #endif
     // ------- //
     virtual void Serialize(CArchive& ar) /* override */;
 
 // Implementation - methods
 protected:
-    BOOL IsExtentOutOfZone(CRect* pRctZone, CPoint& pntOffset);
+    BOOL IsExtentOutOfZone(const CRect& pRctZone, CPoint& pntOffset) const;
     // ------- //
-    virtual void SetUpDraw(CDC* pDC, CPen* pPen, CBrush* pBrush) /* override */;
-    virtual void CleanUpDraw(CDC *pDC) /* override */;
+    virtual void SetUpDraw(CDC& pDC, CPen& pPen, CBrush& pBrush) const /* override */;
+    virtual void CleanUpDraw(CDC& pDC) const /* override */;
     virtual BOOL BitBlockHitTest(CPoint pt) /* override */;
-    virtual UINT GetLineWidth() /* override */ { return 0; }
-    virtual COLORREF GetLineColor() /* override */ { return noColor; }
-    virtual COLORREF GetFillColor() /* override */ { return noColor; }
+    virtual UINT GetLineWidth() const /* override */ { return 0; }
+    virtual COLORREF GetLineColor() const /* override */ { return noColor; }
+    virtual COLORREF GetFillColor() const /* override */ { return noColor; }
 
-    void CopyAttributes (CDrawObj* source);    //DFM19991213
+    void CopyAttributes (const CDrawObj& source);    //DFM19991213
 
 // Implementation - vars
 protected:
@@ -239,7 +239,7 @@ public:
     COLORREF m_crLine;
     UINT     m_nLineWidth;
 
-    virtual CRect GetEnclosingRect() override;
+    virtual CRect GetEnclosingRect() const override;
     virtual enum CDrawObjType GetType() const override { return drawRect; }
 
     void SetRect(RECT* rect) { m_rctExtent = rect; }
@@ -251,7 +251,7 @@ public:
 
 // Operations
 public:
-    virtual void Draw(CDC* pDC, TileScale eScale) override;
+    virtual void Draw(CDC& pDC, TileScale eScale) override;
 
     // Support required by selection processing.
     virtual BOOL HitTest(CPoint pt) override;
@@ -260,19 +260,19 @@ public:
 #endif
     // ------- //
 #ifndef GPLAY
-    virtual void ForceIntoZone(CRect* pRctZone) override;
+    virtual void ForceIntoZone(const CRect& pRctZone) override;
 #endif
     // ------- //
-    virtual OwnerPtr Clone() override;                  //DFM19991210
+    virtual OwnerPtr Clone() const override;                  //DFM19991210
 
     virtual void Serialize(CArchive& ar) override;
 // Implementation
 protected:
-    virtual UINT GetLineWidth() override { return m_nLineWidth; }
-    virtual COLORREF GetLineColor() override { return m_crLine; }
-    virtual COLORREF GetFillColor() override { return m_crFill; }
+    virtual UINT GetLineWidth() const override { return m_nLineWidth; }
+    virtual COLORREF GetLineColor() const override { return m_crLine; }
+    virtual COLORREF GetFillColor() const override { return m_crFill; }
 
-    void CopyAttributes (CRectObj* source);     //DFM19991213
+    void CopyAttributes (const CRectObj& source);     //DFM19991213
 };
 
 ///////////////////////////////////////////////////////////////////////
@@ -287,11 +287,11 @@ public:
 
 // Operations
 public:
-    virtual void Draw(CDC* pDC, TileScale eScale) override;
+    virtual void Draw(CDC& pDC, TileScale eScale) override;
 #ifndef GPLAY
     virtual CSelection* CreateSelectProxy(CBrdEditView& pView) override;
 #endif
-    virtual OwnerPtr Clone() override;  //DFM19991210
+    virtual OwnerPtr Clone() const override;  //DFM19991210
 };
 
 ///////////////////////////////////////////////////////////////////////
@@ -318,7 +318,7 @@ public:
     void GetLine(POINT& ptBeg, POINT& ptEnd)
         { ptBeg = m_ptBeg; ptEnd = m_ptEnd; }
 
-    virtual CRect GetEnclosingRect() override;
+    virtual CRect GetEnclosingRect() const override;
     virtual enum CDrawObjType GetType() const override { return drawLine; }
 
     virtual BOOL SetForeColor(COLORREF cr) override { m_crLine = cr; return TRUE; }
@@ -327,7 +327,7 @@ public:
 
 // Operations
 public:
-    virtual void Draw(CDC* pDC, TileScale eScale) override;
+    virtual void Draw(CDC& pDC, TileScale eScale) override;
     // Support required by selection processing.
     virtual BOOL HitTest(CPoint pt) override;
 #ifdef GPLAY
@@ -337,19 +337,19 @@ public:
 #endif
     // ------- //
 #ifndef GPLAY
-    virtual void ForceIntoZone(CRect* pRctZone) override;
+    virtual void ForceIntoZone(const CRect& pRctZone) override;
 #endif
     virtual void OffsetObject(CPoint offset) override;       //DFM19991221
     // ------- //
-    virtual OwnerPtr Clone(void) override;                  //DFM19991210
+    virtual OwnerPtr Clone(void) const override;                  //DFM19991210
 #ifdef GPLAY
-    virtual OwnerPtr Clone(CGamDoc* pDoc) override;
-    virtual BOOL Compare(CDrawObj* pObj) override;
+    virtual OwnerPtr Clone(CGamDoc* pDoc) const override;
+    virtual BOOL Compare(const CDrawObj& pObj) const override;
 #endif
     virtual void Serialize(CArchive& ar) override;
 
 protected:
-    void CopyAttributes (CLine *source);            //DFM19991214
+    void CopyAttributes (const CLine& source);            //DFM19991214
 };
 
 ///////////////////////////////////////////////////////////////////////
@@ -371,7 +371,7 @@ public:
     POINT*   m_pPnts;
     int      m_nPnts;
 
-    virtual CRect GetEnclosingRect() override;
+    virtual CRect GetEnclosingRect() const override;
     virtual enum CDrawObjType GetType() const override { return drawPolygon; }
 
     virtual BOOL SetForeColor(COLORREF cr) override { m_crLine = cr; return TRUE; }
@@ -386,7 +386,7 @@ public:
 
 // Overrides
 public:
-    virtual void Draw(CDC* pDC, TileScale eScale) override;
+    virtual void Draw(CDC& pDC, TileScale eScale) override;
 
     // Support required by selection processing.
     virtual BOOL HitTest(CPoint pt) override;
@@ -395,23 +395,23 @@ public:
 #endif
     // ------- //
 #ifndef GPLAY
-    virtual void ForceIntoZone(CRect* pRctZone) override;
+    virtual void ForceIntoZone(const CRect& pRctZone) override;
 #endif
     virtual void OffsetObject(CPoint offset) override; //DFM19991221
     // ------- //
-    virtual OwnerPtr Clone() override;
+    virtual OwnerPtr Clone() const override;
 
     virtual void Serialize(CArchive& ar) override;
 // Implementation
 protected:
     void ComputeExtent();
 
-    void CopyAttributes(CPolyObj *source);
+    void CopyAttributes(const CPolyObj& source);
 
     // ------- //
-    virtual UINT GetLineWidth() override { return m_nLineWidth; }
-    virtual COLORREF GetLineColor() override { return m_crLine; }
-    virtual COLORREF GetFillColor() override { return m_crFill; }
+    virtual UINT GetLineWidth() const override { return m_nLineWidth; }
+    virtual COLORREF GetLineColor() const override { return m_crLine; }
+    virtual COLORREF GetFillColor() const override { return m_crFill; }
 };
 
 ///////////////////////////////////////////////////////////////////////
@@ -438,7 +438,7 @@ public:
 
 // Operations
 public:
-    virtual void Draw(CDC* pDC, TileScale eScale) override;
+    virtual void Draw(CDC& pDC, TileScale eScale) override;
     // Support required by selection processing.
     virtual BOOL HitTest(CPoint pt) override;
 #ifndef GPLAY
@@ -446,13 +446,13 @@ public:
 #endif
     // ------- //
 #ifndef GPLAY
-    virtual void ForceIntoZone(CRect* pRctZone) override;
+    virtual void ForceIntoZone(const CRect& pRctZone) override;
 #endif
     virtual void OffsetObject(CPoint offset) override;
     // ------- //
-    virtual OwnerPtr Clone() override;
+    virtual OwnerPtr Clone() const override;
 
-    void CopyAttributes(CText *source);
+    void CopyAttributes(const CText& source);
 
     virtual void Serialize(CArchive& ar) override;
 };
@@ -475,7 +475,7 @@ public:
 // Operations
 public:
 
-    virtual void Draw(CDC* pDC, TileScale eScale) override;
+    virtual void Draw(CDC& pDC, TileScale eScale) override;
     // Support required by selection processing.
     virtual BOOL HitTest(CPoint pt) override;
 #ifndef GPLAY
@@ -483,13 +483,13 @@ public:
 #endif
     // ------- //
 #ifndef GPLAY
-    virtual void ForceIntoZone(CRect* pRctZone) override;
+    virtual void ForceIntoZone(const CRect& pRctZone) override;
 #endif
     virtual void OffsetObject(CPoint offset) override;
     // ------- //
-    virtual OwnerPtr Clone() override;
+    virtual OwnerPtr Clone() const override;
 
-    void CopyAttributes(CBitmapImage *source);
+    void CopyAttributes(const CBitmapImage& source);
 
     virtual void Serialize(CArchive& ar) override;
 
@@ -514,7 +514,7 @@ public:
     virtual enum CDrawObjType GetType() const override { return drawTile; }
 // Operations
 public:
-    virtual void Draw(CDC* pDC, TileScale eScale) override;
+    virtual void Draw(CDC& pDC, TileScale eScale) override;
     // Support required by selection processing.
     virtual BOOL HitTest(CPoint pt) override;
 #ifndef GPLAY
@@ -522,13 +522,13 @@ public:
 #endif
     // ------- //
 #ifndef GPLAY
-    virtual void ForceIntoZone(CRect* pRctZone) override;
+    virtual void ForceIntoZone(const CRect& pRctZone) override;
 #endif
     virtual void OffsetObject(CPoint offset) override;
     // ------- //
-    virtual OwnerPtr Clone() override;
+    virtual OwnerPtr Clone() const override;
 
-    void CopyAttributes(CTileImage *source);
+    void CopyAttributes(const CTileImage& source);
 
     virtual void Serialize(CArchive& ar) override;
 };
@@ -562,19 +562,19 @@ public:
     void SetOwnerMask(DWORD dwMask);
 
     virtual enum CDrawObjType GetType() const override { return drawPieceObj; }
-    virtual ObjectID GetObjectID() override { return static_cast<ObjectID>(m_pid); }
+    virtual ObjectID GetObjectID() const override { return static_cast<ObjectID>(m_pid); }
 
 // Operations
 public:
     void ResyncExtentRect();
 
-    virtual void Draw(CDC* pDC, TileScale eScale) override;
+    virtual void Draw(CDC& pDC, TileScale eScale) override;
     // Support required by selection processing.
     virtual BOOL HitTest(CPoint pt) override;
     virtual CSelection* CreateSelectProxy(CPlayBoardView& pView) override;
     // ------- //
-    virtual OwnerPtr Clone(CGamDoc* pDoc) override;
-    virtual BOOL Compare(CDrawObj* pObj) override;
+    virtual OwnerPtr Clone(CGamDoc* pDoc) const override;
+    virtual BOOL Compare(const CDrawObj& pObj) const override;
     virtual void Serialize(CArchive& ar) override;
 };
 
@@ -591,11 +591,11 @@ protected:
 
     ObjectID    m_dwObjectID;
 public:
-    virtual ObjectID GetObjectID() override { return m_dwObjectID; }
+    virtual ObjectID GetObjectID() const override { return m_dwObjectID; }
     void    SetObjectID(ObjectID dwID) { m_dwObjectID = dwID; }
     // ------ //
-    virtual OwnerPtr Clone(CGamDoc* pDoc) override;
-    virtual BOOL Compare(CDrawObj* pObj) override;
+    virtual OwnerPtr Clone(CGamDoc* pDoc) const override;
+    virtual BOOL Compare(const CDrawObj& pObj) const override;
     virtual void Serialize(CArchive& ar) override;
 };
 
@@ -620,7 +620,7 @@ public:
     int  GetFacing() { return m_nFacingDegCW; }
 
     void    SetObjectID(ObjectID dwID) { m_dwObjectID = dwID; }
-    virtual ObjectID GetObjectID() override { return m_dwObjectID; }
+    virtual ObjectID GetObjectID() const override { return m_dwObjectID; }
 
     void ResyncExtentRect();
 
@@ -633,13 +633,13 @@ protected:
 public:
     TileID GetCurrentTileID();
     // ------- //
-    virtual void Draw(CDC* pDC, TileScale eScale) override;
+    virtual void Draw(CDC& pDC, TileScale eScale) override;
     // Support required by selection processing.
     virtual BOOL HitTest(CPoint pt) override;
     virtual CSelection* CreateSelectProxy(CPlayBoardView& pView) override;
     // ------- //
-    virtual OwnerPtr Clone(CGamDoc* pDoc) override;
-    virtual BOOL Compare(CDrawObj* pObj) override;
+    virtual OwnerPtr Clone(CGamDoc* pDoc) const override;
+    virtual BOOL Compare(const CDrawObj& pObj) const override;
     virtual void Serialize(CArchive& ar) override;
 };
 
@@ -678,28 +678,26 @@ public:
 public:
     const_iterator Find(const CDrawObj& drawObj) const;
     iterator Find(const CDrawObj& drawObj);
-    void AddObject(CDrawObj* pDrawObj) { AddToFront(pDrawObj); }
     // NOTE:  See WARNING: above
-    void RemoveObject(CDrawObj* pDrawObj);
-    void RemoveObjectsInList(CPtrList* pLst);
-    void AddToEnd(CDrawObj* pDrawObj) { AddToBack(CDrawObj::OwnerPtr(pDrawObj)); }
+    void RemoveObject(const CDrawObj& pDrawObj);
+    void RemoveObjectsInList(const CPtrList& pLst);
     void AddToBack(CDrawObj::OwnerPtr pDrawObj) { push_front(std::move(pDrawObj)); }
     void AddToFront(CDrawObj::OwnerPtr pDrawObj) { push_back(std::move(pDrawObj)); }
     CDrawObj& Front() { return *back(); }
     CDrawObj& Back() { return *front(); }
-    void Draw(CDC* pDC, CRect* pDrawRct, TileScale eScale,
+    void Draw(CDC& pDC, const CRect& pDrawRct, TileScale eScale,
         BOOL bApplyVisibility = TRUE, BOOL bDrawPass2Objects = FALSE,
         BOOL bHideUnlocked = FALSE, BOOL bDrawLockedFirst = FALSE);
     CDrawObj* HitTest(CPoint pt, TileScale eScale = (TileScale)AllTileScales,
         BOOL bApplyVisibility = TRUE);
-    void DrillDownHitTest(CPoint point, CPtrList* selLst,
+    void DrillDownHitTest(CPoint point, CPtrList& selLst,
         TileScale eScale = (TileScale)AllTileScales, BOOL bApplyVisibility = TRUE);
 #ifdef GPLAY
     void ArrangePieceTableInDrawOrder(std::vector<PieceID>& pTbl) const;
     void ArrangePieceTableInVisualOrder(std::vector<PieceID>& pTbl) const;
 #endif
-    void ArrangeObjectListInDrawOrder(CPtrList* pLst);
-    void ArrangeObjectListInVisualOrder(CPtrList* pLst);
+    void ArrangeObjectListInDrawOrder(CPtrList& pLst);
+    void ArrangeObjectListInVisualOrder(CPtrList& pLst);
     void ArrangeObjectPtrTableInDrawOrder(std::vector<CB::not_null<CDrawObj*>>& pTbl) const;
     void ArrangeObjectPtrTableInVisualOrder(std::vector<CB::not_null<CDrawObj*>>& pTbl) const;
 #ifdef GPLAY
@@ -707,23 +705,23 @@ public:
 
     CPieceObj* FindPieceID(PieceID pid);
     CDrawObj* FindObjectID(ObjectID oid);
-    BOOL HasObject(CDrawObj* pObj) { return Find(*pObj) != end(); }
-    BOOL HasMarker();
-    void GetPieceObjectPtrList(CPtrList* pLst);
-    void GetPieceIDTable(std::vector<PieceID>& pTbl);
-    void GetObjectListFromPieceIDTable(const std::vector<PieceID>& pTbl, CPtrList* pLst);
-    static void GetPieceIDTableFromObjList(CPtrList* pLst, std::vector<PieceID>& pTbl,
+    BOOL HasObject(const CDrawObj& pObj) const { return Find(pObj) != end(); }
+    BOOL HasMarker() const;
+    void GetPieceObjectPtrList(CPtrList& pLst);
+    void GetPieceIDTable(std::vector<PieceID>& pTbl) const;
+    void GetObjectListFromPieceIDTable(const std::vector<PieceID>& pTbl, CPtrList& pLst);
+    static void GetPieceIDTableFromObjList(CPtrList& pLst, std::vector<PieceID>& pTbl,
         BOOL bDeleteObjs = FALSE);
     // ------- //
-    CDrawList Clone(CGamDoc* pDoc);
-    void Restore(CGamDoc* pDoc, CDrawList* pLst);
-    BOOL Compare(CDrawList* pLst);
-    void AppendWithOffset(CDrawList* pSourceLst, CPoint pntOffet);
+    CDrawList Clone(CGamDoc* pDoc) const;
+    void Restore(CGamDoc* pDoc, const CDrawList& pLst);
+    BOOL Compare(const CDrawList& pLst) const;
+    void AppendWithOffset(const CDrawList& pSourceLst, CPoint pntOffet);
 #else
     BOOL PurgeMissingTileIDs(CTileManager* pTMgr);
-    BOOL IsTileInUse(TileID tid);
+    BOOL IsTileInUse(TileID tid) const;
     // ------- //
-    void ForceIntoZone(CRect* pRctZone);
+    void ForceIntoZone(const CRect& pRctZone);
 #endif
     // -------- //
     void Serialize(CArchive& ar);

--- a/GShr/DrawObj.h
+++ b/GShr/DrawObj.h
@@ -556,9 +556,9 @@ public:
 
     void SetPiece(CRect& rct, PieceID pid);
 
-    BOOL IsOwned();
-    BOOL IsOwnedBy(DWORD dwMask);
-    BOOL IsOwnedButNotByCurrentPlayer();
+    BOOL IsOwned() const;
+    BOOL IsOwnedBy(DWORD dwMask) const;
+    BOOL IsOwnedButNotByCurrentPlayer() const;
     void SetOwnerMask(DWORD dwMask);
 
     virtual enum CDrawObjType GetType() const override { return drawPieceObj; }

--- a/GShr/DrawObj.h
+++ b/GShr/DrawObj.h
@@ -99,59 +99,59 @@ public:
     void  ModifyDObjFlags(DWORD dwFlags, BOOL bState)
         { if (bState) SetDObjFlags(dwFlags); else ClearDObjFlags(dwFlags); }
 
-    virtual CRect& GetRect() { return m_rctExtent; }
-    virtual const void SetRect(const CRect& rct) { m_rctExtent = rct; }
+    virtual CRect& GetRect() /* override */ { return m_rctExtent; }
+    virtual const void SetRect(const CRect& rct) /* override */ { m_rctExtent = rct; }
 
-    virtual CRect GetEnclosingRect() { return m_rctExtent; }
-    virtual BOOL HitTest(CPoint pt) { return FALSE; }
+    virtual CRect GetEnclosingRect() /* override */ { return m_rctExtent; }
+    virtual BOOL HitTest(CPoint pt) /* override */ { return FALSE; }
 #ifdef GPLAY
-    virtual ObjectID GetObjectID();
-    virtual void MoveObject(CPoint ptUpLeft);
+    virtual ObjectID GetObjectID() /* override */;
+    virtual void MoveObject(CPoint ptUpLeft) /* override */;
 #endif
-    virtual void OffsetObject(CPoint offset);
+    virtual void OffsetObject(CPoint offset) /* override */;
     // ----- //
-    virtual BOOL IsVisible(RECT* pClipRct);
-    virtual CDrawObjType GetType() const = 0;
+    virtual BOOL IsVisible(RECT* pClipRct) /* override */;
+    virtual CDrawObjType GetType() const /* override */ = 0;
     // ----- //
     // Some functions that may or may not mean anything to the
     // underlying object. The object will return TRUE if the
     // property was meaningful.
-    virtual BOOL SetForeColor(COLORREF cr) { return FALSE; }
-    virtual BOOL SetBackColor(COLORREF cr) { return FALSE; }
-    virtual BOOL SetLineWidth(UINT nLineWidth) { return FALSE; }
-    virtual BOOL SetFont(FontID fid) { return FALSE; }
+    virtual BOOL SetForeColor(COLORREF cr) /* override */ { return FALSE; }
+    virtual BOOL SetBackColor(COLORREF cr) /* override */ { return FALSE; }
+    virtual BOOL SetLineWidth(UINT nLineWidth) /* override */ { return FALSE; }
+    virtual BOOL SetFont(FontID fid) /* override */ { return FALSE; }
 
 // Operations
 public:
-    virtual void Draw(CDC* pDC, TileScale eScale) = 0;
+    virtual void Draw(CDC* pDC, TileScale eScale) /* override */ = 0;
     // Support required by selection objects
 #ifdef GPLAY
-    virtual CSelection* CreateSelectProxy(CPlayBoardView& pView) { return NULL;}
+    virtual CSelection* CreateSelectProxy(CPlayBoardView& pView) /* override */ { return NULL; }
 #else
-    virtual CSelection* CreateSelectProxy(CBrdEditView& pView) { return NULL;}
+    virtual CSelection* CreateSelectProxy(CBrdEditView& pView) /* override */ { return NULL; }
 #endif
     // ------- //
 #ifndef GPLAY
-    virtual void ForceIntoZone(CRect* pRctZone) = 0;
+    virtual void ForceIntoZone(CRect* pRctZone) /* override */ = 0;
 #endif
-    virtual OwnerPtr Clone() { AfxThrowInvalidArgException(); }
+    virtual OwnerPtr Clone() /* override */ { AfxThrowInvalidArgException(); }
 #ifdef GPLAY
-    virtual OwnerPtr Clone(CGamDoc* pDoc) { AfxThrowInvalidArgException(); }
-    virtual BOOL Compare(CDrawObj* pObj) { AfxThrowInvalidArgException(); }
+    virtual OwnerPtr Clone(CGamDoc* pDoc) /* override */ { AfxThrowInvalidArgException(); }
+    virtual BOOL Compare(CDrawObj* pObj) /* override */ { AfxThrowInvalidArgException(); }
 #endif
     // ------- //
-    virtual void Serialize(CArchive& ar);
+    virtual void Serialize(CArchive& ar) /* override */;
 
 // Implementation - methods
 protected:
     BOOL IsExtentOutOfZone(CRect* pRctZone, CPoint& pntOffset);
     // ------- //
-    virtual void SetUpDraw(CDC* pDC, CPen* pPen, CBrush* pBrush);
-    virtual void CleanUpDraw(CDC *pDC);
-    virtual BOOL BitBlockHitTest(CPoint pt);
-    virtual UINT GetLineWidth() { return 0; }
-    virtual COLORREF GetLineColor() { return noColor; }
-    virtual COLORREF GetFillColor() { return noColor; }
+    virtual void SetUpDraw(CDC* pDC, CPen* pPen, CBrush* pBrush) /* override */;
+    virtual void CleanUpDraw(CDC *pDC) /* override */;
+    virtual BOOL BitBlockHitTest(CPoint pt) /* override */;
+    virtual UINT GetLineWidth() /* override */ { return 0; }
+    virtual COLORREF GetLineColor() /* override */ { return noColor; }
+    virtual COLORREF GetFillColor() /* override */ { return noColor; }
 
     void CopyAttributes (CDrawObj* source);    //DFM19991213
 
@@ -239,38 +239,38 @@ public:
     COLORREF m_crLine;
     UINT     m_nLineWidth;
 
-    virtual CRect GetEnclosingRect();
-    virtual enum CDrawObjType GetType() const { return drawRect; }
+    virtual CRect GetEnclosingRect() override;
+    virtual enum CDrawObjType GetType() const override { return drawRect; }
 
     void SetRect(RECT* rect) { m_rctExtent = rect; }
 
-    virtual BOOL SetForeColor(COLORREF cr) { m_crLine = cr; return TRUE; }
-    virtual BOOL SetBackColor(COLORREF cr) { m_crFill = cr; return TRUE; }
-    virtual BOOL SetLineWidth(UINT nLineWidth)
+    virtual BOOL SetForeColor(COLORREF cr) override { m_crLine = cr; return TRUE; }
+    virtual BOOL SetBackColor(COLORREF cr) override { m_crFill = cr; return TRUE; }
+    virtual BOOL SetLineWidth(UINT nLineWidth) override
         { m_nLineWidth = nLineWidth; return TRUE; }
 
 // Operations
 public:
-    virtual void Draw(CDC* pDC, TileScale eScale);
+    virtual void Draw(CDC* pDC, TileScale eScale) override;
 
     // Support required by selection processing.
-    virtual BOOL HitTest(CPoint pt);
+    virtual BOOL HitTest(CPoint pt) override;
 #ifndef GPLAY
-    virtual CSelection* CreateSelectProxy(CBrdEditView& pView);
+    virtual CSelection* CreateSelectProxy(CBrdEditView& pView) override;
 #endif
     // ------- //
 #ifndef GPLAY
-    virtual void ForceIntoZone(CRect* pRctZone);
+    virtual void ForceIntoZone(CRect* pRctZone) override;
 #endif
     // ------- //
-    virtual OwnerPtr Clone();                  //DFM19991210
+    virtual OwnerPtr Clone() override;                  //DFM19991210
 
-    virtual void Serialize(CArchive& ar);
+    virtual void Serialize(CArchive& ar) override;
 // Implementation
 protected:
-    virtual UINT GetLineWidth() { return m_nLineWidth; }
-    virtual COLORREF GetLineColor() { return m_crLine; }
-    virtual COLORREF GetFillColor() { return m_crFill; }
+    virtual UINT GetLineWidth() override { return m_nLineWidth; }
+    virtual COLORREF GetLineColor() override { return m_crLine; }
+    virtual COLORREF GetFillColor() override { return m_crFill; }
 
     void CopyAttributes (CRectObj* source);     //DFM19991213
 };
@@ -283,15 +283,15 @@ class CEllipse : public CRectObj
 public:
     CEllipse() {}
 
-    virtual enum CDrawObjType GetType() const { return drawEllipse; }
+    virtual enum CDrawObjType GetType() const override { return drawEllipse; }
 
 // Operations
 public:
-    virtual void Draw(CDC* pDC, TileScale eScale);
+    virtual void Draw(CDC* pDC, TileScale eScale) override;
 #ifndef GPLAY
-    virtual CSelection* CreateSelectProxy(CBrdEditView& pView);
+    virtual CSelection* CreateSelectProxy(CBrdEditView& pView) override;
 #endif
-    virtual OwnerPtr Clone();  //DFM19991210
+    virtual OwnerPtr Clone() override;  //DFM19991210
 };
 
 ///////////////////////////////////////////////////////////////////////
@@ -318,35 +318,35 @@ public:
     void GetLine(POINT& ptBeg, POINT& ptEnd)
         { ptBeg = m_ptBeg; ptEnd = m_ptEnd; }
 
-    virtual CRect GetEnclosingRect();
-    virtual enum CDrawObjType GetType() const { return drawLine; }
+    virtual CRect GetEnclosingRect() override;
+    virtual enum CDrawObjType GetType() const override { return drawLine; }
 
-    virtual BOOL SetForeColor(COLORREF cr) { m_crLine = cr; return TRUE; }
-    virtual BOOL SetLineWidth(UINT nLineWidth)
+    virtual BOOL SetForeColor(COLORREF cr) override { m_crLine = cr; return TRUE; }
+    virtual BOOL SetLineWidth(UINT nLineWidth) override
         { m_nLineWidth = nLineWidth; return TRUE; }
 
 // Operations
 public:
-    virtual void Draw(CDC* pDC, TileScale eScale);
+    virtual void Draw(CDC* pDC, TileScale eScale) override;
     // Support required by selection processing.
-    virtual BOOL HitTest(CPoint pt);
+    virtual BOOL HitTest(CPoint pt) override;
 #ifdef GPLAY
-    virtual CSelection* CreateSelectProxy(CPlayBoardView& pView);
+    virtual CSelection* CreateSelectProxy(CPlayBoardView& pView) override;
 #else
-    virtual CSelection* CreateSelectProxy(CBrdEditView& pView);
+    virtual CSelection* CreateSelectProxy(CBrdEditView& pView) override;
 #endif
     // ------- //
 #ifndef GPLAY
-    virtual void ForceIntoZone(CRect* pRctZone);
+    virtual void ForceIntoZone(CRect* pRctZone) override;
 #endif
-    virtual void OffsetObject(CPoint offset);       //DFM19991221
+    virtual void OffsetObject(CPoint offset) override;       //DFM19991221
     // ------- //
-    virtual OwnerPtr Clone(void);                  //DFM19991210
+    virtual OwnerPtr Clone(void) override;                  //DFM19991210
 #ifdef GPLAY
-    virtual OwnerPtr Clone(CGamDoc* pDoc);
-    virtual BOOL Compare(CDrawObj* pObj);
+    virtual OwnerPtr Clone(CGamDoc* pDoc) override;
+    virtual BOOL Compare(CDrawObj* pObj) override;
 #endif
-    virtual void Serialize(CArchive& ar);
+    virtual void Serialize(CArchive& ar) override;
 
 protected:
     void CopyAttributes (CLine *source);            //DFM19991214
@@ -371,12 +371,12 @@ public:
     POINT*   m_pPnts;
     int      m_nPnts;
 
-    virtual CRect GetEnclosingRect();
-    virtual enum CDrawObjType GetType() const { return drawPolygon; }
+    virtual CRect GetEnclosingRect() override;
+    virtual enum CDrawObjType GetType() const override { return drawPolygon; }
 
-    virtual BOOL SetForeColor(COLORREF cr) { m_crLine = cr; return TRUE; }
-    virtual BOOL SetBackColor(COLORREF cr) { m_crFill = cr; return TRUE; }
-    virtual BOOL SetLineWidth(UINT nLineWidth)
+    virtual BOOL SetForeColor(COLORREF cr) override { m_crLine = cr; return TRUE; }
+    virtual BOOL SetBackColor(COLORREF cr) override { m_crFill = cr; return TRUE; }
+    virtual BOOL SetLineWidth(UINT nLineWidth) override
         { m_nLineWidth = nLineWidth; return TRUE; }
 
 // Operations
@@ -386,22 +386,22 @@ public:
 
 // Overrides
 public:
-    virtual void Draw(CDC* pDC, TileScale eScale);
+    virtual void Draw(CDC* pDC, TileScale eScale) override;
 
     // Support required by selection processing.
-    virtual BOOL HitTest(CPoint pt);
+    virtual BOOL HitTest(CPoint pt) override;
 #ifndef GPLAY
-    virtual CSelection* CreateSelectProxy(CBrdEditView& pView);
+    virtual CSelection* CreateSelectProxy(CBrdEditView& pView) override;
 #endif
     // ------- //
 #ifndef GPLAY
-    virtual void ForceIntoZone(CRect* pRctZone);
+    virtual void ForceIntoZone(CRect* pRctZone) override;
 #endif
-    virtual void OffsetObject(CPoint offset); //DFM19991221
+    virtual void OffsetObject(CPoint offset) override; //DFM19991221
     // ------- //
-    virtual OwnerPtr Clone();
+    virtual OwnerPtr Clone() override;
 
-    virtual void Serialize(CArchive& ar);
+    virtual void Serialize(CArchive& ar) override;
 // Implementation
 protected:
     void ComputeExtent();
@@ -409,9 +409,9 @@ protected:
     void CopyAttributes(CPolyObj *source);
 
     // ------- //
-    virtual UINT GetLineWidth() { return m_nLineWidth; }
-    virtual COLORREF GetLineColor() { return m_crLine; }
-    virtual COLORREF GetFillColor() { return m_crFill; }
+    virtual UINT GetLineWidth() override { return m_nLineWidth; }
+    virtual COLORREF GetLineColor() override { return m_crLine; }
+    virtual COLORREF GetFillColor() override { return m_crFill; }
 };
 
 ///////////////////////////////////////////////////////////////////////
@@ -431,30 +431,30 @@ public:
 
     void SetText(int x, int y, const char* pszText, FontID fntID,
         COLORREF crText = RGB(255,255,255));
-    virtual enum CDrawObjType GetType() const { return drawText; }
+    virtual enum CDrawObjType GetType() const override { return drawText; }
 
-    virtual BOOL SetForeColor(COLORREF cr) { m_crText = cr; return TRUE; }
-    virtual BOOL SetFont(FontID fid);
+    virtual BOOL SetForeColor(COLORREF cr) override { m_crText = cr; return TRUE; }
+    virtual BOOL SetFont(FontID fid) override;
 
 // Operations
 public:
-    virtual void Draw(CDC* pDC, TileScale eScale);
+    virtual void Draw(CDC* pDC, TileScale eScale) override;
     // Support required by selection processing.
-    virtual BOOL HitTest(CPoint pt);
+    virtual BOOL HitTest(CPoint pt) override;
 #ifndef GPLAY
-    virtual CSelection* CreateSelectProxy(CBrdEditView& pView);
+    virtual CSelection* CreateSelectProxy(CBrdEditView& pView) override;
 #endif
     // ------- //
 #ifndef GPLAY
-    virtual void ForceIntoZone(CRect* pRctZone);
+    virtual void ForceIntoZone(CRect* pRctZone) override;
 #endif
-    virtual void OffsetObject(CPoint offset);
+    virtual void OffsetObject(CPoint offset) override;
     // ------- //
-    virtual OwnerPtr Clone();
+    virtual OwnerPtr Clone() override;
 
     void CopyAttributes(CText *source);
 
-    virtual void Serialize(CArchive& ar);
+    virtual void Serialize(CArchive& ar) override;
 };
 
 ///////////////////////////////////////////////////////////////////////
@@ -470,28 +470,28 @@ public:
     CBitmap         m_bitmap;
 
     void SetBitmap(int x, int y, HBITMAP hBMap, TileScale eBaseScale = fullScale);
-    virtual enum CDrawObjType GetType() const { return drawBitmap; }
+    virtual enum CDrawObjType GetType() const override { return drawBitmap; }
 
 // Operations
 public:
 
-    virtual void Draw(CDC* pDC, TileScale eScale);
+    virtual void Draw(CDC* pDC, TileScale eScale) override;
     // Support required by selection processing.
-    virtual BOOL HitTest(CPoint pt);
+    virtual BOOL HitTest(CPoint pt) override;
 #ifndef GPLAY
-    virtual CSelection* CreateSelectProxy(CBrdEditView& pView);
+    virtual CSelection* CreateSelectProxy(CBrdEditView& pView) override;
 #endif
     // ------- //
 #ifndef GPLAY
-    virtual void ForceIntoZone(CRect* pRctZone);
+    virtual void ForceIntoZone(CRect* pRctZone) override;
 #endif
-    virtual void OffsetObject(CPoint offset);
+    virtual void OffsetObject(CPoint offset) override;
     // ------- //
-    virtual OwnerPtr Clone();
+    virtual OwnerPtr Clone() override;
 
     void CopyAttributes(CBitmapImage *source);
 
-    virtual void Serialize(CArchive& ar);
+    virtual void Serialize(CArchive& ar) override;
 
 protected:
     void SynchronizeExtentRect(CSize sizeWorld, CSize sizeView);
@@ -511,26 +511,26 @@ public:
     CTileManager*   m_pTMgr;
 
     void SetTile(int x, int y, TileID tid);
-    virtual enum CDrawObjType GetType() const { return drawTile; }
+    virtual enum CDrawObjType GetType() const override { return drawTile; }
 // Operations
 public:
-    virtual void Draw(CDC* pDC, TileScale eScale);
+    virtual void Draw(CDC* pDC, TileScale eScale) override;
     // Support required by selection processing.
-    virtual BOOL HitTest(CPoint pt);
+    virtual BOOL HitTest(CPoint pt) override;
 #ifndef GPLAY
-    virtual CSelection* CreateSelectProxy(CBrdEditView& pView);
+    virtual CSelection* CreateSelectProxy(CBrdEditView& pView) override;
 #endif
     // ------- //
 #ifndef GPLAY
-    virtual void ForceIntoZone(CRect* pRctZone);
+    virtual void ForceIntoZone(CRect* pRctZone) override;
 #endif
-    virtual void OffsetObject(CPoint offset);
+    virtual void OffsetObject(CPoint offset) override;
     // ------- //
-    virtual OwnerPtr Clone();
+    virtual OwnerPtr Clone() override;
 
     void CopyAttributes(CTileImage *source);
 
-    virtual void Serialize(CArchive& ar);
+    virtual void Serialize(CArchive& ar) override;
 };
 
 /////////////////////////////////////////////////////////////////////////
@@ -561,21 +561,21 @@ public:
     BOOL IsOwnedButNotByCurrentPlayer();
     void SetOwnerMask(DWORD dwMask);
 
-    virtual enum CDrawObjType GetType() const { return drawPieceObj; }
-    virtual ObjectID GetObjectID() { return static_cast<ObjectID>(m_pid); }
+    virtual enum CDrawObjType GetType() const override { return drawPieceObj; }
+    virtual ObjectID GetObjectID() override { return static_cast<ObjectID>(m_pid); }
 
 // Operations
 public:
     void ResyncExtentRect();
 
-    virtual void Draw(CDC* pDC, TileScale eScale);
+    virtual void Draw(CDC* pDC, TileScale eScale) override;
     // Support required by selection processing.
-    virtual BOOL HitTest(CPoint pt);
-    virtual CSelection* CreateSelectProxy(CPlayBoardView& pView);
+    virtual BOOL HitTest(CPoint pt) override;
+    virtual CSelection* CreateSelectProxy(CPlayBoardView& pView) override;
     // ------- //
-    virtual OwnerPtr Clone(CGamDoc* pDoc);
-    virtual BOOL Compare(CDrawObj* pObj);
-    virtual void Serialize(CArchive& ar);
+    virtual OwnerPtr Clone(CGamDoc* pDoc) override;
+    virtual BOOL Compare(CDrawObj* pObj) override;
+    virtual void Serialize(CArchive& ar) override;
 };
 
 ///////////////////////////////////////////////////////////////////////
@@ -587,16 +587,16 @@ public:
     CLineObj() {}
 // Other...
 protected:
-    virtual enum CDrawObjType GetType() const { return drawLineObj; }
+    virtual enum CDrawObjType GetType() const override { return drawLineObj; }
 
     ObjectID    m_dwObjectID;
 public:
-    virtual ObjectID GetObjectID() { return m_dwObjectID; }
+    virtual ObjectID GetObjectID() override { return m_dwObjectID; }
     void    SetObjectID(ObjectID dwID) { m_dwObjectID = dwID; }
     // ------ //
-    virtual OwnerPtr Clone(CGamDoc* pDoc);
-    virtual BOOL Compare(CDrawObj* pObj);
-    virtual void Serialize(CArchive& ar);
+    virtual OwnerPtr Clone(CGamDoc* pDoc) override;
+    virtual BOOL Compare(CDrawObj* pObj) override;
+    virtual void Serialize(CArchive& ar) override;
 };
 
 ///////////////////////////////////////////////////////////////////////
@@ -620,11 +620,11 @@ public:
     int  GetFacing() { return m_nFacingDegCW; }
 
     void    SetObjectID(ObjectID dwID) { m_dwObjectID = dwID; }
-    virtual ObjectID GetObjectID() { return m_dwObjectID; }
+    virtual ObjectID GetObjectID() override { return m_dwObjectID; }
 
     void ResyncExtentRect();
 
-    virtual enum CDrawObjType GetType() const { return drawMarkObj; }
+    virtual enum CDrawObjType GetType() const override { return drawMarkObj; }
 protected:
     ObjectID m_dwObjectID;
     int      m_nFacingDegCW;           // Rotation of marker (degrees)
@@ -633,14 +633,14 @@ protected:
 public:
     TileID GetCurrentTileID();
     // ------- //
-    virtual void Draw(CDC* pDC, TileScale eScale);
+    virtual void Draw(CDC* pDC, TileScale eScale) override;
     // Support required by selection processing.
-    virtual BOOL HitTest(CPoint pt);
-    virtual CSelection* CreateSelectProxy(CPlayBoardView& pView);
+    virtual BOOL HitTest(CPoint pt) override;
+    virtual CSelection* CreateSelectProxy(CPlayBoardView& pView) override;
     // ------- //
-    virtual OwnerPtr Clone(CGamDoc* pDoc);
-    virtual BOOL Compare(CDrawObj* pObj);
-    virtual void Serialize(CArchive& ar);
+    virtual OwnerPtr Clone(CGamDoc* pDoc) override;
+    virtual BOOL Compare(CDrawObj* pObj) override;
+    virtual void Serialize(CArchive& ar) override;
 };
 
 #endif  // GPLAY

--- a/GShr/DrawObj.h
+++ b/GShr/DrawObj.h
@@ -126,9 +126,9 @@ public:
     virtual void Draw(CDC& pDC, TileScale eScale) /* override */ = 0;
     // Support required by selection objects
 #ifdef GPLAY
-    virtual CSelection* CreateSelectProxy(CPlayBoardView& pView) /* override */ { return NULL; }
+    virtual ::OwnerPtr<CSelection> CreateSelectProxy(CPlayBoardView& pView) /* override */ { AfxThrowInvalidArgException(); }
 #else
-    virtual CSelection* CreateSelectProxy(CBrdEditView& pView) /* override */ { return NULL; }
+    virtual ::OwnerPtr<CSelection> CreateSelectProxy(CBrdEditView& pView) /* override */ { AfxThrowInvalidArgException(); }
 #endif
     // ------- //
 #ifndef GPLAY
@@ -256,7 +256,7 @@ public:
     // Support required by selection processing.
     virtual BOOL HitTest(CPoint pt) override;
 #ifndef GPLAY
-    virtual CSelection* CreateSelectProxy(CBrdEditView& pView) override;
+    virtual ::OwnerPtr<CSelection> CreateSelectProxy(CBrdEditView& pView) override;
 #endif
     // ------- //
 #ifndef GPLAY
@@ -289,7 +289,7 @@ public:
 public:
     virtual void Draw(CDC& pDC, TileScale eScale) override;
 #ifndef GPLAY
-    virtual CSelection* CreateSelectProxy(CBrdEditView& pView) override;
+    virtual ::OwnerPtr<CSelection> CreateSelectProxy(CBrdEditView& pView) override;
 #endif
     virtual OwnerPtr Clone() const override;  //DFM19991210
 };
@@ -331,9 +331,9 @@ public:
     // Support required by selection processing.
     virtual BOOL HitTest(CPoint pt) override;
 #ifdef GPLAY
-    virtual CSelection* CreateSelectProxy(CPlayBoardView& pView) override;
+    virtual ::OwnerPtr<CSelection> CreateSelectProxy(CPlayBoardView& pView) override;
 #else
-    virtual CSelection* CreateSelectProxy(CBrdEditView& pView) override;
+    virtual ::OwnerPtr<CSelection> CreateSelectProxy(CBrdEditView& pView) override;
 #endif
     // ------- //
 #ifndef GPLAY
@@ -389,7 +389,7 @@ public:
     // Support required by selection processing.
     virtual BOOL HitTest(CPoint pt) override;
 #ifndef GPLAY
-    virtual CSelection* CreateSelectProxy(CBrdEditView& pView) override;
+    virtual ::OwnerPtr<CSelection> CreateSelectProxy(CBrdEditView& pView) override;
 #endif
     // ------- //
 #ifndef GPLAY
@@ -440,7 +440,7 @@ public:
     // Support required by selection processing.
     virtual BOOL HitTest(CPoint pt) override;
 #ifndef GPLAY
-    virtual CSelection* CreateSelectProxy(CBrdEditView& pView) override;
+    virtual ::OwnerPtr<CSelection> CreateSelectProxy(CBrdEditView& pView) override;
 #endif
     // ------- //
 #ifndef GPLAY
@@ -477,7 +477,7 @@ public:
     // Support required by selection processing.
     virtual BOOL HitTest(CPoint pt) override;
 #ifndef GPLAY
-    virtual CSelection* CreateSelectProxy(CBrdEditView& pView) override;
+    virtual ::OwnerPtr<CSelection> CreateSelectProxy(CBrdEditView& pView) override;
 #endif
     // ------- //
 #ifndef GPLAY
@@ -516,7 +516,7 @@ public:
     // Support required by selection processing.
     virtual BOOL HitTest(CPoint pt) override;
 #ifndef GPLAY
-    virtual CSelection* CreateSelectProxy(CBrdEditView& pView) override;
+    virtual ::OwnerPtr<CSelection> CreateSelectProxy(CBrdEditView& pView) override;
 #endif
     // ------- //
 #ifndef GPLAY
@@ -569,7 +569,7 @@ public:
     virtual void Draw(CDC& pDC, TileScale eScale) override;
     // Support required by selection processing.
     virtual BOOL HitTest(CPoint pt) override;
-    virtual CSelection* CreateSelectProxy(CPlayBoardView& pView) override;
+    virtual ::OwnerPtr<CSelection> CreateSelectProxy(CPlayBoardView& pView) override;
     // ------- //
     virtual OwnerPtr Clone(CGamDoc* pDoc) const override;
     virtual BOOL Compare(const CDrawObj& pObj) const override;
@@ -634,7 +634,7 @@ public:
     virtual void Draw(CDC& pDC, TileScale eScale) override;
     // Support required by selection processing.
     virtual BOOL HitTest(CPoint pt) override;
-    virtual CSelection* CreateSelectProxy(CPlayBoardView& pView) override;
+    virtual ::OwnerPtr<CSelection> CreateSelectProxy(CPlayBoardView& pView) override;
     // ------- //
     virtual OwnerPtr Clone(CGamDoc* pDoc) const override;
     virtual BOOL Compare(const CDrawObj& pObj) const override;

--- a/GShr/DrawObj.h
+++ b/GShr/DrawObj.h
@@ -678,7 +678,7 @@ public:
     iterator Find(const CDrawObj& drawObj);
     // NOTE:  See WARNING: above
     void RemoveObject(const CDrawObj& pDrawObj);
-    void RemoveObjectsInList(const CPtrList& pLst);
+    void RemoveObjectsInList(const std::vector<CB::not_null<CDrawObj*>>& pLst);
     void AddToBack(CDrawObj::OwnerPtr pDrawObj) { push_front(std::move(pDrawObj)); }
     void AddToFront(CDrawObj::OwnerPtr pDrawObj) { push_back(std::move(pDrawObj)); }
     CDrawObj& Front() { return *back(); }
@@ -688,14 +688,14 @@ public:
         BOOL bHideUnlocked = FALSE, BOOL bDrawLockedFirst = FALSE);
     CDrawObj* HitTest(CPoint pt, TileScale eScale = (TileScale)AllTileScales,
         BOOL bApplyVisibility = TRUE);
-    void DrillDownHitTest(CPoint point, CPtrList& selLst,
+    void DrillDownHitTest(CPoint point, std::vector<CB::not_null<CDrawObj*>>& selLst,
         TileScale eScale = (TileScale)AllTileScales, BOOL bApplyVisibility = TRUE);
 #ifdef GPLAY
     void ArrangePieceTableInDrawOrder(std::vector<PieceID>& pTbl) const;
     void ArrangePieceTableInVisualOrder(std::vector<PieceID>& pTbl) const;
 #endif
-    void ArrangeObjectListInDrawOrder(CPtrList& pLst);
-    void ArrangeObjectListInVisualOrder(CPtrList& pLst);
+    void ArrangeObjectListInDrawOrder(std::vector<CB::not_null<CDrawObj*>>& pLst);
+    void ArrangeObjectListInVisualOrder(std::vector<CB::not_null<CDrawObj*>>& pLst);
     void ArrangeObjectPtrTableInDrawOrder(std::vector<CB::not_null<CDrawObj*>>& pTbl) const;
     void ArrangeObjectPtrTableInVisualOrder(std::vector<CB::not_null<CDrawObj*>>& pTbl) const;
 #ifdef GPLAY
@@ -705,10 +705,10 @@ public:
     CDrawObj* FindObjectID(ObjectID oid);
     BOOL HasObject(const CDrawObj& pObj) const { return Find(pObj) != end(); }
     BOOL HasMarker() const;
-    void GetPieceObjectPtrList(CPtrList& pLst);
+    void GetPieceObjectPtrList(std::vector<CB::not_null<CPieceObj*>>& pLst);
     void GetPieceIDTable(std::vector<PieceID>& pTbl) const;
-    void GetObjectListFromPieceIDTable(const std::vector<PieceID>& pTbl, CPtrList& pLst);
-    static void GetPieceIDTableFromObjList(CPtrList& pLst, std::vector<PieceID>& pTbl,
+    void GetObjectListFromPieceIDTable(const std::vector<PieceID>& pTbl, std::vector<CB::not_null<CPieceObj*>>& pLst);
+    static void GetPieceIDTableFromObjList(const std::vector<CB::not_null<CDrawObj*>>& pLst, std::vector<PieceID>& pTbl,
         BOOL bDeleteObjs = FALSE);
     // ------- //
     CDrawList Clone(CGamDoc* pDoc) const;

--- a/GShr/DrawObj.h
+++ b/GShr/DrawObj.h
@@ -359,17 +359,15 @@ class CPolyObj : public CDrawObj
 // Constructors
 public:
     CPolyObj()
-    { m_crLine = RGB(0,0,0); m_crFill = noColor; m_nLineWidth = 0;
-      m_nPnts = 0; m_pPnts = NULL; }
-    ~CPolyObj() { if (m_pPnts != NULL) delete m_pPnts; }
+    { m_crLine = RGB(0,0,0); m_crFill = noColor; m_nLineWidth = 0; }
+    ~CPolyObj() = default;
 
 // Attributes
 public:
     COLORREF m_crFill;
     COLORREF m_crLine;
     UINT     m_nLineWidth;
-    POINT*   m_pPnts;
-    int      m_nPnts;
+    std::vector<POINT> m_Pnts;
 
     virtual CRect GetEnclosingRect() const override;
     virtual enum CDrawObjType GetType() const override { return drawPolygon; }
@@ -382,7 +380,7 @@ public:
 // Operations
 public:
     void AddPoint(CPoint pnt);
-    void SetNewPolygon(POINT* pPnts, int nPnts);
+    void SetNewPolygon(const std::vector<POINT>& pnts);
 
 // Overrides
 public:

--- a/GShr/DrawObj.h
+++ b/GShr/DrawObj.h
@@ -649,6 +649,12 @@ public:
 ///////////////////////////////////////////////////////////////////////
 // The DrawList manager class
 
+/* WARNING:  Ownership of objects in CDrawList is hard to
+    determine.  CB 3.1 code deletes objects in this list when
+    list is destroyed, which implies list owns its content, but
+    RemoveObject* doesn't delete object, so in that case there
+    must be another owner somewhere.  CB 3.5 doesn't do anything
+    to clarify this. */
 class CDrawList : private std::list<CDrawObj::OwnerPtr>
 {
     using BASE = std::list<CDrawObj::OwnerPtr>;
@@ -673,6 +679,7 @@ public:
     const_iterator Find(const CDrawObj& drawObj) const;
     iterator Find(const CDrawObj& drawObj);
     void AddObject(CDrawObj* pDrawObj) { AddToFront(pDrawObj); }
+    // NOTE:  See WARNING: above
     void RemoveObject(CDrawObj* pDrawObj);
     void RemoveObjectsInList(CPtrList* pLst);
     void AddToEnd(CDrawObj* pDrawObj) { AddToBack(CDrawObj::OwnerPtr(pDrawObj)); }
@@ -693,8 +700,8 @@ public:
 #endif
     void ArrangeObjectListInDrawOrder(CPtrList* pLst);
     void ArrangeObjectListInVisualOrder(CPtrList* pLst);
-    void ArrangeObjectPtrTableInDrawOrder(std::vector<CDrawObj*>& pTbl) const;
-    void ArrangeObjectPtrTableInVisualOrder(std::vector<CDrawObj*>& pTbl) const;
+    void ArrangeObjectPtrTableInDrawOrder(std::vector<CB::not_null<CDrawObj*>>& pTbl) const;
+    void ArrangeObjectPtrTableInVisualOrder(std::vector<CB::not_null<CDrawObj*>>& pTbl) const;
 #ifdef GPLAY
     void SetOwnerMasks(DWORD dwOwnerMask);
 

--- a/GShr/DrawObj.h
+++ b/GShr/DrawObj.h
@@ -126,9 +126,9 @@ public:
     virtual void Draw(CDC* pDC, TileScale eScale) = 0;
     // Support required by selection objects
 #ifdef GPLAY
-    virtual CSelection* CreateSelectProxy(CPlayBoardView* pView) { return NULL;}
+    virtual CSelection* CreateSelectProxy(CPlayBoardView& pView) { return NULL;}
 #else
-    virtual CSelection* CreateSelectProxy(CBrdEditView* pView) { return NULL;}
+    virtual CSelection* CreateSelectProxy(CBrdEditView& pView) { return NULL;}
 #endif
     // ------- //
 #ifndef GPLAY
@@ -256,7 +256,7 @@ public:
     // Support required by selection processing.
     virtual BOOL HitTest(CPoint pt);
 #ifndef GPLAY
-    virtual CSelection* CreateSelectProxy(CBrdEditView* pView);
+    virtual CSelection* CreateSelectProxy(CBrdEditView& pView);
 #endif
     // ------- //
 #ifndef GPLAY
@@ -289,7 +289,7 @@ public:
 public:
     virtual void Draw(CDC* pDC, TileScale eScale);
 #ifndef GPLAY
-    virtual CSelection* CreateSelectProxy(CBrdEditView* pView);
+    virtual CSelection* CreateSelectProxy(CBrdEditView& pView);
 #endif
     virtual OwnerPtr Clone();  //DFM19991210
 };
@@ -331,9 +331,9 @@ public:
     // Support required by selection processing.
     virtual BOOL HitTest(CPoint pt);
 #ifdef GPLAY
-    virtual CSelection* CreateSelectProxy(CPlayBoardView* pView);
+    virtual CSelection* CreateSelectProxy(CPlayBoardView& pView);
 #else
-    virtual CSelection* CreateSelectProxy(CBrdEditView* pView);
+    virtual CSelection* CreateSelectProxy(CBrdEditView& pView);
 #endif
     // ------- //
 #ifndef GPLAY
@@ -391,7 +391,7 @@ public:
     // Support required by selection processing.
     virtual BOOL HitTest(CPoint pt);
 #ifndef GPLAY
-    virtual CSelection* CreateSelectProxy(CBrdEditView* pView);
+    virtual CSelection* CreateSelectProxy(CBrdEditView& pView);
 #endif
     // ------- //
 #ifndef GPLAY
@@ -442,7 +442,7 @@ public:
     // Support required by selection processing.
     virtual BOOL HitTest(CPoint pt);
 #ifndef GPLAY
-    virtual CSelection* CreateSelectProxy(CBrdEditView* pView);
+    virtual CSelection* CreateSelectProxy(CBrdEditView& pView);
 #endif
     // ------- //
 #ifndef GPLAY
@@ -479,7 +479,7 @@ public:
     // Support required by selection processing.
     virtual BOOL HitTest(CPoint pt);
 #ifndef GPLAY
-    virtual CSelection* CreateSelectProxy(CBrdEditView* pView);
+    virtual CSelection* CreateSelectProxy(CBrdEditView& pView);
 #endif
     // ------- //
 #ifndef GPLAY
@@ -518,7 +518,7 @@ public:
     // Support required by selection processing.
     virtual BOOL HitTest(CPoint pt);
 #ifndef GPLAY
-    virtual CSelection* CreateSelectProxy(CBrdEditView* pView);
+    virtual CSelection* CreateSelectProxy(CBrdEditView& pView);
 #endif
     // ------- //
 #ifndef GPLAY
@@ -571,7 +571,7 @@ public:
     virtual void Draw(CDC* pDC, TileScale eScale);
     // Support required by selection processing.
     virtual BOOL HitTest(CPoint pt);
-    virtual CSelection* CreateSelectProxy(CPlayBoardView* pView);
+    virtual CSelection* CreateSelectProxy(CPlayBoardView& pView);
     // ------- //
     virtual OwnerPtr Clone(CGamDoc* pDoc);
     virtual BOOL Compare(CDrawObj* pObj);
@@ -636,7 +636,7 @@ public:
     virtual void Draw(CDC* pDC, TileScale eScale);
     // Support required by selection processing.
     virtual BOOL HitTest(CPoint pt);
-    virtual CSelection* CreateSelectProxy(CPlayBoardView* pView);
+    virtual CSelection* CreateSelectProxy(CPlayBoardView& pView);
     // ------- //
     virtual OwnerPtr Clone(CGamDoc* pDoc);
     virtual BOOL Compare(CDrawObj* pObj);

--- a/GShr/Font.cpp
+++ b/GShr/Font.cpp
@@ -25,6 +25,12 @@
 #include    "stdafx.h"
 #include    "Font.h"
 
+#ifdef      GPLAY
+    #include    "GamDoc.h"
+#else
+    #include    "GmDoc.h"
+#endif
+
 #ifdef _DEBUG
 #undef THIS_FILE
 static char THIS_FILE[] = __FILE__;
@@ -165,6 +171,21 @@ void CFontTbl::Archive(CArchive& ar, FontID& rfontID)
     }
 }
 
+void CFontTbl::Archive(CArchive& ar, UniqueFontID& rfontID)
+{
+    if (ar.IsStoring())
+    {
+        FontID temp = rfontID.Get();
+        Archive(ar, temp);
+    }
+    else
+    {
+        FontID temp = 0;
+        Archive(ar, temp);
+        rfontID.Reset(temp);
+    }
+}
+
 // ===================================================== //
 // (protected)
 BOOL CbFont::AtomsEqual(Atom &atom)
@@ -174,3 +195,11 @@ BOOL CbFont::AtomsEqual(Atom &atom)
             oFnt.taFlags == taFlags;
 }
 
+void UniqueFontID::Reset(FontID f)
+{
+    if (fid != 0)
+    {
+        CGamDoc::GetFontManager()->DeleteFont(fid);
+    }
+    fid = f;
+}

--- a/GShr/Font.h
+++ b/GShr/Font.h
@@ -55,6 +55,21 @@ public:
     BOOL IsULine(void) { return (taFlags & taULine) != 0; }
 };
 
+class UniqueFontID
+{
+public:
+    UniqueFontID() noexcept = default;
+    UniqueFontID(const UniqueFontID&) = delete;
+    UniqueFontID& operator=(const UniqueFontID&) = delete;
+    UniqueFontID(UniqueFontID&& other) noexcept { fid = other.fid; other.fid = 0; }
+    UniqueFontID& operator=(UniqueFontID&& other) noexcept { std::swap(fid, other.fid); return *this; }
+    ~UniqueFontID() { Reset(); }
+    void Reset(FontID f = 0);
+    FontID Get() const { return fid; }
+private:
+    FontID fid = 0;
+};
+
 class CFontTbl : public AtomList
 {
 protected:
@@ -83,6 +98,7 @@ public:
     FNameTbl* GetFontNameTable() { return &oFName; }
     // -------- //
     void Archive(CArchive& ar, FontID& rfontID);
+    void Archive(CArchive& ar, UniqueFontID& rfontID);
 };
 
 #endif

--- a/GShr/GdiTools.h
+++ b/GShr/GdiTools.h
@@ -125,7 +125,7 @@ typedef DELTAGEN *PDELTAGEN;
 ////////////////////////////////////////////////////////////////////
 // From ROTATE.CPP
 
-CDib* Rotate16BitDib(CDib* pSDib, int angle, COLORREF crTrans);
+OwnerPtr<CDib> Rotate16BitDib(CDib* pSDib, int angle, COLORREF crTrans);
 void  RotatePoints(POINT* pPnts, int nPnts, int nDegrees);
 void  OffsetPoints(POINT* pPnts, int nPnts, int xOff, int yOff);
 

--- a/GShr/LBoxGfx2.cpp
+++ b/GShr/LBoxGfx2.cpp
@@ -71,7 +71,7 @@ CGrafixListBox2::CGrafixListBox2()
 
 /////////////////////////////////////////////////////////////////////////////
 
-void CGrafixListBox2::SetItemMap(const std::vector<CDrawObj*>* pMap,
+void CGrafixListBox2::SetItemMap(const std::vector<CB::not_null<CDrawObj*>>* pMap,
     BOOL bKeepPosition /* = TRUE */)
 {
     m_pItemMap = pMap;
@@ -110,11 +110,11 @@ void CGrafixListBox2::UpdateList(BOOL bKeepPosition /* = TRUE */)
 
 /////////////////////////////////////////////////////////////////////////////
 
-CDrawObj* CGrafixListBox2::MapIndexToItem(size_t nIndex)
+CDrawObj& CGrafixListBox2::MapIndexToItem(size_t nIndex)
 {
     ASSERT(m_pItemMap);
     ASSERT(nIndex < m_pItemMap->size());
-    return m_pItemMap->at(nIndex);
+    return *m_pItemMap->at(nIndex);
 }
 
 size_t CGrafixListBox2::MapItemToIndex(CDrawObj* pItem)
@@ -128,17 +128,17 @@ size_t CGrafixListBox2::MapItemToIndex(CDrawObj* pItem)
     return Invalid_v<size_t>;                  // Failed to find it
 }
 
-CDrawObj* CGrafixListBox2::GetCurMapItem()
+CDrawObj& CGrafixListBox2::GetCurMapItem()
 {
     ASSERT(!IsMultiSelect());
     ASSERT(m_pItemMap);
     int nItem = GetCurSel();
     ASSERT(nItem >= 0);
     ASSERT(value_preserving_cast<size_t>(nItem) < m_pItemMap->size());
-    return m_pItemMap->at(value_preserving_cast<size_t>(nItem));
+    return *m_pItemMap->at(value_preserving_cast<size_t>(nItem));
 }
 
-void CGrafixListBox2::GetCurMappedItemList(std::vector<CB::propagate_const<CDrawObj*>>& pLst)
+void CGrafixListBox2::GetCurMappedItemList(std::vector<CB::not_null<CB::propagate_const<CDrawObj*>>>& pLst)
 {
     pLst.clear();
     ASSERT(IsMultiSelect());
@@ -148,8 +148,8 @@ void CGrafixListBox2::GetCurMappedItemList(std::vector<CB::propagate_const<CDraw
     std::vector<int> pSelTbl(value_preserving_cast<size_t>(nSels));
     GetSelItems(nSels, pSelTbl.data());
     pLst.reserve(pSelTbl.size());
-    for (size_t i = 0; i < pSelTbl.size(); i++)
-        pLst.push_back(MapIndexToItem(value_preserving_cast<size_t>(pSelTbl[i])));
+    for (size_t i = size_t(0); i < pSelTbl.size(); i++)
+        pLst.push_back(&MapIndexToItem(value_preserving_cast<size_t>(pSelTbl[i])));
     return;
 }
 
@@ -166,7 +166,7 @@ void CGrafixListBox2::SetCurSelMapped(CDrawObj* nMapVal)
     }
 }
 
-void CGrafixListBox2::SetCurSelsMapped(const std::vector<CDrawObj*>& items)
+void CGrafixListBox2::SetCurSelsMapped(const std::vector<CB::not_null<CDrawObj*>>& items)
 {
     ASSERT(m_pItemMap);
     ASSERT(IsMultiSelect());

--- a/GShr/LBoxGfx2.cpp
+++ b/GShr/LBoxGfx2.cpp
@@ -138,7 +138,7 @@ CDrawObj* CGrafixListBox2::GetCurMapItem()
     return m_pItemMap->at(value_preserving_cast<size_t>(nItem));
 }
 
-void CGrafixListBox2::GetCurMappedItemList(std::vector<CDrawObj*>& pLst)
+void CGrafixListBox2::GetCurMappedItemList(std::vector<CB::propagate_const<CDrawObj*>>& pLst)
 {
     pLst.clear();
     ASSERT(IsMultiSelect());

--- a/GShr/LBoxGfx2.h
+++ b/GShr/LBoxGfx2.h
@@ -60,7 +60,7 @@ public:
     void EnableDropScroll(BOOL bEnable = TRUE) { m_bAllowDropScroll = bEnable; }
     const std::vector<CDrawObj*>* GetItemMap() { return m_pItemMap; }
     CDrawObj* GetCurMapItem();
-    void GetCurMappedItemList(std::vector<CDrawObj*>& pLst);
+    void GetCurMappedItemList(std::vector<CB::propagate_const<CDrawObj*>>& pLst);
     BOOL IsMultiSelect()
         { return (GetStyle() & (LBS_EXTENDEDSEL | LBS_MULTIPLESEL)) != 0; }
     // Note: the following pointer is only good during drag and drop.
@@ -70,7 +70,7 @@ public:
     // data in the case of a shift click isn't valid until the button
     // is released. Makes it tough to use a pre setup list during the
     // drag operation.
-    std::vector<CDrawObj*>& GetMappedMultiSelectList() { return m_multiSelList; }
+    std::vector<CB::propagate_const<CDrawObj*>>& GetMappedMultiSelectList() { return m_multiSelList; }
 
 // Operations
 public:
@@ -106,7 +106,7 @@ protected:
     /* N.B.:  this class could be templatized to hold any pointer,
                 but that generality isn't actually needed yet */
     const std::vector<CDrawObj*>* m_pItemMap;          // Maps index to item
-    std::vector<CDrawObj*> m_multiSelList;      // Holds mapped multi select items on drop
+    std::vector<CB::propagate_const<CDrawObj*>> m_multiSelList;      // Holds mapped multi select items on drop
 
     // Tool tip support
     CToolTipCtrl m_toolTip;

--- a/GShr/LBoxGfx2.h
+++ b/GShr/LBoxGfx2.h
@@ -58,9 +58,9 @@ public:
     void EnableDrag(BOOL bEnable = TRUE) { m_bAllowDrag = bEnable; }
     void EnableSelfDrop(BOOL bEnable = TRUE) { m_bAllowSelfDrop = bEnable; }
     void EnableDropScroll(BOOL bEnable = TRUE) { m_bAllowDropScroll = bEnable; }
-    const std::vector<CDrawObj*>* GetItemMap() { return m_pItemMap; }
-    CDrawObj* GetCurMapItem();
-    void GetCurMappedItemList(std::vector<CB::propagate_const<CDrawObj*>>& pLst);
+    const std::vector<CB::not_null<CDrawObj*>>* GetItemMap() { return m_pItemMap; }
+    CDrawObj& GetCurMapItem();
+    void GetCurMappedItemList(std::vector<CB::not_null<CB::propagate_const<CDrawObj*>>>& pLst);
     BOOL IsMultiSelect()
         { return (GetStyle() & (LBS_EXTENDEDSEL | LBS_MULTIPLESEL)) != 0; }
     // Note: the following pointer is only good during drag and drop.
@@ -70,17 +70,17 @@ public:
     // data in the case of a shift click isn't valid until the button
     // is released. Makes it tough to use a pre setup list during the
     // drag operation.
-    std::vector<CB::propagate_const<CDrawObj*>>& GetMappedMultiSelectList() { return m_multiSelList; }
+    std::vector<CB::not_null<CB::propagate_const<CDrawObj*>>>& GetMappedMultiSelectList() { return m_multiSelList; }
 
 // Operations
 public:
-    void SetItemMap(const std::vector<CDrawObj*>* pMap, BOOL bKeepPosition = TRUE);
+    void SetItemMap(const std::vector<CB::not_null<CDrawObj*>>* pMap, BOOL bKeepPosition = TRUE);
     void UpdateList(BOOL bKeepPosition = TRUE);
     void SetCurSelMapped(CDrawObj* pMapVal);
-    void SetCurSelsMapped(const std::vector<CDrawObj*>& items);
+    void SetCurSelsMapped(const std::vector<CB::not_null<CDrawObj*>>& items);
     void SetSelFromPoint(CPoint point);
     void ShowFirstSelection();
-    CDrawObj* MapIndexToItem(size_t nIndex);
+    CDrawObj& MapIndexToItem(size_t nIndex);
     size_t MapItemToIndex(CDrawObj* pItem);
     void MakeItemVisible(int nItem);
 
@@ -105,8 +105,8 @@ public:
 protected:
     /* N.B.:  this class could be templatized to hold any pointer,
                 but that generality isn't actually needed yet */
-    const std::vector<CDrawObj*>* m_pItemMap;          // Maps index to item
-    std::vector<CB::propagate_const<CDrawObj*>> m_multiSelList;      // Holds mapped multi select items on drop
+    const std::vector<CB::not_null<CDrawObj*>>* m_pItemMap;          // Maps index to item
+    std::vector<CB::not_null<CB::propagate_const<CDrawObj*>>> m_multiSelList;      // Holds mapped multi select items on drop
 
     // Tool tip support
     CToolTipCtrl m_toolTip;

--- a/GShr/LBoxTileBase.cpp
+++ b/GShr/LBoxTileBase.cpp
@@ -135,9 +135,9 @@ void CTileBaseListBox::DrawTileImage(CDC* pDC, CRect rctItem, BOOL bDrawIt, int&
     if (bDrawIt)
     {
         if (tile.GetHeight() >= 255)
-            tile.BitBlt(pDC, x, rctItem.top + tileBorder);// Too large. Don't draw vertically centered
+            tile.BitBlt(CheckedDeref(pDC), x, rctItem.top + tileBorder);// Too large. Don't draw vertically centered
         else
-            tile.BitBlt(pDC, x, (rctItem.Height() - tile.GetHeight()) / 2 + rctItem.top);
+            tile.BitBlt(CheckedDeref(pDC), x, (rctItem.Height() - tile.GetHeight()) / 2 + rctItem.top);
     }
     x += tile.GetWidth() + tileGap;
 }

--- a/GShr/LBoxTileBase2.cpp
+++ b/GShr/LBoxTileBase2.cpp
@@ -135,9 +135,9 @@ void CTileBaseListBox2::DrawTileImage(CDC* pDC, CRect rctItem, BOOL bDrawIt, int
     if (bDrawIt)
     {
         if (tile.GetHeight() >= 255)
-            tile.BitBlt(pDC, x, rctItem.top + tileBorder);// Too large. Don't draw vertically centered
+            tile.BitBlt(CheckedDeref(pDC), x, rctItem.top + tileBorder);// Too large. Don't draw vertically centered
         else
-            tile.BitBlt(pDC, x, (rctItem.Height() - tile.GetHeight()) / 2 + rctItem.top);
+            tile.BitBlt(CheckedDeref(pDC), x, (rctItem.Height() - tile.GetHeight()) / 2 + rctItem.top);
     }
     x += tile.GetWidth() + tileGap;
 }

--- a/GShr/LBoxTileBase2.h
+++ b/GShr/LBoxTileBase2.h
@@ -76,7 +76,7 @@ protected:
     virtual BOOL OnDoesItemHaveTipText(size_t nItem) /* override */ { return FALSE; }
 
     // Subclass should only override one of these if any...
-    virtual const void* OnGetItemDebugIDCode(size_t nItem) /* override */ { return MapIndexToItem(nItem); }
+    virtual const void* OnGetItemDebugIDCode(size_t nItem) /* override */ { return &MapIndexToItem(nItem); }
     virtual void  OnGetItemDebugString(size_t nItem, CString& str) /* override */;
 
     //{{AFX_MSG(CTileBaseListBox)

--- a/GShr/Tile.cpp
+++ b/GShr/Tile.cpp
@@ -54,37 +54,37 @@ CSize CTile::GetSize() const
     return m_pTS != NULL ? m_pTS->GetSize() : m_size;
 }
 
-void CTile::BitBlt(CDC *pDC, int x, int y, DWORD dwRop)
+void CTile::BitBlt(CDC& pDC, int x, int y, DWORD dwRop)
 {
     if (m_pTS != NULL)
-        m_pTS->TileBlt(pDC, x, y, m_yLoc, dwRop);
+        m_pTS->TileBlt(&pDC, x, y, m_yLoc, dwRop);
     else if (m_crTrans != m_crSmall)
     {
         // Only draw color patch if not the transparent color.
         CBrush oBrsh;
         oBrsh.CreateSolidBrush(m_crSmall);
-        CBrush* pPrvBrsh = pDC->SelectObject(&oBrsh);
-        pDC->PatBlt(x, y, m_size.cx, m_size.cy, PATCOPY);
-        pDC->SelectObject(pPrvBrsh);
+        CBrush* pPrvBrsh = pDC.SelectObject(&oBrsh);
+        pDC.PatBlt(x, y, m_size.cx, m_size.cy, PATCOPY);
+        pDC.SelectObject(pPrvBrsh);
     }
 }
 
-void CTile::StretchBlt(CDC *pDC, int x, int y, int cx, int cy, DWORD dwRop)
+void CTile::StretchBlt(CDC& pDC, int x, int y, int cx, int cy, DWORD dwRop)
 {
     if (m_pTS != NULL)
-        m_pTS->StretchBlt(pDC, x, y, cx, cy, m_yLoc, dwRop);
+        m_pTS->StretchBlt(&pDC, x, y, cx, cy, m_yLoc, dwRop);
     else if (m_crTrans != m_crSmall)
     {
         CBrush oBrsh;
         oBrsh.CreateSolidBrush(m_crSmall);
-        CBrush* pPrvBrsh = pDC->SelectObject(&oBrsh);
-        pDC->PatBlt(x, y, cx, cy, PATCOPY);
-        pDC->SelectObject(pPrvBrsh);
+        CBrush* pPrvBrsh = pDC.SelectObject(&oBrsh);
+        pDC.PatBlt(x, y, cx, cy, PATCOPY);
+        pDC.SelectObject(pPrvBrsh);
     }
 }
 
 // Transparent BitBlt
-void CTile::TransBlt(CDC *pDC, int x, int y, BITMAP* pMaskBMapInfo /* = NULL */)
+void CTile::TransBlt(CDC& pDC, int x, int y, BITMAP* pMaskBMapInfo /* = NULL */)
 {
     if (m_pTS != NULL)
     {
@@ -92,23 +92,23 @@ void CTile::TransBlt(CDC *pDC, int x, int y, BITMAP* pMaskBMapInfo /* = NULL */)
         {
             if (pMaskBMapInfo != NULL)
             {
-                m_pTS->TransBltThruDIBSectMonoMask(pDC, x, y, m_yLoc,
+                m_pTS->TransBltThruDIBSectMonoMask(&pDC, x, y, m_yLoc,
                     m_crTrans, pMaskBMapInfo);
             }
             else
-                m_pTS->TransBlt(pDC, x, y, m_yLoc, m_crTrans);
+                m_pTS->TransBlt(&pDC, x, y, m_yLoc, m_crTrans);
         }
         else
-            m_pTS->TileBlt(pDC, x, y, m_yLoc, SRCCOPY);
+            m_pTS->TileBlt(&pDC, x, y, m_yLoc, SRCCOPY);
     }
     else if (RGB565(m_crTrans) != RGB565(m_crSmall))
     {
         // Only draw color patch if not the transparent color.
         CBrush oBrsh;
         oBrsh.CreateSolidBrush(m_crSmall);
-        CBrush* pPrvBrsh = pDC->SelectObject(&oBrsh);
-        pDC->PatBlt(x, y, m_size.cx, m_size.cy, PATCOPY);
-        pDC->SelectObject(pPrvBrsh);
+        CBrush* pPrvBrsh = pDC.SelectObject(&oBrsh);
+        pDC.PatBlt(x, y, m_size.cx, m_size.cy, PATCOPY);
+        pDC.SelectObject(pPrvBrsh);
     }
 }
 

--- a/GShr/Tile.h
+++ b/GShr/Tile.h
@@ -308,9 +308,9 @@ public:
 
 // Operations
 public:
-    void BitBlt(CDC *pDC, int x, int y, DWORD dwRop = SRCCOPY);
-    void StretchBlt(CDC *pDC, int x, int y, int cx, int cy, DWORD dwRop = SRCCOPY);
-    void TransBlt(CDC *pDC, int x, int y, BITMAP* pMaskBMapInfo = NULL);
+    void BitBlt(CDC& pDC, int x, int y, DWORD dwRop = SRCCOPY);
+    void StretchBlt(CDC& pDC, int x, int y, int cx, int cy, DWORD dwRop = SRCCOPY);
+    void TransBlt(CDC& pDC, int x, int y, BITMAP* pMaskBMapInfo = NULL);
     void Update(CBitmap *pBMap);
     void CreateBitmapOfTile(CBitmap *pBMap);
 

--- a/GShr/Tile.h
+++ b/GShr/Tile.h
@@ -129,7 +129,7 @@ protected:
 
 // Implementation - vars...
 protected:
-    CB::propagate_const<std::unique_ptr<CBitmap>> m_pBMap;        // Pointer to DDB
+    OwnerOrNullPtr<CBitmap> m_pBMap;        // Pointer to DDB
     LPBYTE      m_pMem;         // Ptr to DIB Memory (DIBSection)
 
     CSize       m_size;         // Tile sizes for this sheet

--- a/GShr/Tile.h
+++ b/GShr/Tile.h
@@ -129,7 +129,7 @@ protected:
 
 // Implementation - vars...
 protected:
-    std::unique_ptr<CBitmap> m_pBMap;        // Pointer to DDB
+    CB::propagate_const<std::unique_ptr<CBitmap>> m_pBMap;        // Pointer to DDB
     LPBYTE      m_pMem;         // Ptr to DIB Memory (DIBSection)
 
     CSize       m_size;         // Tile sizes for this sheet

--- a/GShr/TileMgr.cpp
+++ b/GShr/TileMgr.cpp
@@ -380,8 +380,6 @@ void CTileManager::CreateTilesFromTileImageArchive(CArchive& ar,
     }
     for (DWORD i = 0; i < nTileCount; i++)
     {
-        std::unique_ptr<CBitmap> pBMapFull;
-        std::unique_ptr<CBitmap> pBMapHalf;
         COLORREF    crSmall;
         BITMAP      bmInfoFull;
         BITMAP      bmInfoHalf;
@@ -391,12 +389,10 @@ void CTileManager::CreateTilesFromTileImageArchive(CArchive& ar,
         ar >> dwTmp; crSmall = (COLORREF)dwTmp;
 
         ar >> dib;
-        pBMapFull = dib.DIBToBitmap(GetAppPalette());
-        ASSERT(pBMapFull != NULL);
+        OwnerPtr<CBitmap> pBMapFull = std::move(dib.DIBToBitmap(GetAppPalette()));
 
         ar >> dib;
-        pBMapHalf = dib.DIBToBitmap(GetAppPalette());
-        ASSERT(pBMapHalf != NULL);
+        OwnerPtr<CBitmap> pBMapHalf = std::move(dib.DIBToBitmap(GetAppPalette()));
 
         VERIFY(pBMapFull->GetObject(sizeof(BITMAP), &bmInfoFull) > 0);
         VERIFY(pBMapHalf->GetObject(sizeof(BITMAP), &bmInfoHalf) > 0);

--- a/GShr/TileSht.cpp
+++ b/GShr/TileSht.cpp
@@ -160,11 +160,11 @@ void CTileSheet::CreateTile()
         SetupPalette(&g_gt.mDC1);
         SetupPalette(&g_gt.mDC2);
 
-        CBitmap* pBMap = new CBitmap;
+        OwnerPtr<CBitmap> pBMap = MakeOwner<CBitmap>();
         pBMap->Attach(Create16BitDIBSection(g_gt.mDC1.m_hDC,
             bmInfo.bmWidth, bmInfo.bmHeight));
         ASSERT(pBMap->m_hObject != NULL);
-        g_gt.mDC1.SelectObject(pBMap);          // Dest bitmap
+        g_gt.mDC1.SelectObject(pBMap.get());          // Dest bitmap
         g_gt.mDC2.SelectObject(m_pBMap.get());        // Source bitmap
 
         g_gt.mDC1.BitBlt(0, 0, m_size.cx, m_sheetHt, &g_gt.mDC2, 0, 0, SRCCOPY);
@@ -175,13 +175,13 @@ void CTileSheet::CreateTile()
 
         m_sheetHt = bmInfo.bmHeight;
 
-        m_pBMap = std::unique_ptr<CBitmap>(pBMap);
+        m_pBMap = std::move(pBMap);
     }
     else
     {
         ASSERT(m_size != CSize(0,0));
         TRACE("CTileSheet::CreateTile - Creating new TileSheet bitmap\n");
-        m_pBMap = CB::make_unique<CBitmap>();
+        m_pBMap = MakeOwner<CBitmap>();
         SetupPalette(&g_gt.mDC1);
         m_pBMap->Attach(Create16BitDIBSection(g_gt.mDC1.m_hDC,
             m_size.cx, m_size.cy));
@@ -212,14 +212,14 @@ void CTileSheet::DeleteTile(int yLoc)
         bmInfo.bmBits = NULL;
         bmInfo.bmHeight -= m_size.cy;           // Decrease size.
 
-        CBitmap* pBMap = new CBitmap;
+        OwnerPtr<CBitmap> pBMap = MakeOwner<CBitmap>();
         g_gt.mDC2.SelectObject(m_pBMap.get());        // Source bitmap
         SetupPalette(&g_gt.mDC2);
 
         pBMap->Attach(Create16BitDIBSection(g_gt.mDC2.m_hDC,
             bmInfo.bmWidth, bmInfo.bmHeight));
 
-        g_gt.mDC1.SelectObject(pBMap);          // Dest bitmap
+        g_gt.mDC1.SelectObject(pBMap.get());          // Dest bitmap
         SetupPalette(&g_gt.mDC1);
 
         if (yLoc > 0)
@@ -238,7 +238,7 @@ void CTileSheet::DeleteTile(int yLoc)
 
         m_sheetHt = bmInfo.bmHeight;
 
-        m_pBMap = std::unique_ptr<CBitmap>(pBMap);
+        m_pBMap = std::move(pBMap);
     }
 }
 

--- a/GShr/TileSht.cpp
+++ b/GShr/TileSht.cpp
@@ -49,14 +49,12 @@ CTileSheet::CTileSheet()
 {
     m_size = CSize(0, 0);
     m_sheetHt = 0;
-    m_pBMap = NULL;
 }
 
 CTileSheet::CTileSheet(CSize size)
 {
     m_size = size;
     m_sheetHt = 0;
-    m_pBMap = NULL;
     m_pMem = NULL;
 }
 
@@ -177,13 +175,13 @@ void CTileSheet::CreateTile()
 
         m_sheetHt = bmInfo.bmHeight;
 
-        m_pBMap.reset(pBMap);
+        m_pBMap = std::unique_ptr<CBitmap>(pBMap);
     }
     else
     {
         ASSERT(m_size != CSize(0,0));
         TRACE("CTileSheet::CreateTile - Creating new TileSheet bitmap\n");
-        m_pBMap.reset(new CBitmap);
+        m_pBMap = CB::make_unique<CBitmap>();
         SetupPalette(&g_gt.mDC1);
         m_pBMap->Attach(Create16BitDIBSection(g_gt.mDC1.m_hDC,
             m_size.cx, m_size.cy));
@@ -204,7 +202,7 @@ void CTileSheet::DeleteTile(int yLoc)
         TRACE("CTileSheet::DeleteTile - Deleting TileSheet bitmap\n");
         // Single tile is all that's left...
         ASSERT(yLoc == 0);
-        m_pBMap.reset();
+        m_pBMap = nullptr;
         m_sheetHt = 0;
     }
     else
@@ -240,7 +238,7 @@ void CTileSheet::DeleteTile(int yLoc)
 
         m_sheetHt = bmInfo.bmHeight;
 
-        m_pBMap.reset(pBMap);
+        m_pBMap = std::unique_ptr<CBitmap>(pBMap);
     }
 }
 
@@ -431,7 +429,7 @@ void CTileSheet::TransBltThruDIBSectMonoMask(CDC *pDC, int xDst, int yDst, int y
 void CTileSheet::ClearSheet()
 {
     m_size = CSize(0, 0);
-    m_pBMap.reset();
+    m_pBMap = nullptr;
     m_pMem = NULL;
 }
 

--- a/GShr/WinState.cpp
+++ b/GShr/WinState.cpp
@@ -272,7 +272,8 @@ void CWinStateManager::ArrangeFrameListInZOrder(std::vector<CB::not_null<CFrameW
     // Now copy the remaining frame pointers into the caller's list
     // in Z order (top to bottom)
     tblFrames.clear();
-    for (size_t i = 0; i < tblZFrames.size(); i++)
+    tblFrames.reserve(tblZFrames.size());
+    for (size_t i = size_t(0); i < tblZFrames.size(); i++)
     {
         if (tblZFrames.at(i) != NULL)
             tblFrames.push_back(tblZFrames.at(i));


### PR DESCRIPTION
Here's some more type safety work.

1)  http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2015/n4388.html explains an often-undesirable characteristic of the C/C++ const type qualifier, and proposes a std::experimental::propagate_const<> template to provide a way to get around this.  However, this is not widely available, so I add a CB::propagate_const<> template to approximate the proposed standard, and then make use of it.

2)  In many cases, pointers are expected not to be null.  Add a CB::not_null<> template that can perform this checking automatically, and assert/throw if this assumption is violated.  Then make use of CB::not_null.

3)  Replace uses of MFC CPtrList (which contains void*) with more narrowly typed uses of std:;list<>.