### PR TITLE
Type safety update for GameElement

### DIFF
--- a/GP/GamDoc5.cpp
+++ b/GP/GamDoc5.cpp
@@ -142,13 +142,13 @@ GameElement CGamDoc::GetGameElementCodeForObject(const CDrawObj& pDObj,
         return MakeObjectIDElement(pObj.GetObjectID());
     }
     ASSERT(!"invalid CDrawObj subtype");
-    return (GameElement)-1;
+    return Invalid_v<GameElement>;
 }
 
 GameElement CGamDoc::GetVerifiedGameElementCodeForObject(const CDrawObj& pDObj,
     BOOL bBottomSide /* = FALSE */)
 {
-    GameElement elem = (GameElement)-1;
+    GameElement elem = Invalid_v<GameElement>;
     if (pDObj.GetType() == CDrawObj::drawPieceObj)
     {
         const CPieceObj& pObj = static_cast<const CPieceObj&>(pDObj);
@@ -158,7 +158,7 @@ GameElement CGamDoc::GetVerifiedGameElementCodeForObject(const CDrawObj& pDObj,
 
         elem = MakePieceElement(pid, nSide);
         if (!HasGameElementString(elem) || pObj.IsOwnedButNotByCurrentPlayer())
-            elem = (GameElement)-1;
+            elem = Invalid_v<GameElement>;
     }
     else if (pDObj.GetType() == CDrawObj::drawMarkObj)
     {
@@ -169,7 +169,7 @@ GameElement CGamDoc::GetVerifiedGameElementCodeForObject(const CDrawObj& pDObj,
             // Try the actual marker ID for string existance.
             elem = MakeMarkerElement(pObj.m_mid);
             if (!HasGameElementString(elem))
-                elem = (GameElement)-1;
+                elem = Invalid_v<GameElement>;
         }
     }
     return elem;

--- a/GP/GamDoc5.cpp
+++ b/GP/GamDoc5.cpp
@@ -141,7 +141,8 @@ GameElement CGamDoc::GetGameElementCodeForObject(const CDrawObj& pDObj,
         const CMarkObj& pObj = static_cast<const CMarkObj&>(pDObj);
         return MakeObjectIDElement(pObj.GetObjectID());
     }
-    return (GameElement)0;
+    ASSERT(!"invalid CDrawObj subtype");
+    return (GameElement)-1;
 }
 
 GameElement CGamDoc::GetVerifiedGameElementCodeForObject(const CDrawObj& pDObj,

--- a/GP/LBoxSlct.cpp
+++ b/GP/LBoxSlct.cpp
@@ -131,7 +131,7 @@ int  CSelectListBox::OnGetHitItemCodeAtPoint(CPoint point, CRect& rct)
     CRect rctRight;
     GetTileRectsForItem(nIndex, tidLeft, tidRight, rctLeft, rctRight);
 
-    GameElement elem = (GameElement)-1;
+    GameElement elem = Invalid_v<GameElement>;
 
     if (!rctLeft.IsRectEmpty() && rctLeft.PtInRect(point))
     {
@@ -148,7 +148,8 @@ int  CSelectListBox::OnGetHitItemCodeAtPoint(CPoint point, CRect& rct)
     else
         return -1;
 
-    return (int)elem;
+    static_assert(sizeof(elem) == sizeof(int), "size mismatch");
+    return reinterpret_cast<int&>(elem);
 }
 
 void CSelectListBox::OnGetTipTextForItemCode(int nItemCode,
@@ -156,7 +157,8 @@ void CSelectListBox::OnGetTipTextForItemCode(int nItemCode,
 {
     if (nItemCode == -1)
         return;
-    GameElement elem = (GameElement)nItemCode;
+    static_assert(sizeof(GameElement) == sizeof(nItemCode), "size mismatch");
+    GameElement& elem = reinterpret_cast<GameElement&>(nItemCode);
     strTip = m_pDoc->GetGameElementString(elem);
 }
 
@@ -167,7 +169,7 @@ BOOL CSelectListBox::OnDoesItemHaveTipText(size_t nItem)
     CDrawObj& pObj = MapIndexToItem(nItem);
     GameElement elem1 = m_pDoc->GetVerifiedGameElementCodeForObject(pObj, FALSE);
     GameElement elem2 = m_pDoc->GetVerifiedGameElementCodeForObject(pObj, TRUE);
-    return elem1 != (GameElement)-1 || elem2 != (GameElement)-1;
+    return elem1 != Invalid_v<GameElement> || elem2 != Invalid_v<GameElement>;
 }
 
 /////////////////////////////////////////////////////////////////////////////

--- a/GP/MoveMgr.cpp
+++ b/GP/MoveMgr.cpp
@@ -799,13 +799,12 @@ void CObjectSetText::Serialize(CArchive& ar)
     CMoveRecord::Serialize(ar);
     if (ar.IsStoring())
     {
-        ar << (DWORD)m_elem;
+        ar << m_elem;
         ar << m_strObjText;
     }
     else
     {
-        DWORD dwTmp;
-        ar >> dwTmp; m_elem = (GameElement)dwTmp;
+        ar >> m_elem;
         ar >> m_strObjText;
     }
 }
@@ -920,14 +919,13 @@ void CObjectLockdown::Serialize(CArchive& ar)
     CMoveRecord::Serialize(ar);
     if (ar.IsStoring())
     {
-        ar << (DWORD)m_elem;
+        ar << m_elem;
         ar << (WORD)m_bLockState;
     }
     else
     {
-        DWORD dwTmp;
         WORD wTmp;
-        ar >> dwTmp; m_elem = (GameElement)dwTmp;
+        ar >> m_elem;
         ar >> wTmp; m_bLockState = (BOOL)wTmp;
     }
 }

--- a/GP/MoveMgr.h
+++ b/GP/MoveMgr.h
@@ -287,7 +287,7 @@ public:
     virtual void DumpToTextFile(CFile& file);
 #endif
 protected:
-    DWORD       m_elem;
+    GameElement m_elem;
     CString     m_strObjText;
 };
 
