### PR TITLE
expand TileID/MarkID/PieceID to 32bits

### DIFF
--- a/GM/GmDoc.cpp
+++ b/GM/GmDoc.cpp
@@ -168,8 +168,13 @@ void CGamDoc::OnIdle(BOOL bActive)
 
 void CGamDoc::UpdateAllViews(CView* pSender, LPARAM lHint, CObject* pHint)
 {
-    if (lHint & HINT_TILEGROUP || lHint & HINT_TILESETDELETED ||
-        lHint & HINT_TILESETPROPCHANGE || lHint == HINT_ALWAYSUPDATE)
+    WORD wHint = LOWORD(lHint);
+    if (
+        ((wHint & HINT_TILEGROUP) && !(wHint & ~HINT_TILEGROUP)) ||
+        wHint == HINT_TILESETDELETED ||
+        wHint == HINT_TILESETPROPCHANGE ||
+        wHint == HINT_ALWAYSUPDATE
+        )
         m_palTile.UpdatePaletteContents();
     CDocument::UpdateAllViews(pSender, lHint, pHint);
 }

--- a/GM/GmDoc.h
+++ b/GM/GmDoc.h
@@ -62,9 +62,9 @@ enum CGamDocHint
 {
     HINT_ALWAYSUPDATE =     0,      // Must be zero!
 
-    HINT_TILECREATED =      1,      // HIWORD = TileID
-    HINT_TILEMODIFIED =     2,      // HIWORD = TileID
-    HINT_TILEDELETED =      3,      // HIWORD = TileID
+    HINT_TILECREATED =      1,      // pHint->m_tid
+    HINT_TILEMODIFIED =     2,      // pHint->m_tid
+    HINT_TILEDELETED =      3,      // pHint->m_tid
     HINT_TILEGROUP =        0x0F,   // Mask for all tile hints
 
     HINT_BOARDDELETED =     0x10,   // pHint->m_pBoard;
@@ -100,6 +100,24 @@ public:
     };
 
     template<>
