### PR TITLE
file version command line option /id32

### DIFF
--- a/GM/Gm.cpp
+++ b/GM/Gm.cpp
@@ -127,7 +127,17 @@ CGmApp::CGmApp()
 /////////////////////////////////////////////////////////////////////////////
 // The one and only CGmApp object
 
-CGmApp theApp;
+CGmApp& CGmApp::Get()
+{
+    /* make this a function variable to ensure
+        it's constructed before use */
+    static CGmApp theApp;
+    return theApp;
+}
+CWinApp& CbGetApp()
+{
+    return CGmApp::Get();
+}
 
 /////////////////////////////////////////////////////////////////////////////
 // CGmApp initialization
@@ -164,7 +174,7 @@ BOOL CGmApp::InitInstance()
 
     CMFCToolTipInfo ttParams;
     ttParams.m_bVislManagerTheme = TRUE;
-    theApp.GetTooltipManager()->SetTooltipParams(AFX_TOOLTIP_TYPE_ALL,
+    CGmApp::Get().GetTooltipManager()->SetTooltipParams(AFX_TOOLTIP_TYPE_ALL,
         RUNTIME_CLASS(CMFCToolTipCtrl), &ttParams);
 
     //////////////////////////////////////////////////////////////////////

--- a/GM/Gm.h
+++ b/GM/Gm.h
@@ -68,7 +68,10 @@ enum { MENU_BV_DRAWING = 0, MENU_IV_BITEDIT, MENU_PJ_DEFAULT,
 class CGmApp : public CWinAppEx
 {
 public:
+    static CGmApp& Get();
+private:
     CGmApp();
+public:
 
 // Atrributes
 public:

--- a/GM/GmDoc.cpp
+++ b/GM/GmDoc.cpp
@@ -76,6 +76,12 @@ IMPLEMENT_DYNCREATE(CGmBoxHint, CObject)
 #define new DEBUG_NEW
 #endif
 
+// KLUDGE:  get access to CGamDoc::GetLoadingVersion
+int GetLoadingVersion()
+{
+    return CGamDoc::GetLoadingVersion();
+}
+
 ///////////////////////////////////////////////////////////////////////
 // CGamDoc - message dispatch table
 

--- a/GM/GmDoc.cpp
+++ b/GM/GmDoc.cpp
@@ -606,7 +606,7 @@ void CGamDoc::Serialize(CArchive& ar)
                 AfxMessageBox(IDS_ERR_GAMEBOXNEWER, MB_OK | MB_ICONEXCLAMATION);
                 AfxThrowArchiveException(CArchiveException::genericException);
             }
-            if (NumVersion(verMajor, verMinor) < NumVersion(2, 90))
+            if (NumVersion(verMajor, verMinor) < NumVersion(fileGbxVerMajor, fileGbxVerMinor))
             {
                 if (AfxMessageBox(IDS_WARN_FILE_UPGRADE,
                     MB_OKCANCEL | MB_DEFBUTTON2 | MB_ICONWARNING) != IDOK)

--- a/GM/LBoxTile.cpp
+++ b/GM/LBoxTile.cpp
@@ -106,7 +106,7 @@ void CTileListBox::OnItemDraw(CDC* pDC, size_t nIndex, UINT nAction, UINT nState
         if (m_bDisplayIDs)
         {
             CString str;
-            str.Format("[%d] ", static_cast<WORD>(MapIndexToItem(nIndex)));
+            str.Format("[%u] ", static_cast<TileID::UNDERLYING_TYPE>(MapIndexToItem(nIndex)));
             CFont* prvFont = (CFont*)pDC->SelectObject(CFont::FromHandle(g_res.h8ss));
             int y = rctItem.top + rctItem.Height() / 2 -
                 (g_res.tm8ss.tmHeight + g_res.tm8ss.tmExternalLeading) / 2;

--- a/GM/VwPrjgb1.cpp
+++ b/GM/VwPrjgb1.cpp
@@ -304,7 +304,8 @@ void CGbxProjView::DoTileNew()
             CSize(dlg.m_nWidth, dlg.m_nHeight),
             CSize(dlg.m_nHalfWidth, dlg.m_nHalfHeight),
             RGB(255, 255, 255));
-        pDoc->UpdateAllViews(NULL, MAKELPARAM(HINT_TILECREATED, static_cast<WORD>(tidNew)), NULL);
+        static_assert(sizeof(TileID::UNDERLYING_TYPE) <= sizeof(WORD), "makelparam can't hold full arg");
+        pDoc->UpdateAllViews(NULL, MAKELPARAM(HINT_TILECREATED, static_cast<TileID::UNDERLYING_TYPE>(tidNew)), NULL);
         pDoc->CreateNewFrame(GetApp()->m_pTileEditTmpl, "Tile Editor",
             reinterpret_cast<LPVOID>(value_preserving_cast<uintptr_t>(tidNew)));
         pDoc->SetModifiedFlag();
@@ -384,7 +385,8 @@ void CGbxProjView::DoTileClone()
         pTMgr->GetTile(tidNew, &tileHalf, halfScale);
         tileHalf.Update(&bmap);
 
-        pDoc->UpdateAllViews(NULL, MAKELPARAM(HINT_TILECREATED, static_cast<WORD>(tidNew)), NULL);
+        static_assert(sizeof(TileID::UNDERLYING_TYPE) <= sizeof(WORD), "makelparam can't hold full arg");
+        pDoc->UpdateAllViews(NULL, MAKELPARAM(HINT_TILECREATED, static_cast<TileID::UNDERLYING_TYPE>(tidNew)), NULL);
 
         pDoc->CreateNewFrame(GetApp()->m_pTileEditTmpl, "Tile Editor",
             reinterpret_cast<LPVOID>(value_preserving_cast<uintptr_t>(tidNew)));
@@ -416,7 +418,8 @@ void CGbxProjView::DoTileDelete()
     for (size_t i = 0; i < tidtbl.size(); i++)
     {
         pTMgr->DeleteTile(tidtbl[i]);
-        pDoc->UpdateAllViews(NULL, MAKELPARAM(HINT_TILEDELETED, static_cast<WORD>(tidtbl[i])), NULL);
+        static_assert(sizeof(TileID::UNDERLYING_TYPE) <= sizeof(WORD), "makelparam can't hold full arg");
+        pDoc->UpdateAllViews(NULL, MAKELPARAM(HINT_TILEDELETED, static_cast<TileID::UNDERLYING_TYPE>(tidtbl[i])), NULL);
     }
     pDoc->NotifyTileDatabaseChange();
     pDoc->SetModifiedFlag();

--- a/GM/VwPrjgbx.cpp
+++ b/GM/VwPrjgbx.cpp
@@ -578,8 +578,8 @@ void CGbxProjView::DoUpdateProjectList(BOOL bUpdateItem /* = TRUE */)
         if (bDisplayIDs)
         {
             CString strTmp = str;
-            str.Format("[%d] %s",
-                value_preserving_cast<int>(static_cast<WORD>(pBMgr->GetBoard(i).GetSerialNumber())), (LPCTSTR)strTmp);
+            str.Format("[%u] %s",
+                value_preserving_cast<unsigned>(static_cast<BoardID::UNDERLYING_TYPE>(pBMgr->GetBoard(i).GetSerialNumber())), (LPCTSTR)strTmp);
         }
         m_listProj.AddItem(grpBrd, str, i);
     }
@@ -874,8 +874,9 @@ void CGbxProjView::OnEditPaste()
         }
         DoUpdateTileList();
         pDoc->NotifyTileDatabaseChange();
-        for (size_t i = 0; i < tidtbl.size(); i++)
-            pDoc->UpdateAllViews(NULL, MAKELPARAM(HINT_TILECREATED, static_cast<WORD>(tidtbl[i])), NULL);
+        static_assert(sizeof(TileID::UNDERLYING_TYPE) <= sizeof(WORD), "makelparam can't hold full arg");
+        for (size_t i = size_t(0); i < tidtbl.size(); i++)
+            pDoc->UpdateAllViews(NULL, MAKELPARAM(HINT_TILECREATED, static_cast<TileID::UNDERLYING_TYPE>(tidtbl[i])), NULL);
         m_listTiles.SetCurSelsMapped(tidtbl);
         m_listTiles.ShowFirstSelection();
     }
@@ -1109,8 +1110,9 @@ void CGbxProjView::OnProjectLoadTileFile()
 
         DoUpdateTileList();
         pDoc->NotifyTileDatabaseChange();
-        for (size_t i = 0; i < tidtbl.size(); i++)
-            pDoc->UpdateAllViews(NULL, MAKELPARAM(HINT_TILECREATED, static_cast<WORD>(tidtbl[i])), NULL);
+        static_assert(sizeof(TileID::UNDERLYING_TYPE) <= sizeof(WORD), "makelparam can't hold full arg");
+        for (size_t i = size_t(0); i < tidtbl.size(); i++)
+            pDoc->UpdateAllViews(NULL, MAKELPARAM(HINT_TILECREATED, static_cast<TileID::UNDERLYING_TYPE>(tidtbl[i])), NULL);
         m_listTiles.SetCurSelsMapped(tidtbl);
         m_listTiles.ShowFirstSelection();
         EndWaitCursor();

--- a/GM/VwTilesl.cpp
+++ b/GM/VwTilesl.cpp
@@ -296,8 +296,9 @@ void CTileSelView::UpdateDocumentTiles()
     m_pTileMgr->UpdateTile(m_tid, &m_bmFull, &m_bmHalf, crSmall);
 
     // Finally handle various notifications
+    static_assert(sizeof(TileID::UNDERLYING_TYPE) <= sizeof(WORD), "makelparam can't hold full arg");
     pDoc->UpdateAllViews(this,
-        MAKELPARAM(HINT_TILEMODIFIED, static_cast<WORD>(m_tid)), NULL);
+        MAKELPARAM(HINT_TILEMODIFIED, static_cast<TileID::UNDERLYING_TYPE>(m_tid)), NULL);
     pDoc->SetModifiedFlag();
 }
 

