### PR TITLE
use GameElement for CGrafixListBox ItemCode

### DIFF
--- a/GM/VwBitedt.h
+++ b/GM/VwBitedt.h
@@ -59,7 +59,7 @@ public:
         { return CSize(m_size.cx * m_nZoom, m_size.cy * m_nZoom); }
     CRect GetZoomedSelectBorderRect();
     CRect GetZoomedSelectRect();
-    void SetSelectRect(CRect& rct) { m_rctPaste = rct; }
+    void SetSelectRect(const CRect& rct) { m_rctPaste = rct; }
     CRect GetSelectRect() { return m_rctPaste; }
     void OffsetSelectRect(CSize size) { m_rctPaste += (CPoint)size; }
     void SetSelectToolControl(BOOL bCapture) { m_bSelectCapture = bCapture; }

--- a/GM/VwEdtbrd.cpp
+++ b/GM/VwEdtbrd.cpp
@@ -1675,7 +1675,7 @@ void CBrdEditView::OnUpdateEditPasteBitmapFromFile(CCmdUI* pCmdUI)
 
 //DFM 19991014...
 //GetKeyState()
-static const short KEY_STATE_VALUE = (short)0x8000;
+static const short KEY_STATE_VALUE = static_cast<short>(static_cast<unsigned short>(0x8000));
 
 void CBrdEditView::HandleKeyDown ()
 {

--- a/GP/Editnocv.cpp
+++ b/GP/Editnocv.cpp
@@ -76,7 +76,7 @@ LRESULT CEditNoChevron::OnPasteMessage(WPARAM, LPARAM)
             while (*pText)
             {
                 // Replace chevrons and paragraph chars with spaces
-                if (*pText == (char)0xBB || *pText == (char)0xB6)
+                if (*pText == static_cast<unsigned char>(0xBB) || *pText == static_cast<unsigned char>(0xB6))
                     *pText = ' ';
                 pText++;
             }

--- a/GP/GamDoc.cpp
+++ b/GP/GamDoc.cpp
@@ -779,7 +779,7 @@ BOOL CGamDoc::OnNewGame()
                 strFileList += strFName;
             }
             CString strMsg;
-            strMsg.Format(IDS_MSG_PLAYER_FILES, strFileList);
+            strMsg.Format(IDS_MSG_PLAYER_FILES, strFileList.GetString());
             AfxMessageBox(strMsg, MB_OK | MB_ICONINFORMATION);
 
             return FALSE;
@@ -2012,7 +2012,7 @@ void CGamDoc::OnFileCreateReferee()
     {
         // File already exists. Prompt for overwrite.
         CString str;
-        str.Format(IDS_WARN_REF_EXISTS, strFName);
+        str.Format(IDS_WARN_REF_EXISTS, strFName.GetString());
         if (AfxMessageBox(str, MB_OKCANCEL | MB_ICONEXCLAMATION | MB_DEFBUTTON2) != IDOK)
             return;
     }
@@ -2031,7 +2031,7 @@ void CGamDoc::OnFileCreateReferee()
     if (bOK)
     {
         CString str;
-        str.Format(IDS_INFO_REF_CREATED, strFName);
+        str.Format(IDS_INFO_REF_CREATED, strFName.GetString());
         AfxMessageBox(str);
     }
 }
@@ -2095,7 +2095,7 @@ void CGamDoc::OnFileChangeGameOwner()
     {
         // File already exists. Prompt for overwrite.
         CString str;
-        str.Format(IDS_WARN_REF_EXISTS, strFName);
+        str.Format(IDS_WARN_REF_EXISTS, strFName.GetString());
         if (AfxMessageBox(str, MB_OKCANCEL | MB_ICONEXCLAMATION | MB_DEFBUTTON2) != IDOK)
             return;
     }
@@ -2114,7 +2114,7 @@ void CGamDoc::OnFileChangeGameOwner()
     if (bOK)
     {
         CString str;
-        str.Format(IDS_INFO_GAME_CREATED, strFName);
+        str.Format(IDS_INFO_GAME_CREATED, strFName.GetString());
         AfxMessageBox(str);
     }
 }

--- a/GP/LBoxSlct.cpp
+++ b/GP/LBoxSlct.cpp
@@ -116,12 +116,12 @@ BOOL CSelectListBox::OnIsToolTipsEnabled()
     return m_pDoc->IsShowingObjectTips();
 }
 