+    struct Args<HINT_TILECREATED>
+    {
+        TileID m_tid;
+    };
+
+    template<>
+    struct Args<HINT_TILEMODIFIED>
+    {
+        TileID m_tid;
+    };
+
+    template<>
+    struct Args<HINT_TILEDELETED>
+    {
+        TileID m_tid;
+    };
+
+    template<>
     struct Args<HINT_BOARDDELETED>
     {
         CBoard*     m_pBoard;
@@ -132,6 +150,9 @@ public:
 private:
     CGamDocHint hint;
     union {
+        Args<HINT_TILECREATED> m_tileCreated;
+        Args<HINT_TILEMODIFIED> m_tileModified;
+        Args<HINT_TILEDELETED> m_tileDeleted;
         Args<HINT_BOARDDELETED> m_boardDeleted;
         Args<HINT_TILESETDELETED> m_tileSetDeleted;
         Args<HINT_PIECESETDELETED> m_pieceSetDeleted;

--- a/GM/PalTile.cpp
+++ b/GM/PalTile.cpp
@@ -242,8 +242,7 @@ void CTilePalette::PostNcDestroy()
 
 void CTilePalette::OnTileNameCbnSelchange()
 {
-    if (!m_comboTGrp.GetDroppedState())
-        UpdateTileList();
+    UpdateTileList();
 }
 
 BOOL CTilePalette::OnHelpInfo(HELPINFO* pHelpInfo)

--- a/GM/VwEdtbrd.cpp
+++ b/GM/VwEdtbrd.cpp
@@ -180,8 +180,7 @@ void CBrdEditView::OnInitialUpdate()
 void CBrdEditView::OnUpdate(CView* pSender, LPARAM lHint, CObject* pHint)
 {
     WORD wHint = LOWORD(lHint);
-    TileID tid = static_cast<TileID>(HIWORD(lHint));
-    if ((wHint == HINT_TILEMODIFIED && m_pBoard->IsTileInUse(tid)) ||
+    if ((wHint == HINT_TILEMODIFIED && m_pBoard->IsTileInUse(static_cast<CGmBoxHint*>(pHint)->GetArgs<HINT_TILEMODIFIED>().m_tid)) ||
         wHint == HINT_TILEDELETED || wHint == HINT_TILESETDELETED)
     {
         Invalidate(FALSE);          // Do redraw

--- a/GM/VwPrjgb1.cpp
+++ b/GM/VwPrjgb1.cpp
@@ -304,8 +304,9 @@ void CGbxProjView::DoTileNew()
             CSize(dlg.m_nWidth, dlg.m_nHeight),
             CSize(dlg.m_nHalfWidth, dlg.m_nHalfHeight),
             RGB(255, 255, 255));
-        static_assert(sizeof(TileID::UNDERLYING_TYPE) <= sizeof(WORD), "makelparam can't hold full arg");
-        pDoc->UpdateAllViews(NULL, MAKELPARAM(uint16_t(HINT_TILECREATED), static_cast<TileID::UNDERLYING_TYPE>(tidNew)), NULL);
+        CGmBoxHint hint;
+        hint.GetArgs<HINT_TILECREATED>().m_tid = tidNew;
+        pDoc->UpdateAllViews(NULL, HINT_TILECREATED, &hint);
         pDoc->CreateNewFrame(GetApp()->m_pTileEditTmpl, "Tile Editor",
             reinterpret_cast<LPVOID>(value_preserving_cast<uintptr_t>(tidNew)));
         pDoc->SetModifiedFlag();
@@ -385,8 +386,9 @@ void CGbxProjView::DoTileClone()
         pTMgr->GetTile(tidNew, &tileHalf, halfScale);
         tileHalf.Update(&bmap);
 
-        static_assert(sizeof(TileID::UNDERLYING_TYPE) <= sizeof(WORD), "makelparam can't hold full arg");
-        pDoc->UpdateAllViews(NULL, MAKELPARAM(uint16_t(HINT_TILECREATED), static_cast<TileID::UNDERLYING_TYPE>(tidNew)), NULL);
+        CGmBoxHint hint;
+        hint.GetArgs<HINT_TILECREATED>().m_tid = tidNew;
+        pDoc->UpdateAllViews(NULL, HINT_TILECREATED, &hint);
 
         pDoc->CreateNewFrame(GetApp()->m_pTileEditTmpl, "Tile Editor",
             reinterpret_cast<LPVOID>(value_preserving_cast<uintptr_t>(tidNew)));
@@ -418,8 +420,9 @@ void CGbxProjView::DoTileDelete()
     for (size_t i = 0; i < tidtbl.size(); i++)
     {
         pTMgr->DeleteTile(tidtbl[i]);
-        static_assert(sizeof(TileID::UNDERLYING_TYPE) <= sizeof(WORD), "makelparam can't hold full arg");
-        pDoc->UpdateAllViews(NULL, MAKELPARAM(uint16_t(HINT_TILEDELETED), static_cast<TileID::UNDERLYING_TYPE>(tidtbl[i])), NULL);
+        CGmBoxHint hint;
+        hint.GetArgs<HINT_TILEDELETED>().m_tid = tidtbl[i];
+        pDoc->UpdateAllViews(NULL, HINT_TILEDELETED, &hint);
     }
     pDoc->NotifyTileDatabaseChange();
     pDoc->SetModifiedFlag();

--- a/GM/VwPrjgb1.cpp
+++ b/GM/VwPrjgb1.cpp
@@ -305,7 +305,7 @@ void CGbxProjView::DoTileNew()
             CSize(dlg.m_nHalfWidth, dlg.m_nHalfHeight),
             RGB(255, 255, 255));
         static_assert(sizeof(TileID::UNDERLYING_TYPE) <= sizeof(WORD), "makelparam can't hold full arg");
-        pDoc->UpdateAllViews(NULL, MAKELPARAM(HINT_TILECREATED, static_cast<TileID::UNDERLYING_TYPE>(tidNew)), NULL);
+        pDoc->UpdateAllViews(NULL, MAKELPARAM(uint16_t(HINT_TILECREATED), static_cast<TileID::UNDERLYING_TYPE>(tidNew)), NULL);
         pDoc->CreateNewFrame(GetApp()->m_pTileEditTmpl, "Tile Editor",
             reinterpret_cast<LPVOID>(value_preserving_cast<uintptr_t>(tidNew)));
         pDoc->SetModifiedFlag();
@@ -386,7 +386,7 @@ void CGbxProjView::DoTileClone()
         tileHalf.Update(&bmap);
 
         static_assert(sizeof(TileID::UNDERLYING_TYPE) <= sizeof(WORD), "makelparam can't hold full arg");
-        pDoc->UpdateAllViews(NULL, MAKELPARAM(HINT_TILECREATED, static_cast<TileID::UNDERLYING_TYPE>(tidNew)), NULL);
+        pDoc->UpdateAllViews(NULL, MAKELPARAM(uint16_t(HINT_TILECREATED), static_cast<TileID::UNDERLYING_TYPE>(tidNew)), NULL);
 
         pDoc->CreateNewFrame(GetApp()->m_pTileEditTmpl, "Tile Editor",
             reinterpret_cast<LPVOID>(value_preserving_cast<uintptr_t>(tidNew)));
@@ -419,7 +419,7 @@ void CGbxProjView::DoTileDelete()
     {
         pTMgr->DeleteTile(tidtbl[i]);
         static_assert(sizeof(TileID::UNDERLYING_TYPE) <= sizeof(WORD), "makelparam can't hold full arg");
-        pDoc->UpdateAllViews(NULL, MAKELPARAM(HINT_TILEDELETED, static_cast<TileID::UNDERLYING_TYPE>(tidtbl[i])), NULL);
+        pDoc->UpdateAllViews(NULL, MAKELPARAM(uint16_t(HINT_TILEDELETED), static_cast<TileID::UNDERLYING_TYPE>(tidtbl[i])), NULL);
     }
     pDoc->NotifyTileDatabaseChange();
     pDoc->SetModifiedFlag();

--- a/GM/VwPrjgbx.cpp
+++ b/GM/VwPrjgbx.cpp
@@ -874,9 +874,12 @@ void CGbxProjView::OnEditPaste()
         }
         DoUpdateTileList();
         pDoc->NotifyTileDatabaseChange();
-        static_assert(sizeof(TileID::UNDERLYING_TYPE) <= sizeof(WORD), "makelparam can't hold full arg");
         for (size_t i = size_t(0); i < tidtbl.size(); i++)
-            pDoc->UpdateAllViews(NULL, MAKELPARAM(uint16_t(HINT_TILECREATED), static_cast<TileID::UNDERLYING_TYPE>(tidtbl[i])), NULL);
+        {
+            CGmBoxHint hint;
+            hint.GetArgs<HINT_TILECREATED>().m_tid = tidtbl[i];
+            pDoc->UpdateAllViews(NULL, HINT_TILECREATED, &hint);
+        }
         m_listTiles.SetCurSelsMapped(tidtbl);
         m_listTiles.ShowFirstSelection();
     }
@@ -1110,9 +1113,12 @@ void CGbxProjView::OnProjectLoadTileFile()
 
         DoUpdateTileList();
         pDoc->NotifyTileDatabaseChange();
-        static_assert(sizeof(TileID::UNDERLYING_TYPE) <= sizeof(WORD), "makelparam can't hold full arg");
         for (size_t i = size_t(0); i < tidtbl.size(); i++)
-            pDoc->UpdateAllViews(NULL, MAKELPARAM(uint16_t(HINT_TILECREATED), static_cast<TileID::UNDERLYING_TYPE>(tidtbl[i])), NULL);
+        {
+            CGmBoxHint hint;
+            hint.GetArgs<HINT_TILECREATED>().m_tid = tidtbl[i];
+            pDoc->UpdateAllViews(NULL, HINT_TILECREATED, &hint);
+        }
         m_listTiles.SetCurSelsMapped(tidtbl);
         m_listTiles.ShowFirstSelection();
         EndWaitCursor();

--- a/GM/VwPrjgbx.cpp
+++ b/GM/VwPrjgbx.cpp
@@ -876,7 +876,7 @@ void CGbxProjView::OnEditPaste()
         pDoc->NotifyTileDatabaseChange();
         static_assert(sizeof(TileID::UNDERLYING_TYPE) <= sizeof(WORD), "makelparam can't hold full arg");
         for (size_t i = size_t(0); i < tidtbl.size(); i++)
-            pDoc->UpdateAllViews(NULL, MAKELPARAM(HINT_TILECREATED, static_cast<TileID::UNDERLYING_TYPE>(tidtbl[i])), NULL);
+            pDoc->UpdateAllViews(NULL, MAKELPARAM(uint16_t(HINT_TILECREATED), static_cast<TileID::UNDERLYING_TYPE>(tidtbl[i])), NULL);
         m_listTiles.SetCurSelsMapped(tidtbl);
         m_listTiles.ShowFirstSelection();
     }