--- a/GP/DlgNewGeoBoard.cpp
+++ b/GP/DlgNewGeoBoard.cpp
@@ -121,7 +121,7 @@ void CCreateGeomorphicBoardDialog::LoadBoardListWithCompliantBoards()
         if (!(pCellForm->GetCellType() == cformHexFlat && (pBArray->GetCols() & 1) != 0 ||
               pCellForm->GetCellType() == cformHexPnt && (pBArray->GetRows() & 1) != 0))
             continue;                           // These maps aren't compliant at all
-        if (static_cast<WORD>(pBrd.GetSerialNumber()) >= GEO_BOARD_SERNUM_BASE)
+        if (static_cast<BoardID::UNDERLYING_TYPE>(pBrd.GetSerialNumber()) >= GEO_BOARD_SERNUM_BASE)
             continue;                           // Can't build geo maps from geo maps
 
         if (m_pRootMapCellForm != NULL)
@@ -136,7 +136,7 @@ void CCreateGeomorphicBoardDialog::LoadBoardListWithCompliantBoards()
                 continue;
         }
         int nItem = m_listBoard.AddString(pBrd.GetName());
-        m_listBoard.SetItemData(nItem, value_preserving_cast<DWORD_PTR>(static_cast<WORD>(pBrd.GetSerialNumber())));
+        m_listBoard.SetItemData(nItem, value_preserving_cast<DWORD_PTR>(static_cast<BoardID::UNDERLYING_TYPE>(pBrd.GetSerialNumber())));
     }
     if (m_listBoard.GetCount() > 0)
         m_listBoard.SetCurSel(0);
