### PR TITLE
fix CMarkListBox::SelectMarker() numeric conversion error

### DIFF
--- a/GShr/LBoxMark.cpp
+++ b/GShr/LBoxMark.cpp
@@ -122,9 +122,11 @@ void CMarkListBox::SelectMarker(MarkID mid)
         if (GetCount() >= 1)
             SetCurSel(0);           // Just select the first one.
     }
-
-    ShowListIndex(value_preserving_cast<int>(nIndex));
-    SetCurSel(value_preserving_cast<int>(nIndex));
+    else
+    {
+        ShowListIndex(value_preserving_cast<int>(nIndex));
+        SetCurSel(value_preserving_cast<int>(nIndex));
+    }
 }
 
 /////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
https://github.com/CyberBoardPBEM/cbwindows/pull/56#issuecomment-878728144 reports an assert failure in `CMarkListBox::SelectMarker()`.  The least-change fix (i.e., maintaining the same behavior as tag v3.5-prerelease-2) would be

```
diff --git a/GShr/LBoxMark.cpp b/GShr/LBoxMark.cpp
index f73df04..2668711 100644
--- a/GShr/LBoxMark.cpp
+++ b/GShr/LBoxMark.cpp
@@ -123,8 +123,8 @@ void CMarkListBox::SelectMarker(MarkID mid)
             SetCurSel(0);           // Just select the first one.
     }
 
-    ShowListIndex(value_preserving_cast<int>(nIndex));
-    SetCurSel(value_preserving_cast<int>(nIndex));
+    ShowListIndex(nIndex != Invalid_v<size_t> ? value_preserving_cast<int>(nIndex) : -1);
+    SetCurSel(nIndex != Invalid_v<size_t> ? value_preserving_cast<int>(nIndex) : -1);
 }
 
 /////////////////////////////////////////////////////////////////////////////
```

However, when I looked more broadly, I noticed that `CTrayListBox::SelectTrayPiece()` performs a similar operation, but its tag v3.5-prerelease-2 logic actually corresponds to

```
diff --git a/GShr/LBoxMark.cpp b/GShr/LBoxMark.cpp
index f73df04..f38bed0 100644
--- a/GShr/LBoxMark.cpp
+++ b/GShr/LBoxMark.cpp
@@ -122,9 +122,11 @@ void CMarkListBox::SelectMarker(MarkID mid)
         if (GetCount() >= 1)
             SetCurSel(0);           // Just select the first one.
     }
-
-    ShowListIndex(value_preserving_cast<int>(nIndex));
-    SetCurSel(value_preserving_cast<int>(nIndex));
+    else
+    {
+        ShowListIndex(value_preserving_cast<int>(nIndex));
+        SetCurSel(value_preserving_cast<int>(nIndex));
+    }
 }
 
 /////////////////////////////////////////////////////////////////////////////
```

The original `CTrayListBox::SelectTrayPiece()` code makes more sense to me than the original `CMarkListBox::SelectMarker()`, so I am modifying `CMarkListBox::SelectMarker()` to be more like `CTrayListBox::SelectTrayPiece()`.