@@ -1112,7 +1112,7 @@ void CGbxProjView::OnProjectLoadTileFile()
         pDoc->NotifyTileDatabaseChange();
         static_assert(sizeof(TileID::UNDERLYING_TYPE) <= sizeof(WORD), "makelparam can't hold full arg");
         for (size_t i = size_t(0); i < tidtbl.size(); i++)
-            pDoc->UpdateAllViews(NULL, MAKELPARAM(HINT_TILECREATED, static_cast<TileID::UNDERLYING_TYPE>(tidtbl[i])), NULL);
+            pDoc->UpdateAllViews(NULL, MAKELPARAM(uint16_t(HINT_TILECREATED), static_cast<TileID::UNDERLYING_TYPE>(tidtbl[i])), NULL);
         m_listTiles.SetCurSelsMapped(tidtbl);
         m_listTiles.ShowFirstSelection();
         EndWaitCursor();

--- a/GM/VwTilesl.cpp
+++ b/GM/VwTilesl.cpp
@@ -159,7 +159,7 @@ void CTileSelView::OnUpdate(CView* pSender, LPARAM lHint, CObject* pHint)
 
     if (wHint == HINT_TILEDELETED)
     {
-        if (static_cast<TileID>(HIWORD(lHint)) == m_tid)
+        if (static_cast<CGmBoxHint*>(pHint)->GetArgs<HINT_TILEDELETED>().m_tid == m_tid)
         {
             m_bNoUpdate = TRUE;
             CFrameWnd* pFrm = GetParentFrame();
@@ -296,9 +296,9 @@ void CTileSelView::UpdateDocumentTiles()
     m_pTileMgr->UpdateTile(m_tid, &m_bmFull, &m_bmHalf, crSmall);
 
     // Finally handle various notifications
-    static_assert(sizeof(TileID::UNDERLYING_TYPE) <= sizeof(WORD), "makelparam can't hold full arg");
-    pDoc->UpdateAllViews(this,
-        MAKELPARAM(uint16_t(HINT_TILEMODIFIED), static_cast<TileID::UNDERLYING_TYPE>(m_tid)), NULL);
+    CGmBoxHint hint;
+    hint.GetArgs<HINT_TILEMODIFIED>().m_tid = m_tid;
+    pDoc->UpdateAllViews(this, HINT_TILEMODIFIED, &hint);
     pDoc->SetModifiedFlag();
 }
 

--- a/GM/VwTilesl.cpp
+++ b/GM/VwTilesl.cpp
@@ -298,7 +298,7 @@ void CTileSelView::UpdateDocumentTiles()
     // Finally handle various notifications
     static_assert(sizeof(TileID::UNDERLYING_TYPE) <= sizeof(WORD), "makelparam can't hold full arg");
     pDoc->UpdateAllViews(this,
-        MAKELPARAM(HINT_TILEMODIFIED, static_cast<TileID::UNDERLYING_TYPE>(m_tid)), NULL);
+        MAKELPARAM(uint16_t(HINT_TILEMODIFIED), static_cast<TileID::UNDERLYING_TYPE>(m_tid)), NULL);
     pDoc->SetModifiedFlag();
 }
 

--- a/GP/DlgSmsg.cpp
+++ b/GP/DlgSmsg.cpp
@@ -246,7 +246,7 @@ BOOL CSendMsgDialog::OnInitDialog()
 
     if (m_bShowDieRoller)
     {
-        PostMessage(WM_COMMAND, MAKEWPARAM(IDC_D_SMSG_ROLLDICE, BN_CLICKED),
+        PostMessage(WM_COMMAND, MAKEWPARAM(uint16_t(IDC_D_SMSG_ROLLDICE), uint16_t(BN_CLICKED)),
             (LPARAM)::GetDlgItem(m_hWnd, IDC_D_SMSG_ROLLDICE));
     }
 

--- a/GP/GamDoc.cpp
+++ b/GP/GamDoc.cpp
@@ -1280,7 +1280,7 @@ void CGamDoc::OnPbckNext()
                 if (m_nCurMove != Invalid_v<size_t> ||
                     (m_bStepToNextHist && IsPlayingHistory() && !IsPlayingLastHistory()))
                 {
-                    GetMainFrame()->PostMessage(WM_COMMAND, MAKEWPARAM(ID_PBCK_NEXT, 0));
+                    GetMainFrame()->PostMessage(WM_COMMAND, MAKEWPARAM(uint16_t(ID_PBCK_NEXT), uint16_t(0)));
                 }
                 else
                     m_bAutoPlayback = FALSE;    // Make sure FALSE in case auto step turned off
@@ -1293,7 +1293,7 @@ void CGamDoc::OnPbckNext()
             // Force switch to next history record.
             OnPbckNextHistory();
             // Queue up the next move command
-            GetMainFrame()->PostMessage(WM_COMMAND, MAKEWPARAM(ID_PBCK_NEXT, 0));
+            GetMainFrame()->PostMessage(WM_COMMAND, MAKEWPARAM(uint16_t(ID_PBCK_NEXT), uint16_t(0)));
         }
 
         m_nMoveInterlock--;

--- a/GP/GamDoc5.cpp
+++ b/GP/GamDoc5.cpp
@@ -443,7 +443,7 @@ void CGamDoc::MsgDialogCancel(BOOL bDiscardHistory /* = FALSE */)
 void CGamDoc::MsgDialogForceDefer()
 {
     if (m_pMsgDialog != NULL)
-        m_pMsgDialog->SendMessage(WM_COMMAND, MAKEWPARAM(IDC_D_SMSG_CLOSE, BN_CLICKED));
+        m_pMsgDialog->SendMessage(WM_COMMAND, MAKEWPARAM(uint16_t(IDC_D_SMSG_CLOSE), uint16_t(BN_CLICKED)));
 }
 
 ////////////////////////////////////////////////////////////////////////////