@@ -224,7 +224,7 @@ void CCreateGeomorphicBoardDialog::OnBtnPressedAddBoard()
     CString strLabel = pBrd.GetName();
 
     int nItem = m_listGeo.AddString(strLabel);
-    m_listGeo.SetItemData(nItem, value_preserving_cast<DWORD_PTR>(static_cast<WORD>(dwItemData)));
+    m_listGeo.SetItemData(nItem, value_preserving_cast<DWORD_PTR>(static_cast<BoardID::UNDERLYING_TYPE>(dwItemData)));
 
     m_nCurrentColumn++;
     if (m_nCurrentColumn == m_nMaxColumns)
@@ -245,7 +245,7 @@ void CCreateGeomorphicBoardDialog::OnBtnPressedAddBreak()
     str.LoadString(IDS_ROW_BREAK);
 
     int nItem = m_listGeo.AddString(str);
-    m_listGeo.SetItemData(nItem, value_preserving_cast<DWORD_PTR>(static_cast<WORD>(nullBid)));
+    m_listGeo.SetItemData(nItem, value_preserving_cast<DWORD_PTR>(static_cast<BoardID::UNDERLYING_TYPE>(nullBid)));
 
     m_nMaxColumns = m_tblColWidth.GetSize();
     m_nRowNumber++;

--- a/GP/DlgSlbrd.cpp
+++ b/GP/DlgSlbrd.cpp
@@ -107,7 +107,7 @@ BOOL CSelectBoardsDialog::OnInitDialog()
     {
         CBoard& pBoard = m_pBMgr->GetBoard(i);
         int nIdx = m_listBoards.AddString(pBoard.GetName());
-        m_listBoards.SetItemData(nIdx, value_preserving_cast<DWORD_PTR>(static_cast<WORD>(pBoard.GetSerialNumber())));
+        m_listBoards.SetItemData(nIdx, value_preserving_cast<DWORD_PTR>(static_cast<BoardID::UNDERLYING_TYPE>(pBoard.GetSerialNumber())));
         m_listBoards.SetCheck(nIdx, 0);
     }
 

--- a/GP/GamDoc.cpp
+++ b/GP/GamDoc.cpp
@@ -71,6 +71,12 @@ IMPLEMENT_DYNCREATE(CGamDocHint, CObject);
 #define new DEBUG_NEW
 #endif
 
+// KLUDGE:  get access to CGamDoc::GetLoadingVersion
+int GetLoadingVersion()
+{
+    return CGamDoc::GetLoadingVersion();
+}
+
 /////////////////////////////////////////////////////////////////////////////
 
 int CGamDoc::c_fileVersion = 0;

--- a/GP/GamDoc3.cpp
+++ b/GP/GamDoc3.cpp
@@ -490,7 +490,7 @@ void CGamDoc::SerializeScenarioOrGame(CArchive& ar)
             AfxMessageBox(IDS_ERR_SCENARIONEWER, MB_OK | MB_ICONEXCLAMATION);
             AfxThrowArchiveException(CArchiveException::genericException);
         }