-int  CSelectListBox::OnGetHitItemCodeAtPoint(CPoint point, CRect& rct)
+GameElement CSelectListBox::OnGetHitItemCodeAtPoint(CPoint point, CRect& rct)
 {
     BOOL bOutsideClient;
     UINT nIndex = ItemFromPoint(point, bOutsideClient);
     if (nIndex >= 65535 || GetCount() <= 0)
-        return -1;
+        return Invalid_v<GameElement>;
 
     TileID tidLeft = GetTileID(TRUE, nIndex);
     ASSERT(tidLeft != nullTid);
@@ -145,17 +145,14 @@ int  CSelectListBox::OnGetHitItemCodeAtPoint(CPoint point, CRect& rct)
         elem = m_pDoc->GetVerifiedGameElementCodeForObject(pObj, TRUE);
         rct = rctRight;
     }
-    else
-        return -1;
 
-    static_assert(sizeof(elem) == sizeof(int), "size mismatch");
-    return reinterpret_cast<int&>(elem);
+    return elem;
 }
 
-void CSelectListBox::OnGetTipTextForItemCode(int nItemCode,
+void CSelectListBox::OnGetTipTextForItemCode(GameElement nItemCode,
     CString& strTip, CString& strTitle)
 {
-    if (nItemCode == -1)
+    if (nItemCode == Invalid_v<GameElement>)
         return;
     static_assert(sizeof(GameElement) == sizeof(nItemCode), "size mismatch");
     GameElement& elem = reinterpret_cast<GameElement&>(nItemCode);

--- a/GP/LBoxSlct.h
+++ b/GP/LBoxSlct.h
@@ -78,8 +78,8 @@ protected:
 
     // Tool tip processing
     virtual BOOL OnIsToolTipsEnabled() override;
-    virtual int  OnGetHitItemCodeAtPoint(CPoint point, CRect& rct) override;
-    virtual void OnGetTipTextForItemCode(int nItemCode, CString& strTip, CString& strTitle) override;
+    virtual GameElement OnGetHitItemCodeAtPoint(CPoint point, CRect& rct) override;
+    virtual void OnGetTipTextForItemCode(GameElement nItemCode, CString& strTip, CString& strTitle) override;
     virtual BOOL OnDoesItemHaveTipText(size_t nItem) override;
 
     //{{AFX_MSG(CSelectListBox)

--- a/GP/LBoxTray.h
+++ b/GP/LBoxTray.h
@@ -92,8 +92,8 @@ protected:
 
     // Tool tip processing
     virtual BOOL OnIsToolTipsEnabled() override;
-    virtual int  OnGetHitItemCodeAtPoint(CPoint point, CRect& rct) override;
-    virtual void OnGetTipTextForItemCode(int nItemCode, CString& strTip, CString& strTitle) override;
+    virtual GameElement OnGetHitItemCodeAtPoint(CPoint point, CRect& rct) override;
+    virtual void OnGetTipTextForItemCode(GameElement nItemCode, CString& strTip, CString& strTitle) override;
     virtual BOOL OnDoesItemHaveTipText(size_t nItem) override;
 
     // Misc

--- a/GP/SelOPlay.h
+++ b/GP/SelOPlay.h
@@ -75,6 +75,7 @@ public:
     CSelection(CPlayBoardView& pView, CDrawObj& pObj) :
         m_pView(&pView), m_pObj(&pObj)
     {}
+    virtual ~CSelection() = default;
 
 // Attributes
 public:

--- a/GP/VwPrjgam.cpp
+++ b/GP/VwPrjgam.cpp
@@ -415,7 +415,7 @@ void CGamProjView::DoUpdateProjectList(BOOL bUpdateItem /* = TRUE */)
             CString strOwner = pDoc->GetPlayerManager()->GetPlayerUsingMask(
                 pDoc->GetCurrentPlayerMask()).m_strName;
             CString strOwnedBy;
-            strOwnedBy.Format(IDS_TIP_OWNED_BY_PROJ, strOwner);
+            strOwnedBy.Format(IDS_TIP_OWNED_BY_PROJ, strOwner.GetString());
             str += strOwnedBy;
         }
     }
@@ -447,7 +447,7 @@ void CGamProjView::DoUpdateProjectList(BOOL bUpdateItem /* = TRUE */)
             CString strOwner = pDoc->GetPlayerManager()->GetPlayerUsingMask(
                 pPBoard.GetOwnerMask()).m_strName;
             CString strOwnedBy;