--- a/GP/Gp.cpp
+++ b/GP/Gp.cpp
@@ -304,7 +304,7 @@ int CGpApp::ExitInstance()
 BOOL CGpApp::PreTranslateMessage(MSG *pMsg)
 {
     if (pMsg->message == WM_CHAR && pMsg->wParam == ' ')
-        m_pMainWnd->PostMessage(WM_COMMAND, MAKEWPARAM(ID_PBCK_NEXT, 0));
+        m_pMainWnd->PostMessage(WM_COMMAND, MAKEWPARAM(uint16_t(ID_PBCK_NEXT), uint16_t(0)));
     return CWinAppEx::PreTranslateMessage(pMsg);
 }
 

--- a/GP/LBoxTray.cpp
+++ b/GP/LBoxTray.cpp
@@ -104,7 +104,7 @@ GameElement CTrayListBox::OnGetHitItemCodeAtPoint(CPoint point, CRect& rct)
     ASSERT(pPTbl != NULL);
 
     PieceID nPid = MapIndexToItem(nIndex);
-    int side = 0;
+    unsigned side = 0u;
 
     TileID tidLeft = pPTbl->GetActiveTileID(nPid);
     ASSERT(tidLeft != nullTid);            // Should exist
@@ -123,7 +123,7 @@ GameElement CTrayListBox::OnGetHitItemCodeAtPoint(CPoint point, CRect& rct)
     else if (!rctRight.IsRectEmpty() && rctRight.PtInRect(point))
     {
         rct = rctRight;
-        side = 1;
+        side = 1u;
     }
     else
         return Invalid_v<GameElement>;

--- a/GP/MoveMgr.cpp
+++ b/GP/MoveMgr.cpp
@@ -982,8 +982,8 @@ void CMovePlotList::SavePlotList(CDrawList* pDwg)
         if (pObj.GetType() == CDrawObj::drawLine)
         {
             CLine& pLObj = static_cast<CLine&>(pObj);
-            m_tblPlot.Add((DWORD)MAKELONG(pLObj.m_ptBeg.x, pLObj.m_ptBeg.y));
-            m_tblPlot.Add((DWORD)MAKELONG(pLObj.m_ptEnd.x, pLObj.m_ptEnd.y));
+            m_tblPlot.Add((DWORD)MAKELONG(static_cast<int16_t>(pLObj.m_ptBeg.x), static_cast<int16_t>(pLObj.m_ptBeg.y)));
+            m_tblPlot.Add((DWORD)MAKELONG(static_cast<int16_t>(pLObj.m_ptEnd.x), static_cast<int16_t>(pLObj.m_ptEnd.y)));
         }
     }
 }

--- a/GP/PBoard.cpp
+++ b/GP/PBoard.cpp
@@ -527,7 +527,7 @@ BoardID CPBoardManager::IssueGeoSerialNumber()
         AfxThrowMemoryException();
     }
     BoardID retval = m_nNextGeoSerialNum;
-    m_nNextGeoSerialNum = static_cast<BoardID>(static_cast<BoardID::UNDERLYING_TYPE>(m_nNextGeoSerialNum) + 1);
+    m_nNextGeoSerialNum = static_cast<BoardID>(static_cast<BoardID::UNDERLYING_TYPE>(m_nNextGeoSerialNum) + BoardID::UNDERLYING_TYPE(1));
     return retval;
 }
 

--- a/GP/PBoard.cpp
+++ b/GP/PBoard.cpp
@@ -521,7 +521,8 @@ CPBoardManager::CPBoardManager()
 
 BoardID CPBoardManager::IssueGeoSerialNumber()
 {
-    if (static_cast<BoardID::UNDERLYING_TYPE>(m_nNextGeoSerialNum) > maxBoards)
+    size_t maxBoards = std::min(max_size(), value_preserving_cast<size_t>(std::numeric_limits<BoardID::UNDERLYING_TYPE>::max()));
+    if (static_cast<BoardID::UNDERLYING_TYPE>(m_nNextGeoSerialNum) >= maxBoards)
     {
         AfxThrowMemoryException();
     }

--- a/GP/PPieces.cpp
+++ b/GP/PPieces.cpp
@@ -159,8 +159,8 @@ void CPieceTable::CreatePlayingPieceTable()
     ASSERT(m_pPMgr != NULL);
     Clear();
     size_t nPieces = m_pPMgr->GetPieceTableSize();
-    ASSERT(nPieces < maxPieces);
-    if (nPieces == 0)
+    ASSERT(nPieces < decltype(m_pPieceTbl)::maxSize);
+    if (nPieces == size_t(0))
         return;
     m_pPieceTbl.ResizeTable(nPieces, &Piece::SetUnused);
 }

--- a/GP/PPieces.h
+++ b/GP/PPieces.h
@@ -160,7 +160,7 @@ public:
 // Implementation
 protected:
     XxxxIDTable<PieceID, Piece,
-                maxPieces, pieceTblBaseSize, pieceTblIncrSize,
+                pieceTblBaseSize, pieceTblIncrSize,
                 true> m_pPieceTbl;
 
     WORD        m_wReserved1;       // For future need (set to 0)

--- a/GP/PalMark.cpp
+++ b/GP/PalMark.cpp
@@ -382,8 +382,7 @@ void CMarkerPalette::OnWindowPosChanging(WINDOWPOS FAR* lpwndpos)
 
 void CMarkerPalette::OnMarkerNameCbnSelchange()
 {
-    if (!m_comboMGrp.GetDroppedState())
-        UpdateMarkerList();
+    UpdateMarkerList();
 }
 
 BOOL CMarkerPalette::OnHelpInfo(HELPINFO* pHelpInfo)

--- a/GP/SelOPlay.cpp
+++ b/GP/SelOPlay.cpp
@@ -151,7 +151,7 @@ void CSelection::Open()
     if (m_pObj->GetType() == CDrawObj::drawMarkObj ||
         m_pObj->GetType() == CDrawObj::drawPieceObj)
     {
-        m_pView->SendMessage(WM_COMMAND, MAKEWPARAM(ID_EDIT_ELEMENT_TEXT, 0));
+        m_pView->SendMessage(WM_COMMAND, MAKEWPARAM(uint16_t(ID_EDIT_ELEMENT_TEXT), uint16_t(0)));
     }
 }
 