-        if (NumVersion(verMajor, verMinor) < NumVersion(2, 90))
+        if (NumVersion(verMajor, verMinor) < NumVersion(fileGbxVerMajor, fileGbxVerMinor))
         {
             if (AfxMessageBox(IDS_WARN_FILE_UPGRADE,
                 MB_OKCANCEL | MB_DEFBUTTON2 | MB_ICONWARNING) != IDOK)

--- a/GP/Gp.cpp
+++ b/GP/Gp.cpp
@@ -121,7 +121,17 @@ CGpApp::CGpApp()
 /////////////////////////////////////////////////////////////////////////////
 // The one and only CGpApp object
 
-CGpApp NEAR theApp;
+CGpApp& CGpApp::Get()
+{
+    /* make this a function variable to ensure
+        it's constructed before use */
+    static CGpApp theApp;
+    return theApp;
+}
+CWinApp& CbGetApp()
+{
+    return CGpApp::Get();
+}
 
 /////////////////////////////////////////////////////////////////////////////
 // CGpApp initialization
@@ -158,7 +168,7 @@ BOOL CGpApp::InitInstance()
 
     CMFCToolTipInfo ttParams;
     ttParams.m_bVislManagerTheme = TRUE;
-    theApp.GetTooltipManager()->SetTooltipParams(AFX_TOOLTIP_TYPE_ALL,
+    CGpApp::Get().GetTooltipManager()->SetTooltipParams(AFX_TOOLTIP_TYPE_ALL,
         RUNTIME_CLASS(CMFCToolTipCtrl), &ttParams);
 
     //////////////////////////////////////////////////////////////////////

--- a/GP/Gp.h
+++ b/GP/Gp.h
@@ -78,7 +78,10 @@ enum { MENU_PV_MOVEMODE = 0, MENU_PV_PLAYMODE, MENU_PV_SCNMODE,
 class CGpApp : public CWinAppEx
 {
 public:
+    static CGpApp& Get();
+private:
     CGpApp();
+public:
 
 // Operations
 public:

--- a/GP/LBoxSlct.cpp
+++ b/GP/LBoxSlct.cpp
@@ -180,12 +180,12 @@ void CSelectListBox::OnGetItemDebugString(size_t nIndex, CString& str)
     if (pDObj.GetType() == CDrawObj::drawPieceObj)
     {
         PieceID pid = static_cast<CPieceObj&>(pDObj).m_pid;
-        str.Format("[pid:%d] ", value_preserving_cast<UINT>(static_cast<WORD>(pid)));
+        str.Format("[pid:%u] ", value_preserving_cast<UINT>(static_cast<PieceID::UNDERLYING_TYPE>(pid)));
     }
     else if (pDObj.GetType() == CDrawObj::drawMarkObj)
     {
         MarkID mid = static_cast<CMarkObj&>(pDObj).m_mid;
-        str.Format("[mid:%d] ", value_preserving_cast<UINT>(static_cast<WORD>(mid)));
+        str.Format("[mid:%u] ", value_preserving_cast<UINT>(static_cast<MarkID::UNDERLYING_TYPE>(mid)));
     }
 }
 

--- a/GP/LBoxTray.cpp
+++ b/GP/LBoxTray.cpp
@@ -129,7 +129,7 @@ int  CTrayListBox::OnGetHitItemCodeAtPoint(CPoint point, CRect& rct)
     else
         return -1;
 
-    return value_preserving_cast<int>(static_cast<WORD>(nPid) | flags);
+    return value_preserving_cast<int>(static_cast<PieceID::UNDERLYING_TYPE>(nPid) | flags);
 }
 
 void CTrayListBox::OnGetTipTextForItemCode(int nItemCode,

--- a/GP/MapFace.h
+++ b/GP/MapFace.h
@@ -53,10 +53,10 @@ typedef DWORD ElementState;
 const DWORD MARKER_ELEMENT_FLAG = 0x80000000L; // Top set if a marker, else a piece
 
 inline ElementState MakePieceState(PieceID pid, WORD nFacingDegCW, BYTE nSide)
-    { return ((DWORD)static_cast<WORD>(pid) << 12) | ((DWORD)nSide << 9) | (nFacingDegCW & 0x1FF); }
+    { return ((DWORD)static_cast<PieceID::UNDERLYING_TYPE>(pid) << 12) | ((DWORD)nSide << 9) | (nFacingDegCW & 0x1FF); }
 
 inline ElementState MakeMarkerState(MarkID mid, WORD nFacingDegCW)
-    { return ((DWORD)static_cast<WORD>(mid) << 12) | (nFacingDegCW & 0x1FF) | MARKER_ELEMENT_FLAG; }
+    { return ((DWORD)static_cast<MarkID::UNDERLYING_TYPE>(mid) << 12) | (nFacingDegCW & 0x1FF) | MARKER_ELEMENT_FLAG; }
 
 inline int GetElementFacingAngle(ElementState elem)
 {

--- a/GP/MoveMgr.cpp
+++ b/GP/MoveMgr.cpp
@@ -83,7 +83,7 @@ BOOL CBoardPieceMove::ValidatePieces(CGamDoc* pDoc)
 #ifdef _DEBUG
     BOOL bUsed = pDoc->GetPieceTable()->IsPieceUsed(m_pid);
     if (!bUsed)
-        TRACE1("CBoardPieceMove::ValidatePieces - Piece %u not in piece table.\n", value_preserving_cast<UINT>(static_cast<WORD>(m_pid)));
+        TRACE1("CBoardPieceMove::ValidatePieces - Piece %u not in piece table.\n", value_preserving_cast<UINT>(static_cast<PieceID::UNDERLYING_TYPE>(m_pid)));
     return bUsed;
 #else
     return pDoc->GetPieceTable()->IsPieceUsed(m_pid);
@@ -171,8 +171,8 @@ void CBoardPieceMove::Serialize(CArchive& ar)
 void CBoardPieceMove::DumpToTextFile(CFile& file)
 {
     char szBfr[256];
-    wsprintf(szBfr, "    board = %d, pos = %d, pid = %d, @(%d, %d)\r\n",
-        value_preserving_cast<int>(static_cast<WORD>(m_nBrdNum)), m_ePos, value_preserving_cast<int>(static_cast<WORD>(m_pid)), m_ptCtr.x, m_ptCtr.y);
+    wsprintf(szBfr, "    board = %u, pos = %d, pid = %u, @(%d, %d)\r\n",
+        value_preserving_cast<unsigned>(static_cast<BoardID::UNDERLYING_TYPE>(m_nBrdNum)), m_ePos, value_preserving_cast<unsigned>(static_cast<PieceID::UNDERLYING_TYPE>(m_pid)), m_ptCtr.x, m_ptCtr.y);
     file.Write(szBfr, lstrlen(szBfr));
 }
 #endif
@@ -194,7 +194,7 @@ BOOL CTrayPieceMove::ValidatePieces(CGamDoc* pDoc)
 #ifdef _DEBUG
     BOOL bUsed = pDoc->GetPieceTable()->IsPieceUsed(m_pid);
     if (!bUsed)
-        TRACE1("CTrayPieceMove::ValidatePieces - Piece %u not in piece table.\n", value_preserving_cast<UINT>(static_cast<WORD>(m_pid)));
+        TRACE1("CTrayPieceMove::ValidatePieces - Piece %u not in piece table.\n", value_preserving_cast<UINT>(static_cast<PieceID::UNDERLYING_TYPE>(m_pid)));
     return bUsed;
 #else
     return pDoc->GetPieceTable()->IsPieceUsed(m_pid);
@@ -255,7 +255,7 @@ void CTrayPieceMove::DumpToTextFile(CFile& file)
 {
     char szBfr[256];
     wsprintf(szBfr, "    tray = %zu, nPos = %zu, pid = %u\r\n",
-        m_nTrayNum, m_nPos, static_cast<WORD>(m_pid));
+        m_nTrayNum, m_nPos, static_cast<PieceID::UNDERLYING_TYPE>(m_pid));
     file.Write(szBfr, lstrlen(szBfr));
 }
 #endif
@@ -268,7 +268,7 @@ BOOL CPieceSetSide::ValidatePieces(CGamDoc* pDoc)
 #ifdef _DEBUG
     BOOL bUsed = pDoc->GetPieceTable()->IsPieceUsed(m_pid);
     if (!bUsed)
-        TRACE1("CPieceSetSide::ValidatePieces - Piece %u not in piece table.\n", value_preserving_cast<UINT>(static_cast<WORD>(m_pid)));
+        TRACE1("CPieceSetSide::ValidatePieces - Piece %u not in piece table.\n", value_preserving_cast<UINT>(static_cast<PieceID::UNDERLYING_TYPE>(m_pid)));
     return bUsed;
 #else
     return pDoc->GetPieceTable()->IsPieceUsed(m_pid);
@@ -347,8 +347,8 @@ void CPieceSetSide::Serialize(CArchive& ar)
 void CPieceSetSide::DumpToTextFile(CFile& file)
 {
     char szBfr[256];
-    wsprintf(szBfr, "    Piece %d is set to %s visible.\r\n",
-        value_preserving_cast<int>(static_cast<WORD>(m_pid)), m_bTopUp ? "top" : "bottom");
+    wsprintf(szBfr, "    Piece %u is set to %s visible.\r\n",
+        value_preserving_cast<unsigned>(static_cast<PieceID::UNDERLYING_TYPE>(m_pid)), m_bTopUp ? "top" : "bottom");
     file.Write(szBfr, lstrlen(szBfr));
 }
 #endif
@@ -361,7 +361,7 @@ BOOL CPieceSetFacing::ValidatePieces(CGamDoc* pDoc)
 #ifdef _DEBUG
     BOOL bUsed = pDoc->GetPieceTable()->IsPieceUsed(m_pid);
     if (!bUsed)
-        TRACE1("CPieceSetFacing::ValidatePieces - Piece %u not in piece table.\n", value_preserving_cast<UINT>(static_cast<WORD>(m_pid)));
+        TRACE1("CPieceSetFacing::ValidatePieces - Piece %u not in piece table.\n", value_preserving_cast<UINT>(static_cast<PieceID::UNDERLYING_TYPE>(m_pid)));
     return bUsed;
 #else
     return pDoc->GetPieceTable()->IsPieceUsed(m_pid);
@@ -428,7 +428,7 @@ void CPieceSetFacing::Serialize(CArchive& ar)
 void CPieceSetFacing::DumpToTextFile(CFile& file)
 {
     char szBfr[256];
-    wsprintf(szBfr, "    Piece %d is rotated %d degrees.\r\n", value_preserving_cast<int>(static_cast<WORD>(m_pid)), m_nFacingDegCW);
+    wsprintf(szBfr, "    Piece %u is rotated %d degrees.\r\n", value_preserving_cast<unsigned>(static_cast<PieceID::UNDERLYING_TYPE>(m_pid)), m_nFacingDegCW);
     file.Write(szBfr, lstrlen(szBfr));
 }
 #endif
@@ -441,7 +441,7 @@ BOOL CPieceSetOwnership::ValidatePieces(CGamDoc* pDoc)
 #ifdef _DEBUG
     BOOL bUsed = pDoc->GetPieceTable()->IsPieceUsed(m_pid);
     if (!bUsed)
-        TRACE1("CPieceSetOwnership::ValidatePieces - Piece %u not in piece table.\n", value_preserving_cast<UINT>(static_cast<WORD>(m_pid)));
+        TRACE1("CPieceSetOwnership::ValidatePieces - Piece %u not in piece table.\n", value_preserving_cast<UINT>(static_cast<PieceID::UNDERLYING_TYPE>(m_pid)));
     return bUsed;
 #else
     return pDoc->GetPieceTable()->IsPieceUsed(m_pid);
@@ -493,8 +493,8 @@ void CPieceSetOwnership::Serialize(CArchive& ar)
 void CPieceSetOwnership::DumpToTextFile(CFile& file)
 {
     char szBfr[256];
-    wsprintf(szBfr, "    Piece %d has ownership changed to 0x%X.\r\n",
-        value_preserving_cast<int>(static_cast<WORD>(m_pid)), m_dwOwnerMask);
+    wsprintf(szBfr, "    Piece %u has ownership changed to 0x%X.\r\n",
+        value_preserving_cast<unsigned>(static_cast<PieceID::UNDERLYING_TYPE>(m_pid)), m_dwOwnerMask);
     file.Write(szBfr, lstrlen(szBfr));
 }
 #endif
@@ -562,8 +562,8 @@ void CMarkerSetFacing::Serialize(CArchive& ar)              // VER2.0 is first t
 void CMarkerSetFacing::DumpToTextFile(CFile& file)
 {
     char szBfr[256];
-    wsprintf(szBfr, "    Marker dwObjID = %lX, mid = %d is rotated %d degrees.\r\n",
-        m_dwObjID, value_preserving_cast<int>(static_cast<WORD>(m_mid)), m_nFacingDegCW);
+    wsprintf(szBfr, "    Marker dwObjID = %lX, mid = %u is rotated %d degrees.\r\n",
+        m_dwObjID, value_preserving_cast<unsigned>(static_cast<MarkID::UNDERLYING_TYPE>(m_mid)), m_nFacingDegCW);
     file.Write(szBfr, lstrlen(szBfr));
 }
 #endif
@@ -659,8 +659,8 @@ void CBoardMarkerMove::Serialize(CArchive& ar)
 void CBoardMarkerMove::DumpToTextFile(CFile& file)
 {
     char szBfr[256];
-    wsprintf(szBfr, "    board = %d, pos = %d, dwObjID = %lX, mid = %d, @(%d, %d)\r\n",
-        value_preserving_cast<int>(static_cast<WORD>(m_nBrdNum)), m_ePos, m_dwObjID, value_preserving_cast<int>(static_cast<WORD>(m_mid)), m_ptCtr.x, m_ptCtr.y);
+    wsprintf(szBfr, "    board = %u, pos = %d, dwObjID = %lX, mid = %u, @(%d, %d)\r\n",
+        value_preserving_cast<unsigned>(static_cast<BoardID::UNDERLYING_TYPE>(m_nBrdNum)), m_ePos, m_dwObjID, value_preserving_cast<unsigned>(static_cast<MarkID::UNDERLYING_TYPE>(m_mid)), m_ptCtr.x, m_ptCtr.y);
     file.Write(szBfr, lstrlen(szBfr));
 }
 #endif
@@ -1099,7 +1099,7 @@ void CEventMessageRcd::Serialize(CArchive& ar)
         else
         {
             ar << value_preserving_cast<WORD>(m_nTray);
-            ar << value_preserving_cast<DWORD>(static_cast<WORD>(m_pieceID));
+            ar << value_preserving_cast<DWORD>(static_cast<PieceID::UNDERLYING_TYPE>(m_pieceID));
             ar << (DWORD)0;
         }
         ar << m_strMsg;
@@ -1131,13 +1131,13 @@ void CEventMessageRcd::DumpToTextFile(CFile& file)
     char szBfr[256];
     if (m_bIsBoardEvent)
     {
-        wsprintf(szBfr, "    BoardEvt = %s, nBoard = %d, (x, y) = (%d, %d)\r\n",
-                 (LPCTSTR)(m_bIsBoardEvent ? "TRUE" : "FALSE"), value_preserving_cast<int>(static_cast<WORD>(m_nBoard)), m_x, m_y);
+        wsprintf(szBfr, "    BoardEvt = %s, nBoard = %u, (x, y) = (%d, %d)\r\n",
+                 (LPCTSTR)(m_bIsBoardEvent ? "TRUE" : "FALSE"), value_preserving_cast<unsigned>(static_cast<BoardID::UNDERLYING_TYPE>(m_nBoard)), m_x, m_y);
     }
     else
     {
-        wsprintf(szBfr, "    BoardEvt = %s, nTray = %zu, pieceID = %d\r\n",
-                 (LPCTSTR)(m_bIsBoardEvent ? "TRUE" : "FALSE"), m_nTray, value_preserving_cast<int>(static_cast<WORD>(m_pieceID)));
+        wsprintf(szBfr, "    BoardEvt = %s, nTray = %zu, pieceID = %u\r\n",
+                 (LPCTSTR)(m_bIsBoardEvent ? "TRUE" : "FALSE"), m_nTray, value_preserving_cast<unsigned>(static_cast<PieceID::UNDERLYING_TYPE>(m_pieceID)));
     }
     file.Write(szBfr, lstrlen(szBfr));
 }

--- a/GP/PBoard.cpp
+++ b/GP/PBoard.cpp
@@ -521,12 +521,12 @@ CPBoardManager::CPBoardManager()
 
 BoardID CPBoardManager::IssueGeoSerialNumber()
 {
-    if (static_cast<WORD>(m_nNextGeoSerialNum) > maxBoards)
+    if (static_cast<BoardID::UNDERLYING_TYPE>(m_nNextGeoSerialNum) > maxBoards)
     {
         AfxThrowMemoryException();
     }
     BoardID retval = m_nNextGeoSerialNum;
-    m_nNextGeoSerialNum = static_cast<BoardID>(static_cast<WORD>(m_nNextGeoSerialNum) + 1);
+    m_nNextGeoSerialNum = static_cast<BoardID>(static_cast<BoardID::UNDERLYING_TYPE>(m_nNextGeoSerialNum) + 1);
     return retval;
 }
 

--- a/GP/PPieces.cpp
+++ b/GP/PPieces.cpp
@@ -542,8 +542,8 @@ void CPieceTable::DumpToTextFile(CFile& file)
         wsprintf(szBfr, "PieceID %5.5d: m_nSide=%02X, m_nFacing=%3u, "
             "m_tidFront=%5u, m_tidBack=%5u\r\n", i,
             (UINT)pPce->m_nSide, (UINT)pPce->m_nFacing,
-            (UINT)static_cast<WORD>(pDef->m_tidFront),
-            (UINT)static_cast<WORD>(pDef->m_tidBack));
+            (UINT)static_cast<TileID::UNDERLYING_TYPE>(pDef->m_tidFront),
+            (UINT)static_cast<TileID::UNDERLYING_TYPE>(pDef->m_tidBack));
         file.Write(szBfr, lstrlen(szBfr));
     }
 }