-            strOwnedBy.Format(IDS_TIP_OWNED_BY_PROJ, strOwner);
+            strOwnedBy.Format(IDS_TIP_OWNED_BY_PROJ, strOwner.GetString());
             str += strOwnedBy;
         }
         m_listProj.AddItem(grpBrd, str, i);

--- a/GP/VwPrjgsn.cpp
+++ b/GP/VwPrjgsn.cpp
@@ -440,7 +440,7 @@ void CGsnProjView::DoUpdateProjectList(BOOL bUpdateItem /* = TRUE */)
             CString strOwner = pDoc->GetPlayerManager()->GetPlayerUsingMask(
                 pPBoard.GetOwnerMask()).m_strName;
             CString strOwnedBy;
-            strOwnedBy.Format(IDS_TIP_OWNED_BY_PROJ, strOwner);
+            strOwnedBy.Format(IDS_TIP_OWNED_BY_PROJ, strOwner.GetString());
             str += strOwnedBy;
         }
         m_listProj.AddItem(grpBrd, str, i);
@@ -466,7 +466,7 @@ void CGsnProjView::DoUpdateProjectList(BOOL bUpdateItem /* = TRUE */)
             CString strOwner = pDoc->GetPlayerManager()->GetPlayerUsingMask(
                 pYSet.GetOwnerMask()).m_strName;
             CString strOwnedBy;
-            strOwnedBy.Format(IDS_TIP_OWNED_BY_PROJ, strOwner);
+            strOwnedBy.Format(IDS_TIP_OWNED_BY_PROJ, strOwner.GetString());
             str += strOwnedBy;
         }
         m_listProj.AddItem(grpTray, str, i);

--- a/GShr/CalcLib.cpp
+++ b/GShr/CalcLib.cpp
@@ -273,7 +273,7 @@ DWORD GetStringHash(LPCSTR str)
 
 // ----------------------------------------------- //
 
-CPoint GetMidRect(CRect& rct)
+CPoint GetMidRect(const CRect& rct)
 {
     return CPoint(MidPnt(rct.left, rct.right), MidPnt(rct.top, rct.bottom));
 }

--- a/GShr/CyberBoard.h
+++ b/GShr/CyberBoard.h
@@ -36,6 +36,18 @@
 
 #include <WinExt.h>
 
+// warning C4239 : nonstandard extension used : 'argument' : conversion from 'xxx' to 'xxx &'
+#pragma warning(error:  4239)
+// warning C4310 : cast truncates constant value
+#pragma warning(error:  4310)
+// warning C4840 : non - portable use of class 'xxx' as an argument to a variadic function
+#pragma warning(error:  4840)
+// warning C5205 : delete of an abstract class 'xxx' that has a non - virtual destructor results in undefined behavior
+// WARNING:  for some reason, this won't change level!
+#pragma warning(1:  5205)
+// WARNING:  for some reason, this won't become an error, even at level 4!
+#pragma warning(error:  5205)
+
 #if defined(max)
     #undef max
 #endif

--- a/GShr/GMisc.h
+++ b/GShr/GMisc.h
@@ -51,7 +51,7 @@ std::vector<int> AllocateAndCalcRandomIndexVector(int nNumIndices, int nRange, U
 #endif
 
 inline int MidPnt(int a, int b) { return a+(b-a)/2; }
-CPoint GetMidRect(CRect& rct);
+CPoint GetMidRect(const CRect& rct);
 CPoint RotatePointAroundPoint(CPoint pntOrigin, CPoint pntXlate, int nAngleDeg);
 
 int GridizeClosest1000(int nVal, int nMultiple, int nOffset);

--- a/GShr/LBoxGfx2.cpp
+++ b/GShr/LBoxGfx2.cpp
@@ -253,14 +253,14 @@ void CGrafixListBox2::DoToolTipHitProcessing(CPoint point)
     }
 
     CRect rctTool;