--- a/GP/VwPbrd1.cpp
+++ b/GP/VwPbrd1.cpp
@@ -193,7 +193,7 @@ void CPlayBoardView::SetNotificationTip(CPoint pointClient, LPCTSTR pszTip)
     m_toolMsgTip.Activate(TRUE);
     m_toolMsgTip.SendMessage(TTM_TRACKACTIVATE, (WPARAM)TRUE, (LPARAM)&ti);
     m_toolMsgTip.SendMessage(TTM_TRACKPOSITION, 0,
-        (LPARAM)MAKELONG(pointScreen.x, pointScreen.y));
+        (LPARAM)MAKELONG(static_cast<int16_t>(pointScreen.x), static_cast<int16_t>(pointScreen.y)));
 
     SetTimer(ID_TIP_MSG_TIMER, MAX_TIP_MSG_TIME, NotificationTipTimeoutHandler);
 }

--- a/GP/WStateGp.cpp
+++ b/GP/WStateGp.cpp
@@ -47,7 +47,7 @@ CWnd* CGpWinStateMgr::OnGetFrameForWinStateElement(const CWinStateElement& pWse)
     else if (pWse.m_wUserCode1 == gpFrmPlayBoard)
     {
         // The second user code is the board's serial number.
-        CPlayBoard& pPBoard = CheckedDeref(pDoc->GetPBoardManager()->GetPBoardBySerial(static_cast<BoardID>(pWse.m_wUserCode2)));
+        CPlayBoard& pPBoard = CheckedDeref(pDoc->GetPBoardManager()->GetPBoardBySerial(pWse.m_boardID));
         CView* pView = pDoc->FindPBoardView(pPBoard);
         if (pView == NULL)
         {
@@ -71,7 +71,7 @@ void CGpWinStateMgr::OnAnnotateWinStateElement(CWinStateElement& pWse, CWnd *pWn
     {
         CPlayBoardFrame* pFrame = (CPlayBoardFrame*)pWnd;
         pWse.m_wUserCode1 = gpFrmPlayBoard;
-        pWse.m_wUserCode2 = static_cast<BoardID::UNDERLYING_TYPE>(pFrame->m_pPBoard->GetSerialNumber());
+        pWse.m_boardID = pFrame->m_pPBoard->GetSerialNumber();
     }
 }
 

--- a/GShr/Board.h
+++ b/GShr/Board.h
@@ -40,8 +40,20 @@
 typedef XxxxID16<'B'> BoardID16;
 typedef XxxxID32<'B'> BoardID32;
 typedef XxxxID<'B'> BoardID;
-const       BoardID nullBid = BoardID(0xFFFF);
-const size_t maxBoards = 32000;
+
+template<>
+struct Invalid<BoardID16>
+{
+    static constexpr BoardID16 value = BoardID16(0xFFFF);
+};
+
+template<>
+struct Invalid<BoardID32>
+{
+    static constexpr BoardID32 value = BoardID32(0xFFFFFFFF);
+};
+
+constexpr BoardID nullBid = Invalid_v<BoardID>;
 // The starting serial number for geomorpically created boards.
 const size_t GEO_BOARD_SERNUM_BASE = 1000;
 

--- a/GShr/CyberBoard.h
+++ b/GShr/CyberBoard.h
@@ -669,7 +669,7 @@ template<char PREFIX>
 using XxxxID32 = XxxxIDExt<PREFIX, uint32_t>;
 
 template<char PREFIX>
-using XxxxID = XxxxID16<PREFIX>;
+using XxxxID = XxxxID32<PREFIX>;
 
 // KLUDGE:  use OwnerPtr since CWordArray doesn't have move operators
 template<char PREFIX, typename UNDERLYING_TYPE>

--- a/GShr/CyberBoard.h
+++ b/GShr/CyberBoard.h
@@ -802,7 +802,7 @@ public:
     size_t GetSize() const { return m_nTblSize; }
     bool Valid(KEY tid) const { return static_cast<KEY::UNDERLYING_TYPE>(tid) < m_nTblSize; }
 
-    const ELEMENT& operator[](KEY tid) const { return m_pTbl[static_cast<KEY::UNDERLYING_TYPE>(tid)]; }
+    const ELEMENT& operator[](KEY tid) const { return m_pTbl[value_preserving_cast<ptrdiff_t>(static_cast<KEY::UNDERLYING_TYPE>(tid))]; }
     ELEMENT& operator[](KEY tid) { return const_cast<ELEMENT&>(std::as_const(*this)[tid]); }
 
     void Clear()

--- a/GShr/DrawObj.cpp
+++ b/GShr/DrawObj.cpp
@@ -346,9 +346,10 @@ void ObjectID32::Serialize(CArchive& ar)
             break;
         case 4: {
             ASSERT(!"probably should never be used");
+            SerializeBackdoor sb;
             ObjectID64 temp;
             ar >> temp;
-            *this = static_cast<ObjectID32>(temp);
+            *this = SerializeBackdoorObjectID::Convert(temp);
             break;
         }
         default:
@@ -373,13 +374,14 @@ ObjectID32::operator ObjectID64() const
     switch (u.tag.subtype)
     {
         case stPieceObj:
-            return ObjectID64(static_cast<PieceID32>(u.pieceObj.pid));
+            return ObjectID64(SerializeBackdoor::Convert(u.pieceObj.pid));
         case stInvalid:
             return ObjectID64();
         case stMarkObj:
             return ObjectID64(u.markObj.id, u.markObj.serial, CDrawObj::drawMarkObj);
         case stLineObj:
             ASSERT(!"future feature");
+            // fall through
         default:
             CbThrowBadCastException();
     }
@@ -427,9 +429,10 @@ void ObjectID64::Serialize(CArchive& ar)
     switch (GetXxxxIDSerializeSize<PieceID>(ar))
     {
         case 2: {
+            SerializeBackdoor sb;
             ObjectID32 temp;
             ar >> temp;
-            *this = static_cast<ObjectID64>(temp);
+            *this = SerializeBackdoorObjectID::Convert(temp);
             break;
         }
         case 4:
@@ -457,7 +460,7 @@ ObjectID64::operator ObjectID32() const
     switch (u.tag.subtype)
     {
         case stPieceObj:
-            return ObjectID32(static_cast<PieceID16>(u.pieceObj.pid));
+            return ObjectID32(SerializeBackdoor::Convert(u.pieceObj.pid));
         case stInvalid:
             return ObjectID32();
         case stMarkObj:
@@ -468,6 +471,26 @@ ObjectID64::operator ObjectID32() const
         default:
             CbThrowBadCastException();
     }
+}
+
+ObjectID64 SerializeBackdoorObjectID::Convert(const ObjectID32& oid)
+{
+    if (!Depth())
+    {
+        ASSERT(!"only for serialize use");
+        AfxThrowNotSupportedException();
+    }
+    return static_cast<ObjectID64>(oid);
+}
+
+ObjectID32 SerializeBackdoorObjectID::Convert(const ObjectID64& oid)
+{
+    if (!Depth())
+    {
+        ASSERT(!"only for serialize use");
+        AfxThrowNotSupportedException();
+    }
+    return static_cast<ObjectID32>(oid);
 }
 #endif
 

--- a/GShr/DrawObj.h
+++ b/GShr/DrawObj.h
@@ -323,9 +323,11 @@ private:
     } u;
 
     // Serialize conversion helpers
+    /* use ObjectID32::operator ObjectID64() const instead of
+        ObjectID64::ObjectID64(const ObjectID32&) to preserve
+        privacy of ObjectID32's content */
     explicit operator ObjectID64() const;
-    // KLUDGE:  can't friend members of an incomplete class
-    friend ObjectID64;
+    friend class SerializeBackdoorObjectID;
 };
 
 inline CArchive& operator<<(CArchive& ar, const ObjectID32& oid)