--- a/GP/VwPrjgam.cpp
+++ b/GP/VwPrjgam.cpp
@@ -439,8 +439,8 @@ void CGamProjView::DoUpdateProjectList(BOOL bUpdateItem /* = TRUE */)
         if (bDisplayIDs)
         {
             CString strTmp = str;
-            str.Format("[%d] %s",
-                static_cast<WORD>(pPBMgr->GetPBoard(i).GetBoard()->GetSerialNumber()), (LPCTSTR)strTmp);
+            str.Format("[%u] %s",
+                value_preserving_cast<unsigned>(static_cast<BoardID::UNDERLYING_TYPE>(pPBMgr->GetPBoard(i).GetBoard()->GetSerialNumber())), (LPCTSTR)strTmp);
         }
         if (pPBoard.IsOwned())
         {

--- a/GP/VwPrjgsn.cpp
+++ b/GP/VwPrjgsn.cpp
@@ -432,8 +432,8 @@ void CGsnProjView::DoUpdateProjectList(BOOL bUpdateItem /* = TRUE */)
         if (bDisplayIDs)
         {
             CString strTmp = str;
-            str.Format("[%d] %s",
-                static_cast<WORD>(pPBoard.GetBoard()->GetSerialNumber()), (LPCTSTR)strTmp);
+            str.Format("[%u] %s",
+                value_preserving_cast<unsigned>(static_cast<BoardID::UNDERLYING_TYPE>(pPBoard.GetBoard()->GetSerialNumber())), (LPCTSTR)strTmp);
         }
         if (pPBoard.IsOwned())
         {

--- a/GP/WStateGp.cpp
+++ b/GP/WStateGp.cpp
@@ -71,7 +71,7 @@ void CGpWinStateMgr::OnAnnotateWinStateElement(CWinStateElement& pWse, CWnd *pWn
     {
         CPlayBoardFrame* pFrame = (CPlayBoardFrame*)pWnd;
         pWse.m_wUserCode1 = gpFrmPlayBoard;
-        pWse.m_wUserCode2 = static_cast<WORD>(pFrame->m_pPBoard->GetSerialNumber());
+        pWse.m_wUserCode2 = static_cast<BoardID::UNDERLYING_TYPE>(pFrame->m_pPBoard->GetSerialNumber());
     }
 }
 

--- a/GShr/Board.cpp
+++ b/GShr/Board.cpp
@@ -500,7 +500,7 @@ size_t CBoardManager::FindBoardBySerial(BoardID nSerialNum) const
 {
     for (size_t i = 0; i < GetNumBoards(); i++)
     {
-        TRACE2("Board %zu has serial number %d\n", i, value_preserving_cast<int>(static_cast<WORD>(GetBoard(i).GetSerialNumber())));
+        TRACE2("Board %zu has serial number %u\n", i, value_preserving_cast<unsigned>(static_cast<BoardID::UNDERLYING_TYPE>(GetBoard(i).GetSerialNumber())));
         if (GetBoard(i).GetSerialNumber() == nSerialNum)
             return i;
     }
@@ -521,12 +521,12 @@ BOOL CBoardManager::DoBoardFontDialog()
 
 BoardID CBoardManager::IssueSerialNumber()
 {
-    if (static_cast<WORD>(m_nNextSerialNumber) == GEO_BOARD_SERNUM_BASE)
+    if (static_cast<BoardID::UNDERLYING_TYPE>(m_nNextSerialNumber) == GEO_BOARD_SERNUM_BASE)
     {
         AfxThrowMemoryException();
     }
     BoardID retval = m_nNextSerialNumber;
-    m_nNextSerialNumber = static_cast<BoardID>(static_cast<WORD>(m_nNextSerialNumber) + 1);
+    m_nNextSerialNumber = static_cast<BoardID>(static_cast<BoardID::UNDERLYING_TYPE>(m_nNextSerialNumber) + WORD(1));
     return retval;
 }
 

--- a/GShr/Board.h
+++ b/GShr/Board.h
@@ -37,6 +37,8 @@
 #include    "DrawObj.h"
 #endif
 
+typedef XxxxID16<'B'> BoardID16;
+typedef XxxxID32<'B'> BoardID32;
 typedef XxxxID<'B'> BoardID;
 const       BoardID nullBid = BoardID(0xFFFF);
 const size_t maxBoards = 32000;

--- a/GShr/CyberBoard.h
+++ b/GShr/CyberBoard.h
@@ -462,8 +462,13 @@ struct is_always_value_preserving
                     "only integral types supported");
     static constexpr bool value = std::is_integral_v<DEST> &&
                                     std::is_integral_v<SRC> &&
-                                    std::is_signed_v<DEST> == std::is_signed_v<SRC> &&
-                                    sizeof(DEST) >= sizeof(SRC);
+                                    (
+                                        (std::is_signed_v<DEST> == std::is_signed_v<SRC> &&
+                                        sizeof(DEST) >= sizeof(SRC))
+                                    ||
+                                        (std::is_unsigned_v<SRC> &&
+                                        sizeof(DEST) > sizeof(SRC))
+                                    );
 };
 
 // convenience helper

--- a/GShr/LBoxGrfx.h
+++ b/GShr/LBoxGrfx.h
@@ -386,7 +386,7 @@ protected:
 
     /* N.B.:  Only CTileBaseListBox requires providing this, but
         it doesn't hurt much to provide it in general.  */
-    virtual int OnGetItemDebugIDCode(size_t nItem) override { return value_preserving_cast<int>(static_cast<WORD>(MapIndexToItem(nItem))); }
+    virtual int OnGetItemDebugIDCode(size_t nItem) override { return value_preserving_cast<int>(static_cast<T::UNDERLYING_TYPE>(MapIndexToItem(nItem))); }
 
 private:
     const std::vector<T>* m_pItemMap;         // Maps index to item

--- a/GShr/LBoxMark.cpp
+++ b/GShr/LBoxMark.cpp
@@ -92,7 +92,7 @@ int  CMarkListBox::OnGetHitItemCodeAtPoint(CPoint point, CRect& rct)
 
     GetTileRectsForItem(value_preserving_cast<int>(nIndex), tid, nullTid, rct, rct);
 
-    return rct.PtInRect(point) ? value_preserving_cast<int>(static_cast<WORD>(mid)) : -1;
+    return rct.PtInRect(point) ? value_preserving_cast<int>(static_cast<MarkID::UNDERLYING_TYPE>(mid)) : -1;
 }
 
 void CMarkListBox::OnGetTipTextForItemCode(int nItemCode,

--- a/GShr/LBoxPiec.cpp
+++ b/GShr/LBoxPiec.cpp
@@ -115,7 +115,7 @@ int  CPieceListBox::OnGetHitItemCodeAtPoint(CPoint point, CRect& rct)
     else
         return -1;
 
-    return value_preserving_cast<int>(static_cast<WORD>(nPid) | flags);
+    return value_preserving_cast<int>(static_cast<PieceID::UNDERLYING_TYPE>(nPid) | flags);
 }
 
 void CPieceListBox::OnGetTipTextForItemCode(int nItemCode,

--- a/GShr/Marks.h
+++ b/GShr/Marks.h
@@ -32,6 +32,8 @@
 //////////////////////////////////////////////////////////////////////
 
 const size_t maxMarks = 32000;
+typedef XxxxID16<'M'> MarkID16;
+typedef XxxxID32<'M'> MarkID32;
 typedef XxxxID<'M'> MarkID;
 
 const       MarkID nullMid = MarkID(0xFFFF);

--- a/GShr/Pieces.h
+++ b/GShr/Pieces.h
@@ -32,6 +32,8 @@
 //////////////////////////////////////////////////////////////////////
 
 const size_t maxPieces = 32000;
+typedef XxxxID16<'P'> PieceID16;
+typedef XxxxID32<'P'> PieceID32;
 typedef XxxxID<'P'> PieceID;
 
 const       PieceID nullPid = PieceID(0xFFFF);

--- a/GShr/Tile.h
+++ b/GShr/Tile.h
@@ -36,6 +36,8 @@ class   CTile;
 ////////////////////////////////////////////////////////////////////
 
 const size_t maxTiles = 32000;
+typedef XxxxID16<'T'> TileID16;
+typedef XxxxID32<'T'> TileID32;
 typedef XxxxID<'T'> TileID;
 
 const       TileID nullTid = TileID(0xFFFF);

--- a/GShr/TileMgr.cpp
+++ b/GShr/TileMgr.cpp
@@ -613,7 +613,7 @@ void CTileManager::DumpTileDatabaseInfoToFile(LPCTSTR pszFileName, BOOL bNewFile
         WriteFileString(hFile, szBfr);
         for (size_t i = 0; i < pTSet.GetTileIDTable().size(); i++)
         {
-            wsprintf(szBfr, " %u", static_cast<WORD>(pTSet.GetTileIDTable().at(i)));
+            wsprintf(szBfr, " %u", static_cast<TileID::UNDERLYING_TYPE>(pTSet.GetTileIDTable().at(i)));
             WriteFileString(hFile, szBfr);
         }
         WriteFileString(hFile, "\r\n");


### PR DESCRIPTION
This implements the file version command line option /id32 discussed in #57.

Also Fix #59