@@ -309,7 +309,7 @@ public:
     virtual void DumpToTextFile(CFile& file);
 #endif
 protected:
-    DWORD       m_elem;
+    GameElement m_elem;
     BOOL        m_bLockState;
 };
 

--- a/GP/VwPbrd.cpp
+++ b/GP/VwPbrd.cpp
@@ -357,7 +357,7 @@ LRESULT CPlayBoardView::OnMessageWindowState(WPARAM wParam, LPARAM lParam)
             for (size_t i = 0; i < tblObjPtrs.size(); i++)
             {
                 CDrawObj& pObj = *tblObjPtrs.at(i);
-                ar << value_preserving_cast<DWORD>(GetDocument()->GetGameElementCodeForObject(pObj));
+                ar << GetDocument()->GetGameElementCodeForObject(pObj);
             }
         }
         else
@@ -383,7 +383,7 @@ LRESULT CPlayBoardView::OnMessageWindowState(WPARAM wParam, LPARAM lParam)
         while (dwSelCount--)
         {
             GameElement elem;
-            ar >> dwTmp; elem = (GameElement)dwTmp;
+            ar >> elem;
             CDrawObj* pObj = NULL;
             if (IsGameElementAPiece(elem))
                 pObj = m_pPBoard->FindPieceID(GetPieceIDFromElement(elem));

--- a/GShr/CyberBoard.h
+++ b/GShr/CyberBoard.h
@@ -581,6 +581,8 @@ public:
     template<typename T, typename = std::enable_if_t<std::is_integral_v<T>>>
     explicit constexpr XxxxID(T i) : XxxxID(value_preserving_cast<uint32_t>(i)) {}
 
+    XxxxID(const XxxxID&) = default;
+    XxxxID& operator=(const XxxxID&) = default;
     ~XxxxID() = default;
 
     explicit constexpr operator WORD() const { return id; }

--- a/GShr/CyberBoard.h
+++ b/GShr/CyberBoard.h
@@ -578,8 +578,8 @@ public:
     // goal is 32bit ids, but currently ids are 16 bit
     explicit constexpr XxxxID(uint32_t i) : id(value_preserving_cast<uint16_t>(i)) {}
 
-    template<typename T>
-    explicit constexpr XxxxID(T i) : XxxxID(value_preserving_cast<uint32_t>(i)) { static_assert(std::is_integral_v<T>, "id must be an integer"); }
+    template<typename T, typename = std::enable_if_t<std::is_integral_v<T>>>
+    explicit constexpr XxxxID(T i) : XxxxID(value_preserving_cast<uint32_t>(i)) {}
 
     ~XxxxID() = default;
 

--- a/GShr/DragDrop.h
+++ b/GShr/DragDrop.h
@@ -125,7 +125,7 @@ struct DragInfo
     template<>
     struct SubInfo<DRAG_SELECTVIEW>
     {
-        const std::vector<CB::not_null<CB::propagate_const<CDrawObj*>>>* m_ptrArray;
+        const std::vector<RefPtr<CDrawObj>>* m_ptrArray;
         CGamDoc* m_gamDoc;
     };
     // TODO:  when upgrade to c++ 17, use std::variant

--- a/GShr/DrawObj.cpp
+++ b/GShr/DrawObj.cpp
@@ -88,10 +88,11 @@ ObjectID::ObjectID(PieceID pid)
     subtype = 0;
 }
 