@@ -470,7 +472,7 @@ private:
 
     // Serialize conversion helpers
     explicit operator ObjectID32() const;
-    friend void ObjectID32::Serialize(CArchive& ar);
+    friend class SerializeBackdoorObjectID;
 };
 
 inline CArchive& operator<<(CArchive& ar, const ObjectID64& oid)
@@ -484,6 +486,14 @@ inline CArchive& operator>>(CArchive& ar, ObjectID64& oid)
     oid.Serialize(ar);
     return ar;
 }
+
+class SerializeBackdoorObjectID : public SerializeBackdoor
+{
+public:
+    using SerializeBackdoor::Convert;
+    static ObjectID64 Convert(const ObjectID32& oid);
+    static ObjectID32 Convert(const ObjectID64& oid);
+};
 #endif
 
 ///////////////////////////////////////////////////////////////////////

--- a/GShr/LBoxGfx2.cpp
+++ b/GShr/LBoxGfx2.cpp
@@ -233,9 +233,9 @@ void CGrafixListBox2::SetSelFromPoint(CPoint point)
     // Short circuit drag processing
     m_bAllowDrag = FALSE;
     SendMessage(WM_LBUTTONDOWN, (WPARAM)MK_LBUTTON,
-        MAKELPARAM(point.x, point.y));
+        MAKELPARAM(static_cast<int16_t>(point.x), static_cast<int16_t>(point.y)));
     SendMessage(WM_LBUTTONUP, (WPARAM)MK_LBUTTON,
-        MAKELPARAM(point.x, point.y));
+        MAKELPARAM(static_cast<int16_t>(point.x), static_cast<int16_t>(point.y)));
     m_bAllowDrag = TRUE;
 }
 

--- a/GShr/LBoxGrfx.cpp
+++ b/GShr/LBoxGrfx.cpp
@@ -109,7 +109,7 @@ void CGrafixListBox::SetNotificationTip(int nItem, LPCTSTR pszTip)
     m_toolMsgTip.Activate(TRUE);
     m_toolMsgTip.SendMessage(TTM_TRACKACTIVATE, (WPARAM)TRUE, (LPARAM)&ti);
     m_toolMsgTip.SendMessage(TTM_TRACKPOSITION, 0,
-        (LPARAM)MAKELONG(pntScreen.x, pntScreen.y));
+        (LPARAM)MAKELONG(static_cast<int16_t>(pntScreen.x), static_cast<int16_t>(pntScreen.y)));
 
     SetTimer(ID_TIP_LISTITEM_MSG_TIMER, MAX_TIP_LISTITEM_MSG_TIME,
         NotificationTipTimeoutHandler);
@@ -185,9 +185,9 @@ void CGrafixListBox::SetSelFromPoint(CPoint point)
     // Short circuit drag processing
     m_bAllowDrag = FALSE;
     SendMessage(WM_LBUTTONDOWN, (WPARAM)MK_LBUTTON,
-        MAKELPARAM(point.x, point.y));
+        MAKELPARAM(static_cast<int16_t>(point.x), static_cast<int16_t>(point.y)));
     SendMessage(WM_LBUTTONUP, (WPARAM)MK_LBUTTON,
-        MAKELPARAM(point.x, point.y));
+        MAKELPARAM(static_cast<int16_t>(point.x), static_cast<int16_t>(point.y)));
     m_bAllowDrag = TRUE;
 }
 

--- a/GShr/LBoxPiec.cpp
+++ b/GShr/LBoxPiec.cpp
@@ -94,7 +94,7 @@ GameElement CPieceListBox::OnGetHitItemCodeAtPoint(CPoint point, CRect& rct)
     ASSERT(m_pDoc != NULL);
 
     PieceID nPid = MapIndexToItem(value_preserving_cast<size_t>(nIndex));
-    int side = 0;
+    unsigned side = 0u;
 
     TileID tidLeft = m_pPMgr->GetPiece(nPid).GetFrontTID();
     ASSERT(tidLeft != nullTid);            // Should exist
@@ -109,7 +109,7 @@ GameElement CPieceListBox::OnGetHitItemCodeAtPoint(CPoint point, CRect& rct)
     else if (!rctRight.IsRectEmpty() && rctRight.PtInRect(point))
     {
         rct = rctRight;
-        side = 1;
+        side = 1u;
     }
     else
         return Invalid_v<GameElement>;

--- a/GShr/LibMfc.cpp
+++ b/GShr/LibMfc.cpp
@@ -264,7 +264,7 @@ BOOL TranslateKeyToScrollBarMessage(CWnd* pWnd, UINT nChar)
     }
     if (nSBCode != (UINT)-1)
     {
-        pWnd->SendMessage(nCmd, MAKELONG(nSBCode, 0));
+        pWnd->SendMessage(nCmd, MAKELONG(uint16_t(nSBCode), uint16_t(0)));
         return TRUE;
     }
     return FALSE;

--- a/GShr/MapStrng.h
+++ b/GShr/MapStrng.h
@@ -165,29 +165,8 @@ public:
     }
 #endif
 
