### PR TITLE
select pieces when dropping the into Piece Tray

### DIFF
--- a/GP/GamDoc1.cpp
+++ b/GP/GamDoc1.cpp
@@ -420,8 +420,6 @@ void CGamDoc::PlacePieceListOnBoard(CPoint pnt, const std::vector<PieceID>& pTbl
 
 size_t CGamDoc::PlacePieceListInTray(const std::vector<PieceID>& pTbl, CTraySet& pYGrp, size_t nPos)
 {
-    //TODO: This code will have to get smarter when dropping pieces
-    //TODO that originate from the same tray.
     for (size_t i = 0; i < pTbl.size(); i++)
     {
         PieceID pid = pTbl.at(i);
@@ -431,6 +429,15 @@ size_t CGamDoc::PlacePieceListInTray(const std::vector<PieceID>& pTbl, CTraySet&
         CTraySet *pCurYGrp = FindPieceInTray(pid);
 
         PlacePieceInTray(pid, pYGrp, nPos);
+        if (pCurYGrp == &pYGrp && nPos != Invalid_v<size_t>)
+        {
+            // May need to mess with 'nPos' if moving the piece
+            // to a location higher up in the list.
+            size_t nIdx = pCurYGrp->GetPieceIDIndex(pid);
+            ASSERT(nIdx != Invalid_v<size_t>);
+            if (nPos > nIdx)
+                nPos--;
+        }
         if (nPos != Invalid_v<size_t>)
             nPos++;
     }

--- a/GP/PalTray.cpp
+++ b/GP/PalTray.cpp
@@ -618,6 +618,13 @@ LRESULT CTrayPalette::OnDragItem(WPARAM wParam, LPARAM lParam)
                 pYGrp, nSel < 0 ? Invalid_v<size_t> : value_preserving_cast<size_t>(nSel));
             nSel = temp == Invalid_v<size_t> ? -1 : value_preserving_cast<int>(temp);
             m_pDoc->UpdateAllViews(NULL, HINT_UPDATESELECTLIST);
+            if (nSel >= 0)
+            {
+                for (no_demote<size_t> i = size_t(0) ; i < m_listPtr.size() ; ++i)
+                {
+                    m_listTray.SetSel(nSel - value_preserving_cast<int>(i));
+                }
+            }
         }
 
         m_listTray.SetCurSel(nSel);

--- a/GP/PalTray.cpp
+++ b/GP/PalTray.cpp
@@ -447,9 +447,9 @@ void CTrayPalette::SelectTrayPiece(size_t nGroup, PieceID pid,
         m_comboYGrp.SetCurSel(FindTrayIndex(nGroup));
         UpdateTrayList();
     }
+    size_t nItem = m_listTray.SelectTrayPiece(pid);
     if (pszNotificationTip != NULL)
     {
-        size_t nItem = m_listTray.SelectTrayPiece(pid);
         m_listTray.SetNotificationTip(value_preserving_cast<int>(nItem), pszNotificationTip);
     }
 }
@@ -620,7 +620,7 @@ LRESULT CTrayPalette::OnDragItem(WPARAM wParam, LPARAM lParam)
             m_pDoc->UpdateAllViews(NULL, HINT_UPDATESELECTLIST);
             if (nSel >= 0)
             {
-                for (no_demote<size_t> i = size_t(0) ; i < m_listPtr.size() ; ++i)
+                for (size_t i = size_t(0) ; i < m_listPtr.size() ; ++i)
                 {
                     m_listTray.SetSel(nSel - value_preserving_cast<int>(i));
                 }


### PR DESCRIPTION
This PR selects pieces when they are dropped into a Piece Tray, both directly and during playback.

However, note that each time playback prepares to show the next move, all selections are cleared.  This means "Automatic Playback" effectively prevents Piece Tray selection from being visible.  That appears to be a pretty deeply embedded assumption, and may be considerable work to change.

Fix #54