-    int nItemCode = OnGetHitItemCodeAtPoint(point, rctTool);
+    GameElement nItemCode = OnGetHitItemCodeAtPoint(point, rctTool);
 
     if (nItemCode != m_nCurItemCode)
     {
         // Object changed so delete previous tool definition
         m_toolTip.DelTool(this, ID_TIP_LISTITEM_HIT);
         m_nCurItemCode = nItemCode;
-        if (nItemCode != -1)
+        if (nItemCode != Invalid_v<GameElement>)
         {
             // New object found so create a new tip
             CString strTip;

--- a/GShr/LBoxGfx2.h
+++ b/GShr/LBoxGfx2.h
@@ -29,6 +29,8 @@
 #include    "DragDrop.h"
 #endif
 
+#include    "MapStrng.h"
+
 class CDrawObj;
 
 /////////////////////////////////////////////////////////////////////////////
@@ -98,8 +100,8 @@ public:
 
     // For tool tip processing
     virtual BOOL OnIsToolTipsEnabled() /* override */ { return FALSE; }
-    virtual int  OnGetHitItemCodeAtPoint(CPoint point, CRect& rct) /* override */ { return -1; }
-    virtual void OnGetTipTextForItemCode(int nItemCode, CString& strTip, CString& strTitle) /* override */ { }
+    virtual GameElement OnGetHitItemCodeAtPoint(CPoint point, CRect& rct) /* override */ { return Invalid_v<GameElement>; }
+    virtual void OnGetTipTextForItemCode(GameElement nItemCode, CString& strTip, CString& strTitle) /* override */ { }
 
 // Implementation
 protected:
@@ -110,7 +112,7 @@ protected:
 
     // Tool tip support
     CToolTipCtrl m_toolTip;
-    int     m_nCurItemCode;
+    GameElement m_nCurItemCode;
 
     // Drag and scroll support vars
     BOOL    m_bAllowDrag;

--- a/GShr/LBoxGrfx.cpp
+++ b/GShr/LBoxGrfx.cpp
@@ -57,9 +57,9 @@ END_MESSAGE_MAP()
 
 /////////////////////////////////////////////////////////////////////////////
 
-CGrafixListBox::CGrafixListBox()
+CGrafixListBox::CGrafixListBox() :
+    m_nCurItemCode(Invalid_v<GameElement>)
 {
-    m_nCurItemCode = -1;
     m_nLastInsert = -1;
     m_nTimerID = 0;
     m_bAllowDrag = FALSE;
@@ -205,14 +205,14 @@ void CGrafixListBox::DoToolTipHitProcessing(CPoint point)
     }
 
     CRect rctTool;
-    int nItemCode = OnGetHitItemCodeAtPoint(point, rctTool);
+    GameElement nItemCode = OnGetHitItemCodeAtPoint(point, rctTool);
 
     if (nItemCode != m_nCurItemCode) // && nItemCode >= 0)
     {
         // Object changed so delete previous tool definition
         m_toolTip.DelTool(this, ID_TIP_LISTITEM_HIT);
         m_nCurItemCode = nItemCode;
-        if (nItemCode != -1)
+        if (nItemCode != Invalid_v<GameElement>)
         {
             // New object found so create a new tip
             CString strTip;

--- a/GShr/LBoxGrfx.h
+++ b/GShr/LBoxGrfx.h
@@ -29,6 +29,8 @@
 #include    "DragDrop.h"
 #endif
 
+#include    "MapStrng.h"
+
 /////////////////////////////////////////////////////////////////////////////
 
 #define     ID_TIP_LISTITEM_HIT             1       // ID used for normal tips
@@ -145,8 +147,8 @@ public:
 
     // For tool tip processing
     virtual BOOL OnIsToolTipsEnabled() /* override */ { return FALSE; }
-    virtual int  OnGetHitItemCodeAtPoint(CPoint point, CRect& rct) /* override */ { return -1; }
-    virtual void OnGetTipTextForItemCode(int nItemCode, CString& strTip, CString& strTitle) /* override */ { }
+    virtual GameElement OnGetHitItemCodeAtPoint(CPoint point, CRect& rct) /* override */ { return Invalid_v<GameElement>; }
+    virtual void OnGetTipTextForItemCode(GameElement nItemCode, CString& strTip, CString& strTitle) /* override */ { }
 
     /* N.B.:  Conceptually, this declaration belongs to
         CTileBaseListBox, but it doesn't hurt much to declare it
@@ -159,7 +161,7 @@ protected:
     // Tool tip support
     CToolTipCtrl m_toolMsgTip;      // Tooltip for notifications
     CToolTipCtrl m_toolTip;         // Tooltip of tile text popups
-    int     m_nCurItemCode;         // current active tip item code
+    GameElement m_nCurItemCode;         // current active tip item code
 
     // Drag and scroll support vars
     static DragInfo di;

--- a/GShr/LBoxMark.cpp
+++ b/GShr/LBoxMark.cpp
@@ -77,12 +77,12 @@ BOOL CMarkListBox::OnIsToolTipsEnabled()
 #endif
 }
 
-int  CMarkListBox::OnGetHitItemCodeAtPoint(CPoint point, CRect& rct)
+GameElement CMarkListBox::OnGetHitItemCodeAtPoint(CPoint point, CRect& rct)
 {
     BOOL bOutsideClient;
     UINT nIndex = ItemFromPoint(point, bOutsideClient);
     if (nIndex >= 65535 || GetCount() <= 0)
-        return -1;
+        return Invalid_v<GameElement>;
 
     CMarkManager* pMMgr = m_pDoc->GetMarkManager();
 
@@ -92,10 +92,10 @@ int  CMarkListBox::OnGetHitItemCodeAtPoint(CPoint point, CRect& rct)
 
     GetTileRectsForItem(value_preserving_cast<int>(nIndex), tid, nullTid, rct, rct);
 
-    return rct.PtInRect(point) ? value_preserving_cast<int>(static_cast<MarkID::UNDERLYING_TYPE>(mid)) : -1;
+    return rct.PtInRect(point) ? GameElement(mid) : Invalid_v<GameElement>;
 }
 
-void CMarkListBox::OnGetTipTextForItemCode(int nItemCode,
+void CMarkListBox::OnGetTipTextForItemCode(GameElement nItemCode,
     CString& strTip, CString& strTitle)
 {
     MarkID mid = static_cast<MarkID>(nItemCode);

--- a/GShr/LBoxMark.h
+++ b/GShr/LBoxMark.h
@@ -82,8 +82,8 @@ protected:
 
     // Tool tip processing
     virtual BOOL OnIsToolTipsEnabled() override;
-    virtual int  OnGetHitItemCodeAtPoint(CPoint point, CRect& rct) override;
-    virtual void OnGetTipTextForItemCode(int nItemCode, CString& strTip, CString& strTitle) override;
+    virtual GameElement OnGetHitItemCodeAtPoint(CPoint point, CRect& rct) override;
+    virtual void OnGetTipTextForItemCode(GameElement nItemCode, CString& strTip, CString& strTitle) override;
     virtual BOOL OnDoesItemHaveTipText(size_t nItem) override;
 
     //{{AFX_MSG(CMarkListBox)

--- a/GShr/LBoxPiec.h
+++ b/GShr/LBoxPiec.h
@@ -68,8 +68,8 @@ protected:
 
     // Tool tip processing
     virtual BOOL OnIsToolTipsEnabled() override;
-    virtual int  OnGetHitItemCodeAtPoint(CPoint point, CRect& rct) override;
-    virtual void OnGetTipTextForItemCode(int nItemCode, CString& strTip, CString& strTitle) override;
+    virtual GameElement OnGetHitItemCodeAtPoint(CPoint point, CRect& rct) override;
+    virtual void OnGetTipTextForItemCode(GameElement nItemCode, CString& strTip, CString& strTitle) override;
     virtual BOOL OnDoesItemHaveTipText(size_t nItem) override;
 
     //{{AFX_MSG(CPieceListBox)

--- a/GShr/MapStrng.h
+++ b/GShr/MapStrng.h
@@ -127,12 +127,28 @@ public:
                 *this != GameElement(Invalid_t());
     }
 
+    explicit operator MarkID() const
+    {
+        if (!IsAMarker()) {
+            CbThrowBadCastException();
+        }
+        return u.markerElement.mid;
+    }
+
     explicit operator PieceID() const
     {
         if (!IsAPiece()) {
             CbThrowBadCastException();
         }
         return u.pieceElement.pid;
+    }
+
+    int GetSide() const
+    {
+        if (!IsAPiece()) {
+            CbThrowBadCastException();
+        }
+        return u.pieceElement.nSide;
     }
 
 #if defined(GPLAY)


### PR DESCRIPTION
The `CGrafixListBox* *ItemCode*` functions store their item descriptions in an `int`.  However, I think `GameElement` already provides storage for everything `ItemCode` needs to store, and adding very simple accessors to `GameElement` allows `ItemCode` users to extract the data they need.

Since `GameElement` will need to be adjusted to handle 32bit IDs anyway, refactoring the code this way will save having to also add 32bit ID handling to the `ItemCode` functions.

Am I overlooking some reason the `ItemCode` functions shouldn't use `GameElement`?