-    void Serialize(CArchive& ar) const
-    {
-        static_assert(sizeof(std::remove_reference_t<decltype(*this)>) == sizeof(u.buf), "size mismatch");
-        static_assert(alignof(std::remove_reference_t<decltype(*this)>) == alignof(decltype(u.buf)), "align mismatch");
-        static_assert(std::is_trivially_copyable_v<std::remove_reference_t<decltype(*this)>>, "needs more complex serialize");
-        if (!ar.IsStoring())
-        {
-            AfxThrowArchiveException(CArchiveException::readOnly);
-        }
-        ar << u.buf;
-    }
-
-    void Serialize(CArchive& ar)
-    {
-        static_assert(sizeof(std::remove_reference_t<decltype(*this)>) == sizeof(u.buf), "size mismatch");
-        static_assert(alignof(std::remove_reference_t<decltype(*this)>) == alignof(decltype(u.buf)), "align mismatch");
-        static_assert(std::is_trivially_copyable_v<std::remove_reference_t<decltype(*this)>>, "needs more complex serialize");
-        if (ar.IsStoring())
-        {
-            AfxThrowArchiveException(CArchiveException::readOnly);
-        }
-        ar >> u.buf;
-    }
+    void Serialize(CArchive& ar) const;
+    void Serialize(CArchive& ar);
 
     UINT Hash() const
     {
@@ -287,6 +266,10 @@ private:
         static_assert(alignof(std::remove_reference_t<decltype(*this)>) == alignof(GameElementLegacyCheck), "align mismatch");
     }
 #endif
+
+    // Serialize conversion helpers
+    explicit operator GameElement64() const;
+    friend class SerializeBackdoorGameElement;
 
     friend Invalid<GameElement32>;
 };
@@ -537,29 +520,8 @@ public:
     }
 #endif
 
-    void Serialize(CArchive& ar) const
-    {
-        static_assert(sizeof(std::remove_reference_t<decltype(*this)>) == sizeof(u.buf), "size mismatch");
-        static_assert(alignof(std::remove_reference_t<decltype(*this)>) == alignof(decltype(u.buf)), "align mismatch");
-        static_assert(std::is_trivially_copyable_v<std::remove_reference_t<decltype(*this)>>, "needs more complex serialize");
-        if (!ar.IsStoring())
-        {
-            AfxThrowArchiveException(CArchiveException::readOnly);
-        }
-        ar << u.buf;
-    }
-
-    void Serialize(CArchive& ar)
-    {
-        static_assert(sizeof(std::remove_reference_t<decltype(*this)>) == sizeof(u.buf), "size mismatch");
-        static_assert(alignof(std::remove_reference_t<decltype(*this)>) == alignof(decltype(u.buf)), "align mismatch");
-        static_assert(std::is_trivially_copyable_v<std::remove_reference_t<decltype(*this)>>, "needs more complex serialize");
-        if (ar.IsStoring())
-        {
-            AfxThrowArchiveException(CArchiveException::readOnly);
-        }
-        ar >> u.buf;
-    }
+    void Serialize(CArchive& ar) const;
+    void Serialize(CArchive& ar);
 
     UINT Hash() const
     {
@@ -660,6 +622,10 @@ private:
     // helper for Invalid_v<GameElement>
     constexpr GameElement64(Invalid_t) : u(Invalid_t()) {}
 
+    // Serialize conversion helpers
+    explicit operator GameElement32() const;
+    friend class SerializeBackdoorGameElement;
+
     friend Invalid<GameElement64>;
 };
 
@@ -738,6 +704,14 @@ inline ObjectID64 GetObjectIDFromElement(GameElement64 elem)
     return retval;
 }
 #endif
+
+class SerializeBackdoorGameElement : public SerializeBackdoor
+{
+public:
+    using SerializeBackdoor::Convert;
+    static GameElement64 Convert(const GameElement32& ge);
+    static GameElement32 Convert(const GameElement64& ge);
+};
 
 
 //////////////////////////////////////////////////////////////////////

--- a/GShr/Marks.h
+++ b/GShr/Marks.h
@@ -31,12 +31,23 @@
 
 //////////////////////////////////////////////////////////////////////
 
-const size_t maxMarks = 32000;
 typedef XxxxID16<'M'> MarkID16;
 typedef XxxxID32<'M'> MarkID32;
 typedef XxxxID<'M'> MarkID;
 
-const       MarkID nullMid = MarkID(0xFFFF);
+template<>
+struct Invalid<MarkID16>
+{
+    static constexpr MarkID16 value = MarkID16(0xFFFF);
+};
+
+template<>
+struct Invalid<MarkID32>
+{
+    static constexpr MarkID32 value = MarkID32(0xFFFFFFFF);
+};
+
+constexpr MarkID nullMid = Invalid_v<MarkID>;
 
 //////////////////////////////////////////////////////////////////////
 
@@ -164,7 +175,7 @@ public:
 // Implementation
 protected:
     XxxxIDTable<MarkID, MarkDef,
-                maxMarks, markTblBaseSize, markTblIncrSize,
+                markTblBaseSize, markTblIncrSize,
                 true> m_pMarkTbl;
     std::vector<CMarkSet> m_MSetTbl;
     WORD        m_wReserved1;   // For future need (set to 0)

--- a/GShr/Marks.h
+++ b/GShr/Marks.h
@@ -125,7 +125,12 @@ protected:
 
 //////////////////////////////////////////////////////////////////////
 