-ObjectID::ObjectID(DWORD dw)
+ObjectID::ObjectID(uint32_t dw)
 {
-    reinterpret_cast<DWORD&>(*this) = dw;
+    reinterpret_cast<uint32_t&>(*this) = dw;
 }
+
 #endif
 
 ////////////////////////////////////////////////////////////////////

--- a/GShr/DrawObj.cpp
+++ b/GShr/DrawObj.cpp
@@ -65,13 +65,6 @@ namespace {
     } objectIDCheck;
 }
 
-ObjectID::ObjectID()
-{
-    id = 0;
-    serial = 0;
-    subtype = 0;
-}
-
 ObjectID::ObjectID(uint16_t i, uint16_t s, CDrawObj::CDrawObjType t) :
     id(i),
     serial(s & 0x0FFF),

--- a/GShr/DrawObj.h
+++ b/GShr/DrawObj.h
@@ -189,7 +189,13 @@ protected:
 class alignas(uint32_t) ObjectID
 {
 public:
-    ObjectID();
+    // KLUDGE:  release link fails if impl is in .cpp
+    constexpr ObjectID() :
+        id(0),
+        serial(0),
+        subtype(0)
+    {
+    }
     ObjectID(uint16_t i, uint16_t s, CDrawObj::CDrawObjType t);
     explicit ObjectID(PieceID pid);
     explicit ObjectID(uint32_t dw);

--- a/GShr/DrawObj.h
+++ b/GShr/DrawObj.h
@@ -193,6 +193,9 @@ public:
     ObjectID(uint16_t i, uint16_t s, CDrawObj::CDrawObjType t);
     explicit ObjectID(PieceID pid);
     explicit ObjectID(uint32_t dw);
+    ObjectID(const ObjectID&) = default;
+    ObjectID& operator=(const ObjectID&) = default;
+    ~ObjectID() = default;
 
     bool operator==(const ObjectID& rhs) const
     {

--- a/GShr/DrawObj.h
+++ b/GShr/DrawObj.h
@@ -192,7 +192,7 @@ public:
     ObjectID();
     ObjectID(uint16_t i, uint16_t s, CDrawObj::CDrawObjType t);
     explicit ObjectID(PieceID pid);
-    explicit ObjectID(DWORD dw);
+    explicit ObjectID(uint32_t dw);
 
     bool operator==(const ObjectID& rhs) const
     {
@@ -201,6 +201,12 @@ public:
     bool operator!=(const ObjectID& rhs) const
     {
         return !operator==(rhs);
+    }
+
+    explicit operator uint32_t() const
+    {
+        static_assert(sizeof(uint32_t) == sizeof(*this), "sizeof error");
+        return reinterpret_cast<const uint32_t&>(*this);
     }
 
 private:

--- a/GShr/LBoxGfx2.cpp
+++ b/GShr/LBoxGfx2.cpp
@@ -117,12 +117,12 @@ CDrawObj& CGrafixListBox2::MapIndexToItem(size_t nIndex)
     return *m_pItemMap->at(nIndex);
 }
 
-size_t CGrafixListBox2::MapItemToIndex(CDrawObj* pItem)
+size_t CGrafixListBox2::MapItemToIndex(const CDrawObj& pItem)
 {
     ASSERT(m_pItemMap);
     for (size_t i = 0; i < m_pItemMap->size(); i++)
     {
-        if (pItem == m_pItemMap->at(i))
+        if (&pItem == m_pItemMap->at(i))
             return i;
     }
     return Invalid_v<size_t>;                  // Failed to find it

--- a/GShr/LBoxGfx2.cpp
+++ b/GShr/LBoxGfx2.cpp
@@ -138,7 +138,7 @@ CDrawObj& CGrafixListBox2::GetCurMapItem()
     return *m_pItemMap->at(value_preserving_cast<size_t>(nItem));
 }
 
-void CGrafixListBox2::GetCurMappedItemList(std::vector<CB::not_null<CB::propagate_const<CDrawObj*>>>& pLst)
+void CGrafixListBox2::GetCurMappedItemList(std::vector<RefPtr<CDrawObj>>& pLst)
 {
     pLst.clear();
     ASSERT(IsMultiSelect());

--- a/GShr/LBoxGfx2.h
+++ b/GShr/LBoxGfx2.h
@@ -81,7 +81,7 @@ public:
     void SetSelFromPoint(CPoint point);
     void ShowFirstSelection();
     CDrawObj& MapIndexToItem(size_t nIndex);
-    size_t MapItemToIndex(CDrawObj* pItem);
+    size_t MapItemToIndex(const CDrawObj& pItem);
     void MakeItemVisible(int nItem);
 
 // Overrides - the subclass of this class must override these

--- a/GShr/LBoxGfx2.h
+++ b/GShr/LBoxGfx2.h
@@ -60,7 +60,7 @@ public:
     void EnableDropScroll(BOOL bEnable = TRUE) { m_bAllowDropScroll = bEnable; }
     const std::vector<CB::not_null<CDrawObj*>>* GetItemMap() { return m_pItemMap; }
     CDrawObj& GetCurMapItem();
-    void GetCurMappedItemList(std::vector<CB::not_null<CB::propagate_const<CDrawObj*>>>& pLst);
+    void GetCurMappedItemList(std::vector<RefPtr<CDrawObj>>& pLst);
     BOOL IsMultiSelect()
         { return (GetStyle() & (LBS_EXTENDEDSEL | LBS_MULTIPLESEL)) != 0; }
     // Note: the following pointer is only good during drag and drop.
@@ -70,7 +70,7 @@ public:
     // data in the case of a shift click isn't valid until the button
     // is released. Makes it tough to use a pre setup list during the
     // drag operation.
-    std::vector<CB::not_null<CB::propagate_const<CDrawObj*>>>& GetMappedMultiSelectList() { return m_multiSelList; }
+    std::vector<RefPtr<CDrawObj>>& GetMappedMultiSelectList() { return m_multiSelList; }
 
 // Operations
 public:
@@ -106,7 +106,7 @@ protected:
     /* N.B.:  this class could be templatized to hold any pointer,
                 but that generality isn't actually needed yet */
     const std::vector<CB::not_null<CDrawObj*>>* m_pItemMap;          // Maps index to item
-    std::vector<CB::not_null<CB::propagate_const<CDrawObj*>>> m_multiSelList;      // Holds mapped multi select items on drop
+    std::vector<RefPtr<CDrawObj>> m_multiSelList;      // Holds mapped multi select items on drop
 
     // Tool tip support
     CToolTipCtrl m_toolTip;

--- a/GShr/MapStrng.cpp
+++ b/GShr/MapStrng.cpp
@@ -27,6 +27,19 @@
 
 ///////////////////////////////////////////////////////////////////////
 
+namespace {
+    class GameElementCheck
+    {
+    public:
+        GameElementCheck()
+        {
+            GameElement test(MarkID(0x1234));
+            static_assert(sizeof(test) == sizeof(uint32_t), "size mismatch");
+            ASSERT(reinterpret_cast<uint32_t&>(test) == 0xF0001234 || !"non-Microsoft field layout");
+        }
+    } gameElementCheck;
+}
+
 void CGameElementStringMap::Clone(CGameElementStringMap* pMapToCopy)
 {
     RemoveAll();
@@ -76,7 +89,7 @@ void CGameElementStringMap::Serialize(CArchive& ar)
             GameElement elem;
             CString str;
             GetNextAssoc(pos, elem, str);
-            ar << (DWORD)elem;
+            ar << elem;
             ar << str;
         }
     }
@@ -87,11 +100,11 @@ void CGameElementStringMap::Serialize(CArchive& ar)
         ar >> dwCount;
         while (dwCount--)
         {
-            DWORD dwElem;
+            GameElement dwElem;
             ar >> dwElem;
             CString str;
             ar >> str;
-            SetAt((GameElement)dwElem, str);
+            SetAt(dwElem, str);
         }
     }
 }

--- a/GShr/MapStrng.cpp
+++ b/GShr/MapStrng.cpp
@@ -27,6 +27,8 @@
 
 ///////////////////////////////////////////////////////////////////////
 
+/* porting check:  verify that compiler generates GameElement
+that is binary-identical to Microsoft one */
 namespace {
     class GameElementCheck
     {


### PR DESCRIPTION
Make the precise layout of GameElement more explicit in preparation for increasing ID width.

Fix #53