-class CGameElementStringMap;
+class GameElement32;
+class GameElement64;
+using GameElement = std::conditional_t<std::is_same_v<TileID, TileID16>, GameElement32, GameElement64>;
+template<typename KEY>
+class CGameElementStringMapT;
+using CGameElementStringMap = CGameElementStringMapT<GameElement>;
 
 class CMarkManager
 {

--- a/GShr/Pieces.h
+++ b/GShr/Pieces.h
@@ -31,12 +31,23 @@
 
 //////////////////////////////////////////////////////////////////////
 
-const size_t maxPieces = 32000;
 typedef XxxxID16<'P'> PieceID16;
 typedef XxxxID32<'P'> PieceID32;
 typedef XxxxID<'P'> PieceID;
 
-const       PieceID nullPid = PieceID(0xFFFF);
+template<>
+struct Invalid<PieceID16>
+{
+    static constexpr PieceID16 value = PieceID16(0xFFFF);
+};
+
+template<>
+struct Invalid<PieceID32>
+{
+    static constexpr PieceID32 value = PieceID32(0xFFFFFFFF);
+};
+
+constexpr PieceID nullPid = Invalid_v<PieceID>;
 
 //////////////////////////////////////////////////////////////////////
 
@@ -151,7 +162,7 @@ public:
 // Implementation
 protected:
     XxxxIDTable<PieceID, PieceDef,
-                maxPieces, pieceTblBaseSize, pieceTblIncrSize,
+                pieceTblBaseSize, pieceTblIncrSize,
                 true> m_pPieceTbl;
     std::vector<CPieceSet> m_PSetTbl;
     WORD        m_wReserved1;       // For future need (set to 0)

--- a/GShr/Pieces.h
+++ b/GShr/Pieces.h
@@ -112,7 +112,12 @@ protected:
 
 //////////////////////////////////////////////////////////////////////
 
-class CGameElementStringMap;
+class GameElement32;
+class GameElement64;
+using GameElement = std::conditional_t<std::is_same_v<TileID, TileID16>, GameElement32, GameElement64>;
+template<typename KEY>
+class CGameElementStringMapT;
+using CGameElementStringMap = CGameElementStringMapT<GameElement>;
 
 class CPieceManager
 {

--- a/GShr/Tile.h
+++ b/GShr/Tile.h
@@ -73,14 +73,13 @@ const size_t tileTblIncrSize = 8;
 
 struct TileLoc
 {
-    /* TODO:  m_nSheet should be size_t, but that breaks file
-        format compatibility, so change this on next new format */
-    WORD    m_nSheet;               // (2.91 BYTE->WORD)
+    size_t  m_nSheet;               // (2.91 BYTE->WORD), (4.0 WORD->size_t)
     int     m_nOffset;
     // ------ //
-    enum { noSheet = 0xFFFF };
+    constexpr static size_t noSheet = Invalid_v<size_t>;
+    constexpr static uint16_t noSheet16 = uint16_t(0xFFFF);
 
-    BOOL IsEmpty() const { return m_nSheet == noSheet; }
+    bool IsEmpty() const { return m_nSheet == noSheet; }
     void SetEmpty() { m_nSheet = noSheet; m_nOffset = 0;  } // (clear offset too)
 
     void Serialize(CArchive& archive);

--- a/GShr/Tile.h
+++ b/GShr/Tile.h
@@ -35,12 +35,23 @@ class   CTile;
 
 ////////////////////////////////////////////////////////////////////
 
-const size_t maxTiles = 32000;
 typedef XxxxID16<'T'> TileID16;
 typedef XxxxID32<'T'> TileID32;
 typedef XxxxID<'T'> TileID;
 
-const       TileID nullTid = TileID(0xFFFF);
+template<>
+struct Invalid<TileID16>
+{
+    static constexpr TileID16 value = TileID16(0xFFFF);
+};
+
+template<>
+struct Invalid<TileID32>
+{
+    static constexpr TileID32 value = TileID32(0xFFFFFFFF);
+};
+
+constexpr TileID nullTid = Invalid_v<TileID>;
 
 const       UINT maxSheetHeight = 8192;     // Max y pixels allowed in a tile sheet
 
@@ -265,7 +276,7 @@ public:
 // Implementation
 protected:
     XxxxIDTable<TileID, TileDef,
-                maxTiles, tileTblBaseSize, tileTblIncrSize,
+                tileTblBaseSize, tileTblIncrSize,
                 false> m_pTileTbl;
     COLORREF    m_crTrans;          // Transparency color for all tiles
     WORD        m_wReserved1;       // For future need (set to 0)

--- a/GShr/TileSet.cpp
+++ b/GShr/TileSet.cpp
@@ -24,6 +24,7 @@
 
 #include    "stdafx.h"
 #include    "Tile.h"
+#include    "Versions.h"
 
 #ifdef _DEBUG
 #undef THIS_FILE

--- a/GShr/WinState.cpp
+++ b/GShr/WinState.cpp
@@ -24,6 +24,7 @@
 
 #include    "stdafx.h"
 #include    "WinState.h"
+#include    "Versions.h"
 
 ///////////////////////////////////////////////////////////////////////////
 // Returns FALSE if no frame restoration data is supplied by frames.
@@ -305,7 +306,7 @@ CWinStateManager::CWinStateElement::CWinStateElement()
 {
     m_wWinCode = 0;
     m_wUserCode1 = 0;
-    m_wUserCode2 = 0;
+    m_boardID = nullBid;
 }
 
 void CWinStateManager::CWinStateElement::Serialize(CArchive& ar)
@@ -314,7 +315,7 @@ void CWinStateManager::CWinStateElement::Serialize(CArchive& ar)
     {
         ar << m_wWinCode;
         ar << m_wUserCode1;
-        ar << m_wUserCode2;
+        ar << m_boardID;
         ar << m_wndState;
         ar << value_preserving_cast<DWORD>(m_pWinStateBfr.GetSize());
         if (m_pWinStateBfr.GetSize() > size_t(0))
@@ -326,7 +327,7 @@ void CWinStateManager::CWinStateElement::Serialize(CArchive& ar)
 
         ar >> m_wWinCode;
         ar >> m_wUserCode1;
-        ar >> m_wUserCode2;
+        ar >> m_boardID;
         ar >> m_wndState;
         DWORD size;
         ar >> size;

--- a/GShr/WinState.h
+++ b/GShr/WinState.h
@@ -25,7 +25,7 @@
 #ifndef _WINSTATE_H
 #define _WINSTATE_H
 
-#include <list>
+#include "Board.h"
 
 ///////////////////////////////////////////////////////////////////////
 
@@ -107,7 +107,7 @@ protected:
     {
         WORD  m_wWinCode;           // Generic type of window
         WORD  m_wUserCode1;         // Used by subclass to refine WinCode
-        WORD  m_wUserCode2;         // Used by subclass to refine WinCode
+        BoardID m_boardID;          // Used by subclass to refine WinCode
         CWinPlacement m_wndState;   // Window placement information
 
         Buffer m_pWinStateBfr;       // Serialized window data


### PR DESCRIPTION
This PR expands TileID/MarkID/PieceID to 32bits to allow for games with larger piece counts.  

Note that saving 32bit IDs to a file requires file format changes, making the files incompatible with previous versions of CyberBoard.  I am not yet enabling the file format changes by default since I am waiting for more testing of these changes.  To opt-in to the file support for 32bit IDs,  run CyberBoard with command line switch `/id32`.

I am also waiting for some more testing before I mark the 32bit issue fixed.
