### PR TITLE
CyberBoard 64-bit process

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,4 +37,7 @@ jobs:
         msbuild zlib\zLib.vcxproj /property:Configuration=Debug /target:build
         msbuild GM\CBDsgn32.vcxproj /property:Configuration=Debug /target:build
         msbuild GP\CBPlay32.vcxproj /property:Configuration=Debug /target:build
+        msbuild zlib\zLib.vcxproj /property:Configuration=Debug /property:Platform=x64 /target:build
+        msbuild GM\CBDsgn32.vcxproj /property:Configuration=Debug /property:Platform=x64 /target:build
+        msbuild GP\CBPlay32.vcxproj /property:Configuration=Debug /property:Platform=x64 /target:build
 

--- a/CyberBoard.sln
+++ b/CyberBoard.sln
@@ -1,31 +1,50 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2012
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "CBDsgn32", "GM\CBDsgn32.vcxproj", "{107CA415-78FA-4517-B192-D207313CD48E}"
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.30611.23
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "CBDesign", "GM\CBDsgn32.vcxproj", "{107CA415-78FA-4517-B192-D207313CD48E}"
 EndProject
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Cbplay32", "GP\Cbplay32.vcxproj", "{2A0A2247-0569-4973-8E0D-8A3DF0B66A43}"
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "CBPlay", "GP\Cbplay32.vcxproj", "{2A0A2247-0569-4973-8E0D-8A3DF0B66A43}"
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "zLib", "zLib\zLib.vcxproj", "{5BF1B9BA-043F-469F-BE19-787FF317EDDC}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Win32 = Debug|Win32
+		Debug|x64 = Debug|x64
 		Release|Win32 = Release|Win32
+		Release|x64 = Release|x64
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{107CA415-78FA-4517-B192-D207313CD48E}.Debug|Win32.ActiveCfg = Debug|Win32
 		{107CA415-78FA-4517-B192-D207313CD48E}.Debug|Win32.Build.0 = Debug|Win32
+		{107CA415-78FA-4517-B192-D207313CD48E}.Debug|x64.ActiveCfg = Debug|x64
+		{107CA415-78FA-4517-B192-D207313CD48E}.Debug|x64.Build.0 = Debug|x64
 		{107CA415-78FA-4517-B192-D207313CD48E}.Release|Win32.ActiveCfg = Release|Win32
 		{107CA415-78FA-4517-B192-D207313CD48E}.Release|Win32.Build.0 = Release|Win32
+		{107CA415-78FA-4517-B192-D207313CD48E}.Release|x64.ActiveCfg = Release|x64
+		{107CA415-78FA-4517-B192-D207313CD48E}.Release|x64.Build.0 = Release|x64
 		{2A0A2247-0569-4973-8E0D-8A3DF0B66A43}.Debug|Win32.ActiveCfg = Debug|Win32
 		{2A0A2247-0569-4973-8E0D-8A3DF0B66A43}.Debug|Win32.Build.0 = Debug|Win32
+		{2A0A2247-0569-4973-8E0D-8A3DF0B66A43}.Debug|x64.ActiveCfg = Debug|x64
+		{2A0A2247-0569-4973-8E0D-8A3DF0B66A43}.Debug|x64.Build.0 = Debug|x64
 		{2A0A2247-0569-4973-8E0D-8A3DF0B66A43}.Release|Win32.ActiveCfg = Release|Win32
 		{2A0A2247-0569-4973-8E0D-8A3DF0B66A43}.Release|Win32.Build.0 = Release|Win32
+		{2A0A2247-0569-4973-8E0D-8A3DF0B66A43}.Release|x64.ActiveCfg = Release|x64
+		{2A0A2247-0569-4973-8E0D-8A3DF0B66A43}.Release|x64.Build.0 = Release|x64
 		{5BF1B9BA-043F-469F-BE19-787FF317EDDC}.Debug|Win32.ActiveCfg = Debug|Win32
 		{5BF1B9BA-043F-469F-BE19-787FF317EDDC}.Debug|Win32.Build.0 = Debug|Win32
+		{5BF1B9BA-043F-469F-BE19-787FF317EDDC}.Debug|x64.ActiveCfg = Debug|x64
+		{5BF1B9BA-043F-469F-BE19-787FF317EDDC}.Debug|x64.Build.0 = Debug|x64
 		{5BF1B9BA-043F-469F-BE19-787FF317EDDC}.Release|Win32.ActiveCfg = Release|Win32
 		{5BF1B9BA-043F-469F-BE19-787FF317EDDC}.Release|Win32.Build.0 = Release|Win32
+		{5BF1B9BA-043F-469F-BE19-787FF317EDDC}.Release|x64.ActiveCfg = Release|x64
+		{5BF1B9BA-043F-469F-BE19-787FF317EDDC}.Release|x64.Build.0 = Release|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {73745982-6D48-4833-A009-4136E65040C2}
 	EndGlobalSection
 EndGlobal

--- a/GM/CBDsgn32.vcxproj
+++ b/GM/CBDsgn32.vcxproj
@@ -5,9 +5,17 @@
       <Configuration>Debug</Configuration>
       <Platform>Win32</Platform>
     </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
     <ProjectConfiguration Include="Release|Win32">
       <Configuration>Release</Configuration>
       <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
@@ -23,7 +31,19 @@
     <UseOfMfc>Static</UseOfMfc>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <PlatformToolset>v142</PlatformToolset>
+    <UseOfMfc>Static</UseOfMfc>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <PlatformToolset>v142</PlatformToolset>
+    <UseOfMfc>Static</UseOfMfc>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <PlatformToolset>v142</PlatformToolset>
     <UseOfMfc>Static</UseOfMfc>
@@ -36,7 +56,14 @@
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
     <Import Project="$(VCTargetsPath)Microsoft.CPP.UpgradeFromVC71.props" />
   </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="$(VCTargetsPath)Microsoft.CPP.UpgradeFromVC71.props" />
+  </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
@@ -47,7 +74,15 @@
     <LinkIncremental>true</LinkIncremental>
     <CustomBuildAfterTargets>BuildLink</CustomBuildAfterTargets>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <LinkIncremental>true</LinkIncremental>
+    <CustomBuildAfterTargets>BuildLink</CustomBuildAfterTargets>
+  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <LinkIncremental>false</LinkIncremental>
+    <CustomBuildAfterTargets>BuildLink</CustomBuildAfterTargets>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <LinkIncremental>false</LinkIncremental>
     <CustomBuildAfterTargets>BuildLink</CustomBuildAfterTargets>
   </PropertyGroup>
@@ -101,6 +136,57 @@ echo off
       <DataExecutionPrevention />
     </Link>
   </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <CustomBuildStep>
+      <Message>Build HTML Help</Message>
+      <Command>makehm IDR_,IDH_R_,0x20000 resource.h &gt;"gmhelpidmap.h"
+makehm ID_,IDH_,0x10000 IDM_,IDH_M_,0x10000 resource.h &gt;&gt;"gmhelpidmap.h"
+..\ghelp\makeidh gmhelpidmap.h
+copy $(ProjectDir)gmhelpidmap.h ..\GHelp\*.*
+copy $(ProjectDir)gmhelp.h ..\GHelp\*.*
+hhc.exe ..\GHelp\CBoard.hhp
+copy ..\GHelp\CBoard.chm $(TargetDir)cboard.chm
+echo off
+</Command>
+      <Outputs>$(TargetDir)cboard.chm;%(Outputs)</Outputs>
+      <Inputs>$(TargetPath);%(Inputs)</Inputs>
+    </CustomBuildStep>
+    <Midl>
+      <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <MkTypLibCompatible>true</MkTypLibCompatible>
+      <SuppressStartupBanner>true</SuppressStartupBanner>
+      <TypeLibraryName>.\Debug/CBDsgn32.tlb</TypeLibraryName>
+    </Midl>
+    <ClCompile>
+      <Optimization>Disabled</Optimization>
+      <AdditionalIncludeDirectories>..\zLib;..\gshr;.;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>_DEBUG;WIN32;_WINDOWS;_AFX_SECURE_NO_WARNINGS;_ATL_SECURE_NO_WARNINGS;_CRT_SECURE_NO_WARNINGS;_CRT_NONSTDC_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <PrecompiledHeaderFile>stdafx.h</PrecompiledHeaderFile>
+      <BrowseInformation>true</BrowseInformation>
+      <WarningLevel>Level4</WarningLevel>
+      <SuppressStartupBanner>true</SuppressStartupBanner>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+    </ClCompile>
+    <ResourceCompile>
+      <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <Culture>0x0409</Culture>
+      <AdditionalIncludeDirectories>$(IntDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <ShowProgress>false</ShowProgress>
+    </ResourceCompile>
+    <Link>
+      <AdditionalDependencies>htmlhelp.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <SuppressStartupBanner>true</SuppressStartupBanner>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <ProgramDatabaseFile>.\Debug/CBDesign.pdb</ProgramDatabaseFile>
+      <SubSystem>Windows</SubSystem>
+      <RandomizedBaseAddress>false</RandomizedBaseAddress>
+      <DataExecutionPrevention>
+      </DataExecutionPrevention>
+    </Link>
+  </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <CustomBuildStep>
       <Message>Build HTML Help</Message>
@@ -146,6 +232,54 @@ echo off
       <SubSystem>Windows</SubSystem>
       <RandomizedBaseAddress>false</RandomizedBaseAddress>
       <DataExecutionPrevention />
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <CustomBuildStep>
+      <Message>Build HTML Help</Message>
+      <Command>makehm IDR_,IDH_R_,0x20000 resource.h &gt;"gmhelpidmap.h"
+makehm ID_,IDH_,0x10000 IDM_,IDH_M_,0x10000 resource.h &gt;&gt;"gmhelpidmap.h"
+..\ghelp\makeidh gmhelpidmap.h
+copy $(ProjectDir)gmhelpidmap.h ..\GHelp\*.*
+copy $(ProjectDir)gmhelp.h ..\GHelp\*.*
+hhc.exe ..\GHelp\CBoard.hhp
+copy ..\GHelp\CBoard.chm $(TargetDir)cboard.chm
+echo off
+</Command>
+      <Outputs>$(TargetDir)cboard.chm;%(Outputs)</Outputs>
+      <Inputs>$(TargetPath);%(Inputs)</Inputs>
+    </CustomBuildStep>
+    <Midl>
+      <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <MkTypLibCompatible>true</MkTypLibCompatible>
+      <SuppressStartupBanner>true</SuppressStartupBanner>
+      <TypeLibraryName>.\Release/CBDsgn32.tlb</TypeLibraryName>
+    </Midl>
+    <ClCompile>
+      <InlineFunctionExpansion>OnlyExplicitInline</InlineFunctionExpansion>
+      <AdditionalIncludeDirectories>..\zLib;..\gshr;.;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>NDEBUG;WIN32;_WINDOWS;_AFX_SECURE_NO_WARNINGS;_ATL_SECURE_NO_WARNINGS;_CRT_SECURE_NO_WARNINGS;_CRT_NONSTDC_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <StringPooling>true</StringPooling>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <PrecompiledHeaderFile>stdafx.h</PrecompiledHeaderFile>
+      <WarningLevel>Level4</WarningLevel>
+      <SuppressStartupBanner>true</SuppressStartupBanner>
+    </ClCompile>
+    <ResourceCompile>
+      <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <Culture>0x0409</Culture>
+      <AdditionalIncludeDirectories>..\..\..\XtremeToolkit\Include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ResourceCompile>
+    <Link>
+      <AdditionalDependencies>htmlhelp.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <SuppressStartupBanner>true</SuppressStartupBanner>
+      <ProgramDatabaseFile>.\Release/CBDesign.pdb</ProgramDatabaseFile>
+      <SubSystem>Windows</SubSystem>
+      <RandomizedBaseAddress>false</RandomizedBaseAddress>
+      <DataExecutionPrevention>
+      </DataExecutionPrevention>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
@@ -214,7 +348,9 @@ echo off
     <ClCompile Include="SelObjs.cpp" />
     <ClCompile Include="StdAfx.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Create</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Create</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Create</PrecompiledHeader>
     </ClCompile>
     <ClCompile Include="..\GShr\StrLib.cpp" />
     <ClCompile Include="..\GShr\Tile.cpp" />

--- a/GM/CBDsgn32.vcxproj
+++ b/GM/CBDsgn32.vcxproj
@@ -82,7 +82,7 @@ echo off
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>stdafx.h</PrecompiledHeaderFile>
       <BrowseInformation>true</BrowseInformation>
-      <WarningLevel>Level3</WarningLevel>
+      <WarningLevel>Level4</WarningLevel>
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
     </ClCompile>
@@ -132,7 +132,7 @@ echo off
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>stdafx.h</PrecompiledHeaderFile>
-      <WarningLevel>Level3</WarningLevel>
+      <WarningLevel>Level4</WarningLevel>
       <SuppressStartupBanner>true</SuppressStartupBanner>
     </ClCompile>
     <ResourceCompile>

--- a/GM/CBDsgn32.vcxproj
+++ b/GM/CBDsgn32.vcxproj
@@ -14,7 +14,6 @@
     <ProjectGuid>{107CA415-78FA-4517-B192-D207313CD48E}</ProjectGuid>
     <RootNamespace>CBDsgn32</RootNamespace>
     <Keyword>MFCProj</Keyword>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
     <ProjectName>CBDesign</ProjectName>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
@@ -45,16 +44,12 @@
     <_ProjectFileVersion>11.0.50727.1</_ProjectFileVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-    <OutDir>.\Debug\</OutDir>
-    <IntDir>.\Debug\</IntDir>
     <LinkIncremental>true</LinkIncremental>
-    <TargetName>$(ProjectName)</TargetName>
+    <CustomBuildAfterTargets>BuildLink</CustomBuildAfterTargets>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
-    <OutDir>.\Release\</OutDir>
-    <IntDir>.\Release\</IntDir>
     <LinkIncremental>false</LinkIncremental>
-    <TargetName>$(ProjectName)</TargetName>
+    <CustomBuildAfterTargets>BuildLink</CustomBuildAfterTargets>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <CustomBuildStep>
@@ -69,6 +64,7 @@ copy ..\GHelp\CBoard.chm $(TargetDir)cboard.chm
 echo off
 </Command>
       <Outputs>$(TargetDir)cboard.chm;%(Outputs)</Outputs>
+      <Inputs>$(TargetPath);%(Inputs)</Inputs>
     </CustomBuildStep>
     <Midl>
       <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -85,15 +81,10 @@ echo off
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>stdafx.h</PrecompiledHeaderFile>
-      <PrecompiledHeaderOutputFile>.\Debug/CBDsgn32.pch</PrecompiledHeaderOutputFile>
-      <AssemblerListingLocation>.\Debug/</AssemblerListingLocation>
-      <ObjectFileName>.\Debug/</ObjectFileName>
-      <ProgramDataBaseFileName>.\Debug/</ProgramDataBaseFileName>
       <BrowseInformation>true</BrowseInformation>
       <WarningLevel>Level3</WarningLevel>
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
-      <CompileAs>Default</CompileAs>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -102,12 +93,9 @@ echo off
       <ShowProgress>false</ShowProgress>
     </ResourceCompile>
     <Link>
-      <AdditionalOptions>/MACHINE:I386 %(AdditionalOptions)</AdditionalOptions>
       <AdditionalDependencies>htmlhelp.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <OutputFile>$(TargetPath)</OutputFile>
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <ProgramDatabaseFile>.\Debug/CBDesign.pdb</ProgramDatabaseFile>
       <SubSystem>Windows</SubSystem>
       <RandomizedBaseAddress>false</RandomizedBaseAddress>
       <DataExecutionPrevention />
@@ -126,6 +114,7 @@ copy ..\GHelp\CBoard.chm $(TargetDir)cboard.chm
 echo off
 </Command>
       <Outputs>$(TargetDir)cboard.chm;%(Outputs)</Outputs>
+      <Inputs>$(TargetPath);%(Inputs)</Inputs>
     </CustomBuildStep>
     <Midl>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -143,13 +132,8 @@ echo off
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>stdafx.h</PrecompiledHeaderFile>
-      <PrecompiledHeaderOutputFile>.\Release/CBDsgn32.pch</PrecompiledHeaderOutputFile>
-      <AssemblerListingLocation>.\Release/</AssemblerListingLocation>
-      <ObjectFileName>.\Release/</ObjectFileName>
-      <ProgramDataBaseFileName>.\Release/</ProgramDataBaseFileName>
       <WarningLevel>Level3</WarningLevel>
       <SuppressStartupBanner>true</SuppressStartupBanner>
-      <CompileAs>Default</CompileAs>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -157,12 +141,8 @@ echo off
       <AdditionalIncludeDirectories>..\..\..\XtremeToolkit\Include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ResourceCompile>
     <Link>
-      <AdditionalOptions>/MACHINE:I386 %(AdditionalOptions)</AdditionalOptions>
       <AdditionalDependencies>htmlhelp.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <OutputFile>Release/CBDesign.exe</OutputFile>
       <SuppressStartupBanner>true</SuppressStartupBanner>
-      <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <ProgramDatabaseFile>.\Release/CBDesign.pdb</ProgramDatabaseFile>
       <SubSystem>Windows</SubSystem>
       <RandomizedBaseAddress>false</RandomizedBaseAddress>
       <DataExecutionPrevention />

--- a/GM/CBDsgn32.vcxproj
+++ b/GM/CBDsgn32.vcxproj
@@ -180,7 +180,6 @@ echo off
       <AdditionalDependencies>htmlhelp.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <ProgramDatabaseFile>.\Debug/CBDesign.pdb</ProgramDatabaseFile>
       <SubSystem>Windows</SubSystem>
       <RandomizedBaseAddress>false</RandomizedBaseAddress>
       <DataExecutionPrevention>
@@ -275,7 +274,6 @@ echo off
     <Link>
       <AdditionalDependencies>htmlhelp.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <SuppressStartupBanner>true</SuppressStartupBanner>
-      <ProgramDatabaseFile>.\Release/CBDesign.pdb</ProgramDatabaseFile>
       <SubSystem>Windows</SubSystem>
       <RandomizedBaseAddress>false</RandomizedBaseAddress>
       <DataExecutionPrevention>

--- a/GM/Cbdesign.rc
+++ b/GM/Cbdesign.rc
@@ -1187,6 +1187,7 @@ BEGIN
     IDS_ERR_BOARDNAME       "You must provide a unique board name."
     IDS_ERR_NOTAGAMEBOX     "The file is not a Game Box."
     IDS_ERR_GAMEBOXNEWER    "The Game Box file was created by a newer version of the program. You must upgrade your CyberBoard software to load it."
+    IDS_ERR_PIECESETSIZE    "Piece Set max size is 65535."
     IDP_DELETEBOARD         "You are about to delete board:\n\n   ""%1""\n\nThis may render current games and scenarios unplayable. Are you sure you want to do this?"
     IDP_DELETETILESET       "You are about to delete tile group:\n\n   ""%1""\n\nThis may render current games and scenarios unplayable. Are you sure you want to do this?"
     IDP_DELETEPIECESET      "You are about to delete piece group:\n\n   ""%1""\n\nThis may render current games and scenarios unplayable. Are you sure you want to do this?"

--- a/GM/DlgBrdp.cpp
+++ b/GM/DlgBrdp.cpp
@@ -242,10 +242,10 @@ void CBoardPropDialog::OnReshape()
 
 void CBoardPropDialog::UpdateInfoArea()
 {
-    char szNum[40];
-    _itoa(m_nRows, szNum, 10);
+    char szNum[std::max(_MAX_U64TOSTR_BASE10_COUNT, _MAX_ITOSTR_BASE10_COUNT)];
+    _ui64toa(m_nRows, szNum, 10);
     m_staticRows.SetWindowText(szNum);
-    _itoa(m_nCols, szNum, 10);
+    _ui64toa(m_nCols, szNum, 10);
     m_staticCols.SetWindowText(szNum);
 
     if (m_bShapeChanged && m_eCellStyle == cformHexPnt)

--- a/GM/DlgBrdp.h
+++ b/GM/DlgBrdp.h
@@ -76,8 +76,8 @@ public:
     UINT            m_yGridSnapOff;
 
     CellFormType    m_eCellStyle;   // Used to disable cell a cell dimension
-    int             m_nRows;
-    int             m_nCols;
+    size_t          m_nRows;
+    size_t          m_nCols;
     int             m_nCellHt;
     int             m_nCellWd;
     BOOL            m_bStaggerIn;

--- a/GM/DlgBrdsz.cpp
+++ b/GM/DlgBrdsz.cpp
@@ -42,8 +42,8 @@ CBoardReshapeDialog::CBoardReshapeDialog(CWnd* pParent /*=NULL*/)
     //{{AFX_DATA_INIT(CBoardReshapeDialog)
     m_nCellHt = 0;
     m_nCellWd = 0;
-    m_nCols = 0;
-    m_nRows = 0;
+    m_nCols = size_t(0);
+    m_nRows = size_t(0);
     m_bStaggerIn = FALSE;
     //}}AFX_DATA_INIT
     m_eCellStyle = cformRect;
@@ -61,9 +61,9 @@ void CBoardReshapeDialog::DoDataExchange(CDataExchange* pDX)
     DDX_Text(pDX, IDC_D_BRDSHP_CELLWD, m_nCellWd);
     DDV_MinMaxUInt(pDX, m_nCellWd, 4, 32000);
     DDX_Text(pDX, IDC_D_BRDSHP_COLS, m_nCols);
-    DDV_MinMaxUInt(pDX, m_nCols, 1, 1000);
+    DDV_MinMaxUInt(pDX, value_preserving_cast<UINT>(m_nCols), 1, 1000);
     DDX_Text(pDX, IDC_D_BRDSHP_ROWS, m_nRows);
-    DDV_MinMaxUInt(pDX, m_nRows, 1, 1000);
+    DDV_MinMaxUInt(pDX, value_preserving_cast<UINT>(m_nRows), 1, 1000);
     DDX_Check(pDX, IDC_D_BRDSHP_STAGGERIN, m_bStaggerIn);
     //}}AFX_DATA_MAP
 }

--- a/GM/DlgBrdsz.h
+++ b/GM/DlgBrdsz.h
@@ -41,8 +41,8 @@ public:
     CEdit   m_editCellHt;
     UINT    m_nCellHt;
     UINT    m_nCellWd;
-    UINT    m_nCols;
-    UINT    m_nRows;
+    size_t  m_nCols;
+    size_t  m_nRows;
     BOOL    m_bStaggerIn;
     //}}AFX_DATA
 

--- a/GM/DlgGboxp.cpp
+++ b/GM/DlgGboxp.cpp
@@ -106,7 +106,7 @@ void CGmBoxPropsDialog::OnContextMenu(CWnd* pWnd, CPoint point)
 void CGmBoxPropsDialog::OnOK()
 {
     CDialog::OnOK();
-    m_nCompressLevel = m_comboCompress.GetItemData(m_comboCompress.GetCurSel());
+    m_nCompressLevel = value_preserving_cast<int>(m_comboCompress.GetItemData(m_comboCompress.GetCurSel()));
 }
 
 

--- a/GM/DlgMkbrd.cpp
+++ b/GM/DlgMkbrd.cpp
@@ -41,8 +41,8 @@ CGridType::CGridType(CWnd* pParent /*=NULL*/)
     //{{AFX_DATA_INIT(CGridType)
     m_iCellWd = 0;
     m_iCellHt = 0;
-    m_iCols = 0;
-    m_iRows = 0;
+    m_iCols = size_t(0);
+    m_iRows = size_t(0);
     m_strBoardName = "";
     m_bStagerIn = FALSE;
     m_nBoardType = -1;
@@ -64,9 +64,9 @@ void CGridType::DoDataExchange(CDataExchange* pDX)
     DDX_Text(pDX, IDC_D_NEWBRD_CELLHEIGHT, m_iCellHt);
     DDV_MinMaxInt(pDX, m_iCellHt, 4, 32000);
     DDX_Text(pDX, IDC_D_NEWBRD_GRIDCOLS, m_iCols);
-    DDV_MinMaxInt(pDX, m_iCols, 1, 1000);
+    DDV_MinMaxUInt(pDX, value_preserving_cast<unsigned>(m_iCols), 1, 1000);
     DDX_Text(pDX, IDC_D_NEWBRD_GRIDROWS, m_iRows);
-    DDV_MinMaxInt(pDX, m_iRows, 1, 1000);
+    DDV_MinMaxUInt(pDX, value_preserving_cast<unsigned>(m_iRows), 1, 1000);
     DDX_Text(pDX, IDC_D_NEWBRD_BOARDNAME, m_strBoardName);
     DDV_MaxChars(pDX, m_strBoardName, 32);
     DDX_Check(pDX, IDC_D_NEWBRD_STAGGERIN, m_bStagerIn);
@@ -207,7 +207,7 @@ void CGridType::UpdateBoardDimensions()
     if (m_nBoardType == cformHexPnt)    // Only first param is used
         m_iCellHt = m_iCellWd;
 
-    if (!(m_iRows > 0 && m_iCols > 0 && m_iCellHt >= 4 && m_iCellWd >= 4))
+    if (!(m_iRows > size_t(0) && m_iCols > size_t(0) && m_iCellHt >= 4 && m_iCellWd >= 4))
     {
         CString str;
         VERIFY(str.LoadString(IDS_BSIZE_INVALID));

--- a/GM/DlgMkbrd.h
+++ b/GM/DlgMkbrd.h
@@ -39,8 +39,8 @@ public:
     CEdit   m_editCellHt;
     int     m_iCellWd;
     int     m_iCellHt;
-    int     m_iCols;
-    int     m_iRows;
+    size_t  m_iCols;
+    size_t  m_iRows;
     CString m_strBoardName;
     BOOL    m_bStagerIn;
     int     m_nBoardType;

--- a/GM/DlgPnew.cpp
+++ b/GM/DlgPnew.cpp
@@ -148,6 +148,15 @@ void CPieceNewDialog::CreatePiece()
     int nNumPieces = atoi(str);
     if (nNumPieces <= 0)
         return;
+    // due to LB_ITEMFROMPOINT limit
+    CPieceSet& pPSet = m_pPMgr->GetPieceSet(m_nPSet);
+    // value_preserving_cast unnecessary due to <= 0 check above
+    if (static_cast<size_t>(nNumPieces) > size_t(0xFFFF) - pPSet.GetPieceIDTable().size())
+    {
+        AfxMessageBox(IDS_ERR_PIECESETSIZE, MB_OK | MB_ICONEXCLAMATION);
+        m_editQty.SetFocus();
+        return;
+    }
 
     BOOL bBackChecked = m_chkBack.GetCheck() == 1;
 

--- a/GM/FrmMain.cpp
+++ b/GM/FrmMain.cpp
@@ -240,7 +240,7 @@ BOOL CMainFrame::OnHelpInfo(HELPINFO* pHelpInfo)
     return TRUE;
 }
 
-void CMainFrame::WinHelp(DWORD dwData, UINT nCmd)
+void CMainFrame::WinHelp(DWORD_PTR dwData, UINT nCmd)
 {
     if (dwData != 0)
         GetApp()->DoHelpContext(dwData);

--- a/GM/FrmMain.cpp
+++ b/GM/FrmMain.cpp
@@ -335,15 +335,15 @@ BOOL CMainFrame::BuildAppGDIPalette()
 {
     ClearSystemPalette();
 
-    int nPalSize = 256;
-    LPLOGPALETTE pLP = (LPLOGPALETTE) new char[sizeof(LOGPALETTE) +
-        nPalSize * sizeof(PALETTEENTRY)];
+    uint16_t nPalSize = uint16_t(256);
+    std::vector<char> v((sizeof(LOGPALETTE) +
+        value_preserving_cast<size_t>(nPalSize * sizeof(PALETTEENTRY))));
+    LPLOGPALETTE pLP = reinterpret_cast<LPLOGPALETTE>(v.data());
     SetupIdentityPalette(nPalSize, pLP);    // Start with speedy identity pal
     GenerateColorWash(&pLP->palPalEntry[10]);
 
     m_appPalette.DeleteObject();
     VERIFY(m_appPalette.CreatePalette(pLP));
-    delete pLP;
 
     return TRUE;
 }

--- a/GM/FrmMain.h
+++ b/GM/FrmMain.h
@@ -95,7 +95,7 @@ public:
 
 // Generated message map functions
 protected:
-    void WinHelp(DWORD dwData, UINT nCmd);
+    void WinHelp(DWORD_PTR dwData, UINT nCmd) override;
 
     afx_msg int OnCreate(LPCREATESTRUCT lpCreateStruct);
     afx_msg void OnClose();

--- a/GM/Gm.cpp
+++ b/GM/Gm.cpp
@@ -161,7 +161,7 @@ BOOL CGmApp::InitInstance()
 
     m_bDisableHtmlHelp = GetProfileInt(szSectSettings, szSectDisableHtmlHelp, 0);
     if (!m_bDisableHtmlHelp)
-        ::HtmlHelp(NULL, NULL, HH_INITIALIZE, (DWORD)&m_dwHtmlHelpCookie);
+        ::HtmlHelp(NULL, NULL, HH_INITIALIZE, reinterpret_cast<uintptr_t>(&m_dwHtmlHelpCookie));
 
     g_gt.InitGdiTools();
     g_res.InitResourceTable(m_hInstance);
@@ -324,7 +324,7 @@ void CGmApp::DoHelpContents()
         DoHelpShellLaunch();
 }
 
-void CGmApp::DoHelpContext(DWORD dwContextData)
+void CGmApp::DoHelpContext(uintptr_t dwContextData)
 {
     if (!m_bDisableHtmlHelp)
         ::HtmlHelp(0, m_pszHelpFilePath, HH_HELP_CONTEXT, dwContextData);
@@ -352,7 +352,7 @@ BOOL CGmApp::DoHelpTipHelp(HELPINFO* pHelpInfo, DWORD* dwIDArray)
         CString strHelpPath = m_pszHelpFilePath;
         strHelpPath += HELP_TIP_CONTEXT_FILE;
         return ::HtmlHelp((HWND)pHelpInfo->hItemHandle,
-            strHelpPath, HH_TP_HELP_WM_HELP, (DWORD)(LPVOID)dwIDArray) != NULL;
+            strHelpPath, HH_TP_HELP_WM_HELP, reinterpret_cast<uintptr_t>(dwIDArray)) != NULL;
     }
     return TRUE;
 }
@@ -368,7 +368,7 @@ void CGmApp::DoHelpWhatIsHelp(CWnd* pWndCtrl, DWORD* dwIDArray)
     CString strHelpPath = m_pszHelpFilePath;
     strHelpPath += HELP_TIP_CONTEXT_FILE;
     ::HtmlHelp(pWndCtrl->GetSafeHwnd(), strHelpPath,
-        HH_TP_HELP_CONTEXTMENU, (DWORD)(LPVOID)dwIDArray);
+        HH_TP_HELP_CONTEXTMENU, reinterpret_cast<uintptr_t>(dwIDArray));
 }
 
 /////////////////////////////////////////////////////////////////////////////

--- a/GM/Gm.h
+++ b/GM/Gm.h
@@ -87,7 +87,7 @@ public:
 public:
     void DoHelpShellLaunch();
     void DoHelpContents();
-    void DoHelpContext(DWORD dwContextData);
+    void DoHelpContext(uintptr_t dwContextData);
     void DoHelpTopic(LPCTSTR pszTopic);
     BOOL DoHelpTipHelp(HELPINFO* pHelpInfo, DWORD* dwIDArray);
     void DoHelpWhatIsHelp(CWnd* pWndCtrl, DWORD* dwIDArray);

--- a/GM/GmDoc.cpp
+++ b/GM/GmDoc.cpp
@@ -785,8 +785,8 @@ void CGamDoc::OnEditCreateBoard()
     dlg.m_iCellWd = 55;
     dlg.m_iCellHt = 55;
     dlg.m_nBoardType = (int)cformHexPnt;
-    dlg.m_iRows = 30;
-    dlg.m_iCols = 30;
+    dlg.m_iRows = size_t(30);
+    dlg.m_iCols = size_t(30);
 
     if (dlg.DoModal() == IDOK)
     {

--- a/GM/GmDoc.cpp
+++ b/GM/GmDoc.cpp
@@ -612,7 +612,9 @@ void CGamDoc::Serialize(CArchive& ar)
             ar >> verMajor;
             ar >> verMinor;
             if (NumVersion(verMajor, verMinor) >
-                NumVersion(fileGbxVerMajor, fileGbxVerMinor))
+                NumVersion(fileGsnVerMajor, fileGsnVerMinor) &&
+                // file 3.90 is the same as 3.10
+                NumVersion(verMajor, verMinor) != NumVersion(3, 90))
             {
                 AfxMessageBox(IDS_ERR_GAMEBOXNEWER, MB_OK | MB_ICONEXCLAMATION);
                 AfxThrowArchiveException(CArchiveException::genericException);

--- a/GM/GmDoc.cpp
+++ b/GM/GmDoc.cpp
@@ -480,9 +480,9 @@ BOOL CGamDoc::DoBoardPropertyDialog(CBoard& pBoard)
     CSize size = pBrdAry->GetCellSize(fullScale);
     dlg.m_nCellHt = size.cy;
     dlg.m_nCellWd = size.cx;
-    CCellForm* pcf = pBrdAry->GetCellForm(fullScale);
-    dlg.m_eCellStyle = pcf->GetCellType();
-    dlg.m_bStaggerIn = pcf->GetCellStagger();
+    CCellForm& pcf = pBrdAry->GetCellForm(fullScale);
+    dlg.m_eCellStyle = pcf.GetCellType();
+    dlg.m_bStaggerIn = pcf.GetCellStagger();
 
     if (dlg.DoModal() == IDOK)
     {

--- a/GM/PalColor.cpp
+++ b/GM/PalColor.cpp
@@ -299,7 +299,7 @@ void CColorPalette::SetupToolTip(CWnd* pWnd, UINT nID, UINT nFlags, LPCTSTR pszT
     ti.cbSize = sizeof(TOOLINFO);
     ti.uFlags |= TTF_IDISHWND | TTF_SUBCLASS | nFlags;
     ti.hwnd = m_hWnd;
-    ti.uId = (UINT)pWnd->GetSafeHwnd();
+    ti.uId = reinterpret_cast<uintptr_t>(pWnd->GetSafeHwnd());
     if (pszText == NULL)
         ti.lpszText = (LPTSTR)MAKEINTRESOURCE(nID);
     else

--- a/GM/Resource.h
+++ b/GM/Resource.h
@@ -17,6 +17,7 @@
 #define IDS_ERR_BOARDNAME               129
 #define IDS_ERR_NOTAGAMEBOX             130
 #define IDS_ERR_GAMEBOXNEWER            131
+#define IDS_ERR_PIECESETSIZE            132
 #define IDP_DELETEBOARD                 133
 #define IDP_DELETETILESET               134
 #define IDP_DELETEPIECESET              135

--- a/GM/SelObjs.cpp
+++ b/GM/SelObjs.cpp
@@ -158,6 +158,7 @@ HCURSOR CSelRect::GetHandleCursor(int nHandleID) const
         case hitRight:
         case hitLeft:        id = IDC_SIZEWE;    break;
         default: ASSERT(FALSE);
+            id = nullptr;
     }
     return AfxGetApp()->LoadStandardCursor(id);
 }
@@ -183,6 +184,7 @@ CPoint CSelRect::GetHandleLoc(int nHandleID) const
         case hitBottom:      x = xCenter;      y = m_rect.bottom; break;
         case hitLeft:        x = m_rect.left;  y = yCenter;       break;
         default: ASSERT(FALSE);
+            x = -1; y = -1;
     }
     return CPoint(x, y);
 }
@@ -276,6 +278,7 @@ HCURSOR CSelLine::GetHandleCursor(int nHandleID) const
             id = IDC_CROSS;
             break;
         default: ASSERT(FALSE);
+            id = nullptr;
     }
     return AfxGetApp()->LoadStandardCursor(id);
 }
@@ -301,6 +304,7 @@ CPoint CSelLine::GetHandleLoc(int nHandleID) const
             }
             break;
         default: ASSERT(FALSE);
+            x = -1; y = -1;
     }
     return CPoint(x, y);
 }
@@ -477,6 +481,7 @@ CPoint CSelGeneric::GetHandleLoc(int nHandleID) const
         case hitBottomRight: x = m_rect.right; y = m_rect.bottom; break;
         case hitBottomLeft:  x = m_rect.left;  y = m_rect.bottom; break;
         default: ASSERT(FALSE);
+            x = -1; y = -1;
     }
     return CPoint(x, y);
 }

--- a/GM/ToolObjs.cpp
+++ b/GM/ToolObjs.cpp
@@ -205,7 +205,7 @@ void CSelectTool::OnMouseMove(CBrdEditView* pView, UINT nFlags, CPoint point)
             if (!rct.PtInRect(pt))
             {
                 // It's in the scroll zone
-                if (m_nTimerID == 0)        // Only start if not scrolling
+                if (m_nTimerID == uintptr_t(0))        // Only start if not scrolling
                     StartScrollTimer(pView);
             }
             else
@@ -338,7 +338,7 @@ void CSelectTool::OnLButtonUp(CBrdEditView* pView, UINT nFlags, CPoint point)
     CTool::OnLButtonUp(pView, nFlags, point);
 }
 
-void CSelectTool::OnTimer(CBrdEditView* pView, UINT nIDEvent)
+void CSelectTool::OnTimer(CBrdEditView* pView, uintptr_t nIDEvent)
 {
     if (CWnd::GetCapture() != pView)
     {
@@ -591,10 +591,10 @@ void CSelectTool::StartDragTimer(CBrdEditView* pView)
 
 void CSelectTool::KillDragTimer(CBrdEditView* pView)
 {
-    if (m_nTimerID != 0)
+    if (m_nTimerID != uintptr_t(0))
     {
         pView->KillTimer(m_nTimerID);
-        m_nTimerID = 0;
+        m_nTimerID = uintptr_t(0);
     }
 }
 
@@ -605,10 +605,10 @@ void CSelectTool::StartScrollTimer(CBrdEditView* pView)
 
 void CSelectTool::KillScrollTimer(CBrdEditView* pView)
 {
-    if (m_nTimerID != 0)
+    if (m_nTimerID != uintptr_t(0))
     {
         pView->KillTimer(m_nTimerID);
-        m_nTimerID = 0;
+        m_nTimerID = uintptr_t(0);
     }
 }
 
@@ -648,7 +648,7 @@ void CShapeTool::OnMouseMove(CBrdEditView* pView, UINT nFlags, CPoint point)
         s_selectTool.OnMouseMove(pView, nFlags, point);
 }
 
-void CShapeTool::OnTimer(CBrdEditView* pView, UINT nIDEvent)
+void CShapeTool::OnTimer(CBrdEditView* pView, uintptr_t nIDEvent)
 {
     s_selectTool.OnTimer(pView, nIDEvent);
 }

--- a/GM/ToolObjs.h
+++ b/GM/ToolObjs.h
@@ -60,7 +60,7 @@ public:
     virtual void OnLButtonDblClk(CBrdEditView* pView, UINT nFlags, CPoint point) {}
     virtual void OnLButtonUp(CBrdEditView* pView, UINT nFlags, CPoint point);
     virtual void OnMouseMove(CBrdEditView* pView, UINT nFlags, CPoint point);
-    virtual void OnTimer(CBrdEditView* pView, UINT nIDEvent) {}
+    virtual void OnTimer(CBrdEditView* pView, uintptr_t nIDEvent) /*override*/ {}
     virtual BOOL OnSetCursor(CBrdEditView* pView, UINT nHitTest)
         { return FALSE; }
 
@@ -81,7 +81,7 @@ class CSelectTool : public CTool
 {
 // Constructors
 public:
-    CSelectTool() : CTool(ttypeSelect) { m_nTimerID = 0; }
+    CSelectTool() : CTool(ttypeSelect) { m_nTimerID = uintptr_t(0); }
 
 // Attributes
 public:
@@ -97,12 +97,12 @@ public:
     virtual void OnLButtonDblClk(CBrdEditView* pView, UINT nFlags, CPoint point);
     virtual void OnLButtonUp(CBrdEditView* pView, UINT nFlags, CPoint point);
     virtual void OnMouseMove(CBrdEditView* pView, UINT nFlags, CPoint point);
-    virtual void OnTimer(CBrdEditView* pView, UINT nIDEvent);
+    virtual void OnTimer(CBrdEditView* pView, uintptr_t nIDEvent) override;
     virtual BOOL OnSetCursor(CBrdEditView* pView, UINT nHitTest);
 
 // Implementation
 public:
-    UINT    m_nTimerID;
+    uintptr_t m_nTimerID;
     CRect   m_rectMultiBorder;
     // ------- //
     BOOL ProcessAutoScroll(CBrdEditView* pView);
@@ -134,7 +134,7 @@ public:
     virtual void OnLButtonDblClk(CBrdEditView* pView, UINT nFlags, CPoint point) {}
     virtual void OnLButtonUp(CBrdEditView* pView, UINT nFlags, CPoint point);
     virtual void OnMouseMove(CBrdEditView* pView, UINT nFlags, CPoint point);
-    virtual void OnTimer(CBrdEditView* pView, UINT nIDEvent);
+    virtual void OnTimer(CBrdEditView* pView, uintptr_t nIDEvent) override;
     virtual BOOL OnSetCursor(CBrdEditView* pView, UINT nHitTest);
 
 // Implementation
@@ -209,7 +209,7 @@ public:
     virtual void OnLButtonDblClk(CBrdEditView* pView, UINT nFlags, CPoint point);
     virtual void OnLButtonUp(CBrdEditView* pView, UINT nFlags, CPoint point) {}
     virtual void OnMouseMove(CBrdEditView* pView, UINT nFlags, CPoint point);
-    virtual void OnTimer(CBrdEditView* pView, UINT nIDEvent) {}
+    virtual void OnTimer(CBrdEditView* pView, uintptr_t nIDEvent) override {}
     virtual BOOL OnSetCursor(CBrdEditView* pView, UINT nHitTest);
 
     // --------- //
@@ -238,7 +238,7 @@ public:
     virtual void OnLButtonDblClk(CBrdEditView* pView, UINT nFlags, CPoint point) {}
     virtual void OnLButtonUp(CBrdEditView* pView, UINT nFlags, CPoint point) {}
     virtual void OnMouseMove(CBrdEditView* pView, UINT nFlags, CPoint point) {}
-    virtual void OnTimer(CBrdEditView* pView, UINT nIDEvent) {}
+    virtual void OnTimer(CBrdEditView* pView, uintptr_t nIDEvent) override {}
     virtual BOOL OnSetCursor(CBrdEditView* pView, UINT nHitTest);
 
 // Implementation
@@ -260,7 +260,7 @@ public:
     virtual void OnLButtonDblClk(CBrdEditView* pView, UINT nFlags, CPoint point) {}
     virtual void OnLButtonUp(CBrdEditView* pView, UINT nFlags, CPoint point);
     virtual void OnMouseMove(CBrdEditView* pView, UINT nFlags, CPoint point) {}
-    virtual void OnTimer(CBrdEditView* pView, UINT nIDEvent) {}
+    virtual void OnTimer(CBrdEditView* pView, uintptr_t nIDEvent) override {}
     virtual BOOL OnSetCursor(CBrdEditView* pView, UINT nHitTest);
 
 // Implementation
@@ -282,7 +282,7 @@ public:
     virtual void OnLButtonDblClk(CBrdEditView* pView, UINT nFlags, CPoint point) {}
     virtual void OnLButtonUp(CBrdEditView* pView, UINT nFlags, CPoint point) {}
     virtual void OnMouseMove(CBrdEditView* pView, UINT nFlags, CPoint point);
-    virtual void OnTimer(CBrdEditView* pView, UINT nIDEvent) {}
+    virtual void OnTimer(CBrdEditView* pView, uintptr_t nIDEvent) override {}
     virtual BOOL OnSetCursor(CBrdEditView* pView, UINT nHitTest);
 
 // Implementation
@@ -304,7 +304,7 @@ public:
     virtual void OnLButtonDblClk(CBrdEditView* pView, UINT nFlags, CPoint point) {}
     virtual void OnLButtonUp(CBrdEditView* pView, UINT nFlags, CPoint point) {}
     virtual void OnMouseMove(CBrdEditView* pView, UINT nFlags, CPoint point);
-    virtual void OnTimer(CBrdEditView* pView, UINT nIDEvent) {}
+    virtual void OnTimer(CBrdEditView* pView, uintptr_t nIDEvent) override {}
     virtual BOOL OnSetCursor(CBrdEditView* pView, UINT nHitTest);
 
 // Implementation
@@ -326,7 +326,7 @@ public:
     virtual void OnLButtonDblClk(CBrdEditView* pView, UINT nFlags, CPoint point) {}
     virtual void OnLButtonUp(CBrdEditView* pView, UINT nFlags, CPoint point) {}
     virtual void OnMouseMove(CBrdEditView* pView, UINT nFlags, CPoint point) {}
-    virtual void OnTimer(CBrdEditView* pView, UINT nIDEvent) {}
+    virtual void OnTimer(CBrdEditView* pView, uintptr_t nIDEvent) override {}
     virtual BOOL OnSetCursor(CBrdEditView* pView, UINT nHitTest);
 
 // Implementation
@@ -348,7 +348,7 @@ public:
     virtual void OnLButtonDblClk(CBrdEditView* pView, UINT nFlags, CPoint point) {}
     virtual void OnLButtonUp(CBrdEditView* pView, UINT nFlags, CPoint point) {}
     virtual void OnMouseMove(CBrdEditView* pView, UINT nFlags, CPoint point);
-    virtual void OnTimer(CBrdEditView* pView, UINT nIDEvent) {}
+    virtual void OnTimer(CBrdEditView* pView, uintptr_t nIDEvent) override {}
     virtual BOOL OnSetCursor(CBrdEditView* pView, UINT nHitTest);
 
 // Implementation

--- a/GM/VwBitedt.cpp
+++ b/GM/VwBitedt.cpp
@@ -854,7 +854,7 @@ void CBitEditView::OnChar(UINT nChar, UINT nRepCnt, UINT nFlags)
     if (m_nCurToolID == ID_ITOOL_TEXT)
     {
         if (nChar != VK_BACK)
-            AddChar(nChar);
+            AddChar(value_preserving_cast<char>(nChar));
         else
             DelChar();
     }

--- a/GM/VwBitedt.cpp
+++ b/GM/VwBitedt.cpp
@@ -1142,14 +1142,13 @@ void CBitEditView::OnImageBoardMask()
 
     CBoard& pBoard = pBMgr->GetBoard(dlg.m_nBrdNum);
 
-    CCellForm* pcf = pBoard.GetBoardArray()->
+    CCellForm& pcf = pBoard.GetBoardArray()->
         GetCellForm(m_pSelView->GetCurrentScale());
-    ASSERT(pcf);
 
-    CSize size = pcf->GetCellSize();
+    CSize size = pcf.GetCellSize();
     g_gt.mDC1.SelectObject(&m_bmView);
 
-    CBitmap* pMask = pcf->GetMask();
+    CBitmap* pMask = pcf.GetMask();
 
     if (pMask != NULL)
     {

--- a/GM/VwEdtbrd.cpp
+++ b/GM/VwEdtbrd.cpp
@@ -914,7 +914,7 @@ void CBrdEditView::SetDrawingTile(CDrawList* pDwg, TileID tid, CPoint pnt,
 
 void CBrdEditView::SetCellTile(TileID tid, CPoint pnt, BOOL bUpdate)
 {
-    int row, col;
+    size_t row, col;
 
     CBoardArray* pBa = m_pBoard->GetBoardArray();
     ASSERT(pBa != NULL);
@@ -924,7 +924,7 @@ void CBrdEditView::SetCellTile(TileID tid, CPoint pnt, BOOL bUpdate)
 
     if (!pBa->FindCell(pnt.x, pnt.y, row, col, m_nZoom))
         return;                                 // Not a valid cell hit
-    if (tid != pBa->GetCellTile(row, col))
+    if (tid != pBa->GetCellTile(value_preserving_cast<size_t>(row), value_preserving_cast<size_t>(col)))
     {
         pBa->SetCellTile(row, col, tid);
         if (bUpdate)
@@ -940,7 +940,7 @@ void CBrdEditView::SetCellTile(TileID tid, CPoint pnt, BOOL bUpdate)
 
 void CBrdEditView::SetCellColor(COLORREF crCell, CPoint pnt, BOOL bUpdate)
 {
-    int row, col;
+    size_t row, col;
 
     CBoardArray* pBa = m_pBoard->GetBoardArray();
     ASSERT(pBa != NULL);

--- a/GM/VwEdtbrd.cpp
+++ b/GM/VwEdtbrd.cpp
@@ -2184,7 +2184,7 @@ BOOL CBrdEditView::DoMouseWheelFix(UINT fFlags, short zDelta, CPoint point)
 
     if (bWin98 || bWinME)
     {
-        static UINT uWheelScrollLines = -1;
+        static UINT uWheelScrollLines = UINT(-1);
         if ((int)uWheelScrollLines < 0)
             ::SystemParametersInfo(SPI_GETWHEELSCROLLLINES, 0, &uWheelScrollLines, 0);
 

--- a/GM/VwEdtbrd.cpp
+++ b/GM/VwEdtbrd.cpp
@@ -622,6 +622,11 @@ void CBrdEditView::OnContextMenu(CWnd* pWnd, CPoint point)
 void CBrdEditView::OnLButtonDown(UINT nFlags, CPoint point)
 {
     ToolType eToolType = MapToolType(m_nCurToolID);
+    if (eToolType == ttypeUnknown)
+    {
+        CScrollView::OnMouseMove(nFlags, point);
+        return;
+    }
     CTool& pTool = CTool::GetTool(eToolType);
     ClientToWorkspace(point);
     pTool.OnLButtonDown(this, nFlags, point);
@@ -630,6 +635,11 @@ void CBrdEditView::OnLButtonDown(UINT nFlags, CPoint point)
 void CBrdEditView::OnMouseMove(UINT nFlags, CPoint point)
 {
     ToolType eToolType = MapToolType(m_nCurToolID);
+    if (eToolType == ttypeUnknown)
+    {
+        CScrollView::OnMouseMove(nFlags, point);
+        return;
+    }
     CTool& pTool = CTool::GetTool(eToolType);
     ClientToWorkspace(point);
     pTool.OnMouseMove(this, nFlags, point);
@@ -638,6 +648,11 @@ void CBrdEditView::OnMouseMove(UINT nFlags, CPoint point)
 void CBrdEditView::OnLButtonUp(UINT nFlags, CPoint point)
 {
     ToolType eToolType = MapToolType(m_nCurToolID);
+    if (eToolType == ttypeUnknown)
+    {
+        CScrollView::OnMouseMove(nFlags, point);
+        return;
+    }
     CTool& pTool = CTool::GetTool(eToolType);
     ClientToWorkspace(point);
     pTool.OnLButtonUp(this, nFlags, point);
@@ -646,6 +661,11 @@ void CBrdEditView::OnLButtonUp(UINT nFlags, CPoint point)
 void CBrdEditView::OnLButtonDblClk(UINT nFlags, CPoint point)
 {
     ToolType eToolType = MapToolType(m_nCurToolID);
+    if (eToolType == ttypeUnknown)
+    {
+        CScrollView::OnMouseMove(nFlags, point);
+        return;
+    }
     CTool& pTool = CTool::GetTool(eToolType);
     ClientToWorkspace(point);
     pTool.OnLButtonDblClk(this, nFlags, point);

--- a/GM/VwEdtbrd.cpp
+++ b/GM/VwEdtbrd.cpp
@@ -216,7 +216,7 @@ void CBrdEditView::OnDraw(CDC* pDC)
     CBitmap bmMem;
     CRect oRct;
     CDC* pDrawDC = pDC;
-    CBitmap* pPrvBMap;
+    CBitmap* pPrvBMap = nullptr;
 
     pDC->GetClipBox(&oRct);
     if (oRct.IsRectEmpty())
@@ -1343,6 +1343,9 @@ void CBrdEditView::OnUpdateToolPalette(CCmdUI* pCmdUI)
         case ID_TOOL_OVAL:
             bEnable = iLayer == LAYER_BASE || iLayer == LAYER_TOP;
             break;
+        default:
+            ASSERT(!"unexpected tool id");
+            bEnable = false;
     }
     if (pCmdUI->m_pSubMenu != NULL)
     {

--- a/GM/VwEdtbrd.cpp
+++ b/GM/VwEdtbrd.cpp
@@ -651,7 +651,7 @@ void CBrdEditView::OnLButtonDblClk(UINT nFlags, CPoint point)
     pTool.OnLButtonDblClk(this, nFlags, point);
 }
 
-void CBrdEditView::OnTimer(UINT nIDEvent)
+void CBrdEditView::OnTimer(uintptr_t nIDEvent)
 {
     ToolType eToolType = MapToolType(m_nCurToolID);
     CTool& pTool = CTool::GetTool(eToolType);

--- a/GM/VwEdtbrd.h
+++ b/GM/VwEdtbrd.h
@@ -202,7 +202,7 @@ protected:
     afx_msg void OnLButtonUp(UINT nFlags, CPoint point);
     afx_msg void OnMouseMove(UINT nFlags, CPoint point);
     afx_msg void OnLButtonDblClk(UINT nFlags, CPoint point);
-    afx_msg void OnTimer(UINT nIDEvent);
+    afx_msg void OnTimer(uintptr_t nIDEvent);
     afx_msg void OnKeyDown(UINT nChar, UINT nRepCnt, UINT nFlags);
     afx_msg void OnChar(UINT nChar, UINT nRepCnt, UINT nFlags);
     afx_msg BOOL OnSetCursor(CWnd* pWnd, UINT nHitTest, UINT message);

--- a/GP/CBPlay32.vcxproj
+++ b/GP/CBPlay32.vcxproj
@@ -13,7 +13,6 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{2A0A2247-0569-4973-8E0D-8A3DF0B66A43}</ProjectGuid>
     <Keyword>MFCProj</Keyword>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
     <ProjectName>CBPlay</ProjectName>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
@@ -45,14 +44,12 @@
     <_ProjectFileVersion>11.0.50727.1</_ProjectFileVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
-    <OutDir>.\Release\</OutDir>
-    <IntDir>.\Release\</IntDir>
     <LinkIncremental>false</LinkIncremental>
+    <CustomBuildAfterTargets>BuildLink</CustomBuildAfterTargets>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-    <OutDir>.\Debug\</OutDir>
-    <IntDir>.\Debug\</IntDir>
     <LinkIncremental>true</LinkIncremental>
+    <CustomBuildAfterTargets>BuildLink</CustomBuildAfterTargets>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <CustomBuildStep>
@@ -67,6 +64,7 @@ copy ..\GHelp\CBoard.chm $(TargetDir)cboard.chm
 echo off
 </Command>
       <Outputs>$(TargetDir)cboard.chm;%(Outputs)</Outputs>
+      <Inputs>$(TargetPath);%(Inputs)</Inputs>
     </CustomBuildStep>
     <Midl>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -84,31 +82,21 @@ echo off
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>stdafx.h</PrecompiledHeaderFile>
-      <PrecompiledHeaderOutputFile>.\Release/Cbplay32.pch</PrecompiledHeaderOutputFile>
-      <AssemblerListingLocation>.\Release/</AssemblerListingLocation>
-      <ObjectFileName>.\Release/</ObjectFileName>
-      <ProgramDataBaseFileName>.\Release/</ProgramDataBaseFileName>
       <WarningLevel>Level3</WarningLevel>
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
-      <CompileAs>Default</CompileAs>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <Culture>0x0409</Culture>
-      <AdditionalIncludeDirectories>..\..\..\XtremeToolkit\Include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ResourceCompile>
     <Link>
-      <AdditionalOptions>/MACHINE:I386 %(AdditionalOptions)</AdditionalOptions>
       <AdditionalDependencies>htmlhelp.lib;gdiplus.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <OutputFile>Release/CBPlay.exe</OutputFile>
       <SuppressStartupBanner>true</SuppressStartupBanner>
-      <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <ProgramDatabaseFile>.\Release/CBPlay.pdb</ProgramDatabaseFile>
-      <SubSystem>Windows</SubSystem>
       <RandomizedBaseAddress>false</RandomizedBaseAddress>
       <DataExecutionPrevention />
+      <SubSystem>Windows</SubSystem>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
@@ -124,6 +112,7 @@ copy ..\GHelp\CBoard.chm $(TargetDir)cboard.chm
 echo off
 </Command>
       <Outputs>$(TargetDir)cboard.chm;%(Outputs)</Outputs>
+      <Inputs>$(TargetPath);%(Inputs)</Inputs>
     </CustomBuildStep>
     <Midl>
       <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -140,32 +129,22 @@ echo off
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>stdafx.h</PrecompiledHeaderFile>
-      <PrecompiledHeaderOutputFile>.\Debug/Cbplay32.pch</PrecompiledHeaderOutputFile>
-      <AssemblerListingLocation>.\Debug/</AssemblerListingLocation>
-      <ObjectFileName>.\Debug/</ObjectFileName>
-      <ProgramDataBaseFileName>.\Debug/</ProgramDataBaseFileName>
       <BrowseInformation>true</BrowseInformation>
       <WarningLevel>Level3</WarningLevel>
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
-      <CompileAs>Default</CompileAs>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <Culture>0x0409</Culture>
-      <AdditionalIncludeDirectories>..\..\..\XtremeToolkit\Include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ResourceCompile>
     <Link>
-      <AdditionalOptions>/MACHINE:I386 %(AdditionalOptions)</AdditionalOptions>
       <AdditionalDependencies>htmlhelp.lib;gdiplus.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <OutputFile>$(TargetPath)</OutputFile>
       <SuppressStartupBanner>true</SuppressStartupBanner>
-      <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <ProgramDatabaseFile>.\Debug/CBPlay.pdb</ProgramDatabaseFile>
-      <SubSystem>Windows</SubSystem>
       <RandomizedBaseAddress>false</RandomizedBaseAddress>
       <DataExecutionPrevention />
+      <SubSystem>Windows</SubSystem>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/GP/CBPlay32.vcxproj
+++ b/GP/CBPlay32.vcxproj
@@ -5,9 +5,17 @@
       <Configuration>Debug</Configuration>
       <Platform>Win32</Platform>
     </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
     <ProjectConfiguration Include="Release|Win32">
       <Configuration>Release</Configuration>
       <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
@@ -22,7 +30,19 @@
     <UseOfMfc>Static</UseOfMfc>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <PlatformToolset>v142</PlatformToolset>
+    <UseOfMfc>Static</UseOfMfc>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <PlatformToolset>v142</PlatformToolset>
+    <UseOfMfc>Static</UseOfMfc>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <PlatformToolset>v142</PlatformToolset>
     <UseOfMfc>Static</UseOfMfc>
@@ -35,7 +55,15 @@
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
     <Import Project="$(VCTargetsPath)Microsoft.CPP.UpgradeFromVC71.props" />
   </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="$(VCTargetsPath)Microsoft.CPP.UpgradeFromVC71.props" />
+  </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="$(VCTargetsPath)Microsoft.CPP.UpgradeFromVC71.props" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
     <Import Project="$(VCTargetsPath)Microsoft.CPP.UpgradeFromVC71.props" />
   </ImportGroup>
@@ -47,7 +75,15 @@
     <LinkIncremental>false</LinkIncremental>
     <CustomBuildAfterTargets>BuildLink</CustomBuildAfterTargets>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <LinkIncremental>false</LinkIncremental>
+    <CustomBuildAfterTargets>BuildLink</CustomBuildAfterTargets>
+  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+    <CustomBuildAfterTargets>BuildLink</CustomBuildAfterTargets>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <LinkIncremental>true</LinkIncremental>
     <CustomBuildAfterTargets>BuildLink</CustomBuildAfterTargets>
   </PropertyGroup>
@@ -99,6 +135,54 @@ echo off
       <SubSystem>Windows</SubSystem>
     </Link>
   </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <CustomBuildStep>
+      <Message>Build HTML Help</Message>
+      <Command>makehm IDR_,IDH_R_,0x20000 resource.h &gt;"gphelpidmap.h"
+makehm ID_,IDH_,0x10000 IDM_,IDH_M_,0x10000 resource.h &gt;&gt;"gphelpidmap.h"
+..\ghelp\makeidh gphelpidmap.h
+copy $(ProjectDir)gphelpidmap.h ..\GHelp\*.*
+copy $(ProjectDir)gphelp.h ..\GHelp\*.*
+hhc.exe ..\GHelp\CBoard.hhp
+copy ..\GHelp\CBoard.chm $(TargetDir)cboard.chm
+echo off
+</Command>
+      <Outputs>$(TargetDir)cboard.chm;%(Outputs)</Outputs>
+      <Inputs>$(TargetPath);%(Inputs)</Inputs>
+    </CustomBuildStep>
+    <Midl>
+      <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <MkTypLibCompatible>true</MkTypLibCompatible>
+      <SuppressStartupBanner>true</SuppressStartupBanner>
+      <TypeLibraryName>.\Release/Cbplay32.tlb</TypeLibraryName>
+    </Midl>
+    <ClCompile>
+      <InlineFunctionExpansion>OnlyExplicitInline</InlineFunctionExpansion>
+      <AdditionalIncludeDirectories>$(VCToolsInstallDir)atlmfc\src\mfc;..\zLib;..\gshr;.;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>NDEBUG;WIN32;_WINDOWS;GPLAY;_AFX_SECURE_NO_WARNINGS;_ATL_SECURE_NO_WARNINGS;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <StringPooling>true</StringPooling>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <PrecompiledHeaderFile>stdafx.h</PrecompiledHeaderFile>
+      <WarningLevel>Level4</WarningLevel>
+      <SuppressStartupBanner>true</SuppressStartupBanner>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+    </ClCompile>
+    <ResourceCompile>
+      <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <Culture>0x0409</Culture>
+    </ResourceCompile>
+    <Link>
+      <AdditionalDependencies>htmlhelp.lib;gdiplus.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <SuppressStartupBanner>true</SuppressStartupBanner>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <RandomizedBaseAddress>false</RandomizedBaseAddress>
+      <DataExecutionPrevention>
+      </DataExecutionPrevention>
+      <SubSystem>Windows</SubSystem>
+    </Link>
+  </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <CustomBuildStep>
       <Message>Build HTML Help</Message>
@@ -144,6 +228,54 @@ echo off
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <RandomizedBaseAddress>false</RandomizedBaseAddress>
       <DataExecutionPrevention />
+      <SubSystem>Windows</SubSystem>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <CustomBuildStep>
+      <Message>Build HTML Help</Message>
+      <Command>makehm IDR_,IDH_R_,0x20000 resource.h &gt;"gphelpidmap.h"
+makehm ID_,IDH_,0x10000 IDM_,IDH_M_,0x10000 resource.h &gt;&gt;"gphelpidmap.h"
+..\ghelp\makeidh gphelpidmap.h
+copy $(ProjectDir)gphelpidmap.h ..\GHelp\*.*
+copy $(ProjectDir)gphelp.h ..\GHelp\*.*
+hhc.exe ..\GHelp\CBoard.hhp
+copy ..\GHelp\CBoard.chm $(TargetDir)cboard.chm
+echo off
+</Command>
+      <Outputs>$(TargetDir)cboard.chm;%(Outputs)</Outputs>
+      <Inputs>$(TargetPath);%(Inputs)</Inputs>
+    </CustomBuildStep>
+    <Midl>
+      <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <MkTypLibCompatible>true</MkTypLibCompatible>
+      <SuppressStartupBanner>true</SuppressStartupBanner>
+      <TypeLibraryName>.\Debug/Cbplay32.tlb</TypeLibraryName>
+    </Midl>
+    <ClCompile>
+      <Optimization>Disabled</Optimization>
+      <AdditionalIncludeDirectories>$(VCToolsInstallDir)atlmfc\src\mfc;..\zLib;..\gshr;.;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>_DEBUG;WIN32;_WINDOWS;GPLAY;_AFX_SECURE_NO_WARNINGS;_ATL_SECURE_NO_WARNINGS;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <PrecompiledHeaderFile>stdafx.h</PrecompiledHeaderFile>
+      <BrowseInformation>true</BrowseInformation>
+      <WarningLevel>Level4</WarningLevel>
+      <SuppressStartupBanner>true</SuppressStartupBanner>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+    </ClCompile>
+    <ResourceCompile>
+      <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <Culture>0x0409</Culture>
+    </ResourceCompile>
+    <Link>
+      <AdditionalDependencies>htmlhelp.lib;gdiplus.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <SuppressStartupBanner>true</SuppressStartupBanner>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <RandomizedBaseAddress>false</RandomizedBaseAddress>
+      <DataExecutionPrevention>
+      </DataExecutionPrevention>
       <SubSystem>Windows</SubSystem>
     </Link>
   </ItemDefinitionGroup>
@@ -228,7 +360,9 @@ echo off
     <ClCompile Include="SelOPlay.cpp" />
     <ClCompile Include="StdAfx.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Create</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Create</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Create</PrecompiledHeader>
     </ClCompile>
     <ClCompile Include="..\GShr\StrLib.cpp" />
     <ClCompile Include="..\GShr\Tile.cpp" />

--- a/GP/CBPlay32.vcxproj
+++ b/GP/CBPlay32.vcxproj
@@ -82,7 +82,7 @@ echo off
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>stdafx.h</PrecompiledHeaderFile>
-      <WarningLevel>Level3</WarningLevel>
+      <WarningLevel>Level4</WarningLevel>
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
@@ -130,7 +130,7 @@ echo off
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>stdafx.h</PrecompiledHeaderFile>
       <BrowseInformation>true</BrowseInformation>
-      <WarningLevel>Level3</WarningLevel>
+      <WarningLevel>Level4</WarningLevel>
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
     </ClCompile>

--- a/GP/DlgNPly.cpp
+++ b/GP/DlgNPly.cpp
@@ -39,7 +39,7 @@ CCreatePlayersDialog::CCreatePlayersDialog(CWnd* pParent /*=NULL*/)
     : CDialog(CCreatePlayersDialog::IDD, pParent)
 {
     //{{AFX_DATA_INIT(CCreatePlayersDialog)
-    m_nPlayerCount = 0;
+    m_nPlayerCount = size_t(0);
     //}}AFX_DATA_INIT
 }
 
@@ -48,7 +48,7 @@ void CCreatePlayersDialog::DoDataExchange(CDataExchange* pDX)
     CDialog::DoDataExchange(pDX);
     //{{AFX_DATA_MAP(CCreatePlayersDialog)
     DDX_Text(pDX, IDC_D_CPLAY_NUM_PLAYERS, m_nPlayerCount);
-    DDV_MinMaxInt(pDX, m_nPlayerCount, 0, 26);
+    DDV_MinMaxUInt(pDX, value_preserving_cast<unsigned>(m_nPlayerCount), 0, 26);
     //}}AFX_DATA_MAP
 }
 

--- a/GP/DlgNPly.h
+++ b/GP/DlgNPly.h
@@ -41,7 +41,7 @@ public:
 // Dialog Data
     //{{AFX_DATA(CCreatePlayersDialog)
     enum { IDD = IDD_CREATE_PLAYERS };
-    int     m_nPlayerCount;
+    size_t m_nPlayerCount;
     //}}AFX_DATA
 
 

--- a/GP/DlgNewGeoBoard.cpp
+++ b/GP/DlgNewGeoBoard.cpp
@@ -116,10 +116,10 @@ void CCreateGeomorphicBoardDialog::LoadBoardListWithCompliantBoards()
     {
         CBoard& pBrd = pBMgr->GetBoard(i);
         CBoardArray* pBArray = pBrd.GetBoardArray();
-        CCellForm* pCellForm = pBArray->GetCellForm(fullScale);
+        CCellForm& pCellForm = pBArray->GetCellForm(fullScale);
 
-        if (!(pCellForm->GetCellType() == cformHexFlat && (pBArray->GetCols() & size_t(1)) != size_t(0) ||
-              pCellForm->GetCellType() == cformHexPnt && (pBArray->GetRows() & size_t(1)) != size_t(0)))
+        if (!(pCellForm.GetCellType() == cformHexFlat && (pBArray->GetCols() & size_t(1)) != size_t(0) ||
+              pCellForm.GetCellType() == cformHexPnt && (pBArray->GetRows() & size_t(1)) != size_t(0)))
             continue;                           // These maps aren't compliant at all
         if (static_cast<BoardID::UNDERLYING_TYPE>(pBrd.GetSerialNumber()) >= GEO_BOARD_SERNUM_BASE)
             continue;                           // Can't build geo maps from geo maps
@@ -128,7 +128,7 @@ void CCreateGeomorphicBoardDialog::LoadBoardListWithCompliantBoards()
         {
             // Already have at least one map selected. The rest must
             // comply with the geometry of the root one.
-            if (!m_pRootMapCellForm->CompareEqual(*pCellForm))
+            if (!m_pRootMapCellForm->CompareEqual(pCellForm))
                 continue;
             if (m_nMaxColumns != size_t(0) && m_tblColWidth[m_nCurrentColumn] != pBArray->GetCols())
                 continue;
@@ -213,7 +213,7 @@ void CCreateGeomorphicBoardDialog::OnBtnPressedAddBoard()
     ASSERT(nBrdNum != Invalid_v<size_t>);
     CBoard& pBrd = pBMgr->GetBoard(nBrdNum);
     CBoardArray* pBArray = pBrd.GetBoardArray();
-    m_pRootMapCellForm = pBArray->GetCellForm(fullScale);
+    m_pRootMapCellForm = &pBArray->GetCellForm(fullScale);
 
     if (m_nMaxColumns == size_t(0))
         m_tblColWidth.push_back(pBArray->GetCols());

--- a/GP/DlgNewGeoBoard.cpp
+++ b/GP/DlgNewGeoBoard.cpp
@@ -48,7 +48,7 @@ CCreateGeomorphicBoardDialog::CCreateGeomorphicBoardDialog(CWnd* pParent /*=NULL
     m_pDoc = NULL;
     m_pGeoBoard = NULL;
     m_pRootMapCellForm = NULL;
-    m_nCurrentRowHeight = 0;
+    m_nCurrentRowHeight = size_t(0);
     m_nCurrentColumn = size_t(0);
     m_nMaxColumns = size_t(0);
     m_nRowNumber = size_t(0);
@@ -118,8 +118,8 @@ void CCreateGeomorphicBoardDialog::LoadBoardListWithCompliantBoards()
         CBoardArray* pBArray = pBrd.GetBoardArray();
         CCellForm* pCellForm = pBArray->GetCellForm(fullScale);
 
-        if (!(pCellForm->GetCellType() == cformHexFlat && (pBArray->GetCols() & 1) != 0 ||
-              pCellForm->GetCellType() == cformHexPnt && (pBArray->GetRows() & 1) != 0))
+        if (!(pCellForm->GetCellType() == cformHexFlat && (pBArray->GetCols() & size_t(1)) != size_t(0) ||
+              pCellForm->GetCellType() == cformHexPnt && (pBArray->GetRows() & size_t(1)) != size_t(0)))
             continue;                           // These maps aren't compliant at all
         if (static_cast<BoardID::UNDERLYING_TYPE>(pBrd.GetSerialNumber()) >= GEO_BOARD_SERNUM_BASE)
             continue;                           // Can't build geo maps from geo maps
@@ -130,7 +130,7 @@ void CCreateGeomorphicBoardDialog::LoadBoardListWithCompliantBoards()
             // comply with the geometry of the root one.
             if (!m_pRootMapCellForm->CompareEqual(*pCellForm))
                 continue;
-            if (m_nMaxColumns != size_t(0) && m_tblColWidth[value_preserving_cast<INT_PTR>(m_nCurrentColumn)] != pBArray->GetCols())
+            if (m_nMaxColumns != size_t(0) && m_tblColWidth[m_nCurrentColumn] != pBArray->GetCols())
                 continue;
             if (m_nCurrentColumn > size_t(0) && pBArray->GetRows() != m_nCurrentRowHeight)
                 continue;
@@ -155,7 +155,7 @@ void CCreateGeomorphicBoardDialog::UpdateButtons()
         m_btnAddBreak.EnableWindow(FALSE);
         m_btnAddBoard.EnableWindow(m_listBoard.GetCurSel() >= 0);
     }
-    else if (m_nMaxColumns == size_t(0) && m_tblColWidth.GetSize() > 0)
+    else if (m_nMaxColumns == size_t(0) && !m_tblColWidth.empty())
     {
         // At least one column but no row break yet. Allow anything.
         m_btnAddBreak.EnableWindow(TRUE);
@@ -216,9 +216,9 @@ void CCreateGeomorphicBoardDialog::OnBtnPressedAddBoard()
     m_pRootMapCellForm = pBArray->GetCellForm(fullScale);
 
     if (m_nMaxColumns == size_t(0))
-        m_tblColWidth.Add(pBArray->GetCols());
+        m_tblColWidth.push_back(pBArray->GetCols());
 
-    if (m_nCurrentRowHeight == 0)
+    if (m_nCurrentRowHeight == size_t(0))
         m_nCurrentRowHeight = pBArray->GetRows();
 
     CString strLabel = pBrd.GetName();
@@ -232,7 +232,7 @@ void CCreateGeomorphicBoardDialog::OnBtnPressedAddBoard()
         m_btnAddBoard.EnableWindow(FALSE);
         m_btnAddBreak.EnableWindow(TRUE);
     }
-    else if (m_nMaxColumns == size_t(0) && m_tblColWidth.GetSize() > 0)
+    else if (m_nMaxColumns == size_t(0) && !m_tblColWidth.empty())
         m_btnAddBreak.EnableWindow(TRUE);
 
     LoadBoardListWithCompliantBoards();
@@ -247,10 +247,10 @@ void CCreateGeomorphicBoardDialog::OnBtnPressedAddBreak()
     int nItem = m_listGeo.AddString(str);
     m_listGeo.SetItemData(nItem, value_preserving_cast<DWORD_PTR>(static_cast<BoardID::UNDERLYING_TYPE>(nullBid)));
 
-    m_nMaxColumns = value_preserving_cast<size_t>(m_tblColWidth.GetSize());
+    m_nMaxColumns = m_tblColWidth.size();
     m_nRowNumber++;
     m_nCurrentColumn = size_t(0);
-    m_nCurrentRowHeight = 0;
+    m_nCurrentRowHeight = size_t(0);
 
     LoadBoardListWithCompliantBoards();
     UpdateButtons();
@@ -261,10 +261,10 @@ void CCreateGeomorphicBoardDialog::OnBtnPressClear()
     m_listGeo.ResetContent();
     m_nMaxColumns = size_t(0);
     m_nCurrentColumn = size_t(0);
-    m_nCurrentRowHeight = 0;
+    m_nCurrentRowHeight = size_t(0);
     m_nRowNumber = size_t(0);
     m_pRootMapCellForm = NULL;
-    m_tblColWidth.RemoveAll();
+    m_tblColWidth.clear();
 
     LoadBoardListWithCompliantBoards();
     UpdateButtons();
@@ -292,7 +292,7 @@ void CCreateGeomorphicBoardDialog::OnOK()
     m_pGeoBoard->SetSerialNumber(m_pDoc->GetPBoardManager()->IssueGeoSerialNumber());
 
     m_pGeoBoard->SetBoardRowCount(m_nRowNumber + size_t(1));
-    m_pGeoBoard->SetBoardColCount(value_preserving_cast<size_t>(m_tblColWidth.GetSize()));
+    m_pGeoBoard->SetBoardColCount(m_tblColWidth.size());
 
     for (int i = 0; i < m_listGeo.GetCount(); i++)
     {

--- a/GP/DlgNewGeoBoard.cpp
+++ b/GP/DlgNewGeoBoard.cpp
@@ -49,9 +49,9 @@ CCreateGeomorphicBoardDialog::CCreateGeomorphicBoardDialog(CWnd* pParent /*=NULL
     m_pGeoBoard = NULL;
     m_pRootMapCellForm = NULL;
     m_nCurrentRowHeight = 0;
-    m_nCurrentColumn = 0;
-    m_nMaxColumns = 0;
-    m_nRowNumber = 0;
+    m_nCurrentColumn = size_t(0);
+    m_nMaxColumns = size_t(0);
+    m_nRowNumber = size_t(0);
 }
 
 /////////////////////////////////////////////////////////////////////////////
@@ -105,7 +105,7 @@ static DWORD adwHelpMap[] =
 void CCreateGeomorphicBoardDialog::LoadBoardListWithCompliantBoards()
 {
     m_listBoard.ResetContent();
-    if (m_nMaxColumns != 0 && m_nCurrentColumn == m_nMaxColumns)
+    if (m_nMaxColumns != size_t(0) && m_nCurrentColumn == m_nMaxColumns)
         return;               // No boards allowed since row break is only option
 
     // All boards must use hexes and have an odd number of columns
@@ -130,9 +130,9 @@ void CCreateGeomorphicBoardDialog::LoadBoardListWithCompliantBoards()
             // comply with the geometry of the root one.
             if (!m_pRootMapCellForm->CompareEqual(*pCellForm))
                 continue;
-            if (m_nMaxColumns != 0 && m_tblColWidth[m_nCurrentColumn] != pBArray->GetCols())
+            if (m_nMaxColumns != size_t(0) && m_tblColWidth[value_preserving_cast<INT_PTR>(m_nCurrentColumn)] != pBArray->GetCols())
                 continue;
-            if (m_nCurrentColumn > 0 && pBArray->GetRows() != m_nCurrentRowHeight)
+            if (m_nCurrentColumn > size_t(0) && pBArray->GetRows() != m_nCurrentRowHeight)
                 continue;
         }
         int nItem = m_listBoard.AddString(pBrd.GetName());
@@ -144,9 +144,9 @@ void CCreateGeomorphicBoardDialog::LoadBoardListWithCompliantBoards()
 
 void CCreateGeomorphicBoardDialog::UpdateButtons()
 {
-    BOOL bEnableOK = m_editBoardName.GetWindowTextLength() > 0 &&
-         m_listGeo.GetCount() > 0 &&
-        (m_nCurrentColumn == m_nMaxColumns || m_nMaxColumns == 0);
+    BOOL bEnableOK = m_editBoardName.GetWindowTextLength() > size_t(0) &&
+         m_listGeo.GetCount() > size_t(0) &&
+        (m_nCurrentColumn == m_nMaxColumns || m_nMaxColumns == size_t(0));
     m_btnOK.EnableWindow(bEnableOK);
 
     if (m_pRootMapCellForm == NULL)
@@ -155,13 +155,13 @@ void CCreateGeomorphicBoardDialog::UpdateButtons()
         m_btnAddBreak.EnableWindow(FALSE);
         m_btnAddBoard.EnableWindow(m_listBoard.GetCurSel() >= 0);
     }
-    else if (m_nMaxColumns == 0 && m_tblColWidth.GetSize() > 0)
+    else if (m_nMaxColumns == size_t(0) && m_tblColWidth.GetSize() > 0)
     {
         // At least one column but no row break yet. Allow anything.
         m_btnAddBreak.EnableWindow(TRUE);
         m_btnAddBoard.EnableWindow(m_listBoard.GetCurSel() >= 0);
     }
-    else if (m_nMaxColumns > 0 && m_nCurrentColumn == m_nMaxColumns)
+    else if (m_nMaxColumns > size_t(0) && m_nCurrentColumn == m_nMaxColumns)
     {
         m_btnAddBreak.EnableWindow(TRUE);
         m_btnAddBoard.EnableWindow(FALSE);
@@ -215,7 +215,7 @@ void CCreateGeomorphicBoardDialog::OnBtnPressedAddBoard()
     CBoardArray* pBArray = pBrd.GetBoardArray();
     m_pRootMapCellForm = pBArray->GetCellForm(fullScale);
 
-    if (m_nMaxColumns == 0)
+    if (m_nMaxColumns == size_t(0))
         m_tblColWidth.Add(pBArray->GetCols());
 
     if (m_nCurrentRowHeight == 0)
@@ -232,7 +232,7 @@ void CCreateGeomorphicBoardDialog::OnBtnPressedAddBoard()
         m_btnAddBoard.EnableWindow(FALSE);
         m_btnAddBreak.EnableWindow(TRUE);
     }
-    else if (m_nMaxColumns == 0 && m_tblColWidth.GetSize() > 0)
+    else if (m_nMaxColumns == size_t(0) && m_tblColWidth.GetSize() > 0)
         m_btnAddBreak.EnableWindow(TRUE);
 
     LoadBoardListWithCompliantBoards();
@@ -247,9 +247,9 @@ void CCreateGeomorphicBoardDialog::OnBtnPressedAddBreak()
     int nItem = m_listGeo.AddString(str);
     m_listGeo.SetItemData(nItem, value_preserving_cast<DWORD_PTR>(static_cast<BoardID::UNDERLYING_TYPE>(nullBid)));
 
-    m_nMaxColumns = m_tblColWidth.GetSize();
+    m_nMaxColumns = value_preserving_cast<size_t>(m_tblColWidth.GetSize());
     m_nRowNumber++;
-    m_nCurrentColumn = 0;
+    m_nCurrentColumn = size_t(0);
     m_nCurrentRowHeight = 0;
 
     LoadBoardListWithCompliantBoards();
@@ -259,10 +259,10 @@ void CCreateGeomorphicBoardDialog::OnBtnPressedAddBreak()
 void CCreateGeomorphicBoardDialog::OnBtnPressClear()
 {
     m_listGeo.ResetContent();
-    m_nMaxColumns = 0;
-    m_nCurrentColumn = 0;
+    m_nMaxColumns = size_t(0);
+    m_nCurrentColumn = size_t(0);
     m_nCurrentRowHeight = 0;
-    m_nRowNumber = 0;
+    m_nRowNumber = size_t(0);
     m_pRootMapCellForm = NULL;
     m_tblColWidth.RemoveAll();
 
@@ -291,8 +291,8 @@ void CCreateGeomorphicBoardDialog::OnOK()
     m_pGeoBoard->SetName(strName);
     m_pGeoBoard->SetSerialNumber(m_pDoc->GetPBoardManager()->IssueGeoSerialNumber());
 
-    m_pGeoBoard->SetBoardRowCount(m_nRowNumber + 1);
-    m_pGeoBoard->SetBoardColCount(m_tblColWidth.GetSize());
+    m_pGeoBoard->SetBoardRowCount(m_nRowNumber + size_t(1));
+    m_pGeoBoard->SetBoardColCount(value_preserving_cast<size_t>(m_tblColWidth.GetSize()));
 
     for (int i = 0; i < m_listGeo.GetCount(); i++)
     {

--- a/GP/DlgNewGeoBoard.h
+++ b/GP/DlgNewGeoBoard.h
@@ -73,10 +73,10 @@ protected:
 
     CCellForm*  m_pRootMapCellForm;
     int         m_nCurrentRowHeight;                    // Height of current row maps
-    int         m_nRowNumber;
+    size_t      m_nRowNumber;
 
-    int         m_nCurrentColumn;
-    int         m_nMaxColumns;                          // Set when first row break added
+    size_t      m_nCurrentColumn;
+    size_t      m_nMaxColumns;                       // Set when first row break added
     CArray< int, int > m_tblColWidth;
 
     CGeomorphicBoard*   m_pGeoBoard;                    // Set if OK pressed

--- a/GP/DlgNewGeoBoard.h
+++ b/GP/DlgNewGeoBoard.h
@@ -72,12 +72,12 @@ public:
 protected:
 
     CCellForm*  m_pRootMapCellForm;
-    int         m_nCurrentRowHeight;                    // Height of current row maps
+    size_t      m_nCurrentRowHeight;                    // Height of current row maps
     size_t      m_nRowNumber;
 
     size_t      m_nCurrentColumn;
     size_t      m_nMaxColumns;                       // Set when first row break added
-    CArray< int, int > m_tblColWidth;
+    std::vector<size_t> m_tblColWidth;
 
     CGeomorphicBoard*   m_pGeoBoard;                    // Set if OK pressed
 

--- a/GP/FrmMain.cpp
+++ b/GP/FrmMain.cpp
@@ -321,7 +321,7 @@ BOOL CMainFrame::OnHelpInfo(HELPINFO* pHelpInfo)
     return TRUE;
 }
 
-void CMainFrame::WinHelp(DWORD dwData, UINT nCmd)
+void CMainFrame::WinHelp(DWORD_PTR dwData, UINT nCmd)
 {
     if (dwData != 0)
         GetApp()->DoHelpContext(dwData);

--- a/GP/FrmMain.cpp
+++ b/GP/FrmMain.cpp
@@ -397,16 +397,16 @@ BOOL CMainFrame::BuildAppGDIPalette()
 {
     ClearSystemPalette();
 
-    int nPalSize = 256;
-    LPLOGPALETTE pLP = (LPLOGPALETTE) new char[sizeof(LOGPALETTE) +
-        nPalSize * sizeof(PALETTEENTRY)];
+    uint16_t nPalSize = uint16_t(256);
+    std::vector<char> v((sizeof(LOGPALETTE) +
+        value_preserving_cast<size_t>(nPalSize * sizeof(PALETTEENTRY))));
+    LPLOGPALETTE pLP = reinterpret_cast<LPLOGPALETTE>(v.data());
     // Start with speedy identity pal
     SetupIdentityPalette(nPalSize, pLP);
     GenerateColorWash(&pLP->palPalEntry[10]);
 
     m_appPalette.DeleteObject();
     m_appPalette.CreatePalette(pLP);
-    delete pLP;
 
     return TRUE;
 }

--- a/GP/FrmMain.h
+++ b/GP/FrmMain.h
@@ -103,7 +103,7 @@ public:
 
 // Generated message map functions
 protected:
-    void WinHelp(DWORD dwData, UINT nCmd);
+    void WinHelp(DWORD_PTR dwData, UINT nCmd) override;
 
     afx_msg int OnCreate(LPCREATESTRUCT lpCreateStruct);
     afx_msg void OnUpdateDisable(CCmdUI* pCmdUI);

--- a/GP/GamDoc.cpp
+++ b/GP/GamDoc.cpp
@@ -398,22 +398,31 @@ void CGamDoc::DeleteContents()
     if (m_palTrayA.m_hWnd != NULL)
     {
         CDockTrayPalette* pFrame = (CDockTrayPalette*)m_palTrayA.GetDockingFrame();
-        ASSERT_KINDOF(CDockTrayPalette, pFrame);
-        pFrame->SetChild(NULL);         // Need to remove pointer from Tray's UI Frame.
+        if (pFrame)
+        {
+            ASSERT_KINDOF(CDockTrayPalette, pFrame);
+            pFrame->SetChild(NULL);         // Need to remove pointer from Tray's UI Frame.
+        }
         m_palTrayA.DestroyWindow();
     }
     if (m_palTrayB.m_hWnd != NULL)
     {
         CDockTrayPalette* pFrame = (CDockTrayPalette*)m_palTrayB.GetDockingFrame();
-        ASSERT_KINDOF(CDockTrayPalette, pFrame);
-        pFrame->SetChild(NULL);         // Need to remove pointer from Tray's UI Frame.
+        if (pFrame)
+        {
+            ASSERT_KINDOF(CDockTrayPalette, pFrame);
+            pFrame->SetChild(NULL);         // Need to remove pointer from Tray's UI Frame.
+        }
         m_palTrayB.DestroyWindow();
     }
     if (m_palMark.m_hWnd != NULL)
     {
         CDockMarkPalette* pFrame = (CDockMarkPalette*)m_palMark.GetDockingFrame();
-        ASSERT_KINDOF(CDockMarkPalette, pFrame);
-        pFrame->SetChild(NULL);         // Need to remove pointer from Marker's UI Frame.
+        if (pFrame)
+        {
+            ASSERT_KINDOF(CDockMarkPalette, pFrame);
+            pFrame->SetChild(NULL);         // Need to remove pointer from Marker's UI Frame.
+        }
         m_palMark.DestroyWindow();
     }
 

--- a/GP/GamDoc.cpp
+++ b/GP/GamDoc.cpp
@@ -1885,7 +1885,7 @@ void CGamDoc::OnEditCreatePlayers()
         szBfr[1] = 0;
         for (int i = 0; i < dlg.m_nPlayerCount; i++)
         {
-            szBfr[0] = 'A' + i;
+            szBfr[0] = value_preserving_cast<char>('A' + i);
             CString str;
             str.Format(IDS_BASE_PLAYER_NAME, szBfr);
             m_pPlayerMgr->AddPlayer(str);

--- a/GP/GamDoc.cpp
+++ b/GP/GamDoc.cpp
@@ -1868,7 +1868,7 @@ void CGamDoc::OnUpdateViewSaveWinState(CCmdUI* pCmdUI)
 void CGamDoc::OnEditCreatePlayers()
 {
     CCreatePlayersDialog dlg;
-    dlg.m_nPlayerCount = m_pPlayerMgr != NULL ? m_pPlayerMgr->GetSize() : 0;
+    dlg.m_nPlayerCount = value_preserving_cast<size_t>(m_pPlayerMgr != NULL ? m_pPlayerMgr->GetSize() : 0);
     if (dlg.DoModal() != IDOK)
         return;
 
@@ -1878,14 +1878,14 @@ void CGamDoc::OnEditCreatePlayers()
         m_pPlayerMgr = NULL;
     }
     ClearAllOwnership();            // Start with clean slate
-    if (dlg.m_nPlayerCount > 0)
+    if (dlg.m_nPlayerCount > size_t(0))
     {
         m_pPlayerMgr = new CPlayerManager;
         char szBfr[2];
         szBfr[1] = 0;
-        for (int i = 0; i < dlg.m_nPlayerCount; i++)
+        for (size_t i = size_t(0) ; i < dlg.m_nPlayerCount ; ++i)
         {
-            szBfr[0] = value_preserving_cast<char>('A' + i);
+            szBfr[0] = value_preserving_cast<char>(size_t('A') + i);
             CString str;
             str.Format(IDS_BASE_PLAYER_NAME, szBfr);
             m_pPlayerMgr->AddPlayer(str);

--- a/GP/GamDoc.h
+++ b/GP/GamDoc.h
@@ -344,9 +344,9 @@ public:
         PlacePos ePos = placeDefault);
     void RecordPieceMoveToTray(const CTraySet& pYGrp, PieceID pid, size_t nPos);
     void RecordPieceSetSide(PieceID pid, BOOL bTopUp);
-    void RecordPieceSetFacing(PieceID pid, int nFacingDegCW);
+    void RecordPieceSetFacing(PieceID pid, uint16_t nFacingDegCW);
     void RecordPieceSetOwnership(PieceID pid, DWORD dwOwnerMask);
-    void RecordMarkerSetFacing(ObjectID dwObjID, MarkID mid, int nFacingDegCW);
+    void RecordMarkerSetFacing(ObjectID dwObjID, MarkID mid, uint16_t nFacingDegCW);
     void RecordMarkMoveToBoard(CPlayBoard* pPBrd, ObjectID dwObjID,
         MarkID mid, CPoint pnt, PlacePos ePos = placeDefault);
     void RecordPlotList(CPlayBoard* pPBrd);
@@ -383,12 +383,12 @@ public:
     void InvertPlayingPieceInTray(PieceID pid, BOOL bOkToNotifyTray = TRUE);
 
     void ChangePlayingPieceFacingOnBoard(CPieceObj& pObj, CPlayBoard* pPBrd,
-        int nFacingDegCW);
+        uint16_t nFacingDegCW);
     void ChangePlayingPieceFacingTableOnBoard(const std::vector<CB::not_null<CDrawObj*>>& pLst,
-        CPlayBoard* pPBrd, int nFacingDegCW);
-    void ChangePlayingPieceFacingInTray(PieceID pid, int nFacingDegCW);
+        CPlayBoard* pPBrd, uint16_t nFacingDegCW);
+    void ChangePlayingPieceFacingInTray(PieceID pid, uint16_t nFacingDegCW);
     void ChangeMarkerFacingOnBoard(CMarkObj& pObj, CPlayBoard* pPBrd,
-        int nFacingDegCW);
+        uint16_t nFacingDegCW);
     void SetPieceOwnership(PieceID pid, DWORD dwOwnerMask);
     void SetPieceOwnershipTable(const std::vector<PieceID>& pTblPieces, DWORD dwOwnerMask);
 

--- a/GP/GamDoc1.cpp
+++ b/GP/GamDoc1.cpp
@@ -529,7 +529,7 @@ void CGamDoc::InvertPlayingPieceInTray(PieceID pid, BOOL bOkToNotifyTray /* = TR
 //////////////////////////////////////////////////////////////////////
 // (RECORDS)
 void CGamDoc::ChangePlayingPieceFacingOnBoard(CPieceObj& pObj, CPlayBoard* pPBrd,
-    int nFacingDegCW)
+    uint16_t nFacingDegCW)
 {
     if (!IsQuietPlayback())
     {
@@ -555,7 +555,7 @@ void CGamDoc::ChangePlayingPieceFacingOnBoard(CPieceObj& pObj, CPlayBoard* pPBrd
 }
 
 void CGamDoc::ChangePlayingPieceFacingTableOnBoard(const std::vector<CB::not_null<CDrawObj*>>& pLst,
-    CPlayBoard* pPBrd, int nFacingDegCW)
+    CPlayBoard* pPBrd, uint16_t nFacingDegCW)
 {
     for (auto pos = pLst.begin() ; pos != pLst.end() ; ++pos)
     {
@@ -574,7 +574,7 @@ void CGamDoc::ChangePlayingPieceFacingTableOnBoard(const std::vector<CB::not_nul
 // the move file's game state it can occur. Therefore, I don't do
 // any record processing here.
 
-void CGamDoc::ChangePlayingPieceFacingInTray(PieceID pid, int nFacingDegCW)
+void CGamDoc::ChangePlayingPieceFacingInTray(PieceID pid, uint16_t nFacingDegCW)
 {
     m_pPTbl->SetPieceFacing(pid, nFacingDegCW);
     CTraySet* pYGrp = FindPieceInTray(pid);
@@ -592,7 +592,7 @@ void CGamDoc::ChangePlayingPieceFacingInTray(PieceID pid, int nFacingDegCW)
 // (RECORDS)
 
 void CGamDoc::ChangeMarkerFacingOnBoard(CMarkObj& pObj, CPlayBoard* pPBrd,
-    int nFacingDegCW)
+    uint16_t nFacingDegCW)
 {
     if (!IsQuietPlayback())
     {

--- a/GP/GamDoc2.cpp
+++ b/GP/GamDoc2.cpp
@@ -347,7 +347,7 @@ void CGamDoc::RecordPieceSetSide(PieceID pid, BOOL bTopUp)
 
 ////////////////////////////////////////////////////////////////////
 
-void CGamDoc::RecordPieceSetFacing(PieceID pid, int nFacingDegCW)
+void CGamDoc::RecordPieceSetFacing(PieceID pid, uint16_t nFacingDegCW)
 {
     if (!IsRecording()) return;
     CreateRecordListIfRequired();
@@ -369,7 +369,7 @@ void CGamDoc::RecordPieceSetOwnership(PieceID pid, DWORD dwOwnerMask)
 
 ////////////////////////////////////////////////////////////////////
 
-void CGamDoc::RecordMarkerSetFacing(ObjectID dwObjID, MarkID mid, int nFacingDegCW)
+void CGamDoc::RecordMarkerSetFacing(ObjectID dwObjID, MarkID mid, uint16_t nFacingDegCW)
 {
     if (!IsRecording()) return;
     CreateRecordListIfRequired();

--- a/GP/GamDoc3.cpp
+++ b/GP/GamDoc3.cpp
@@ -181,7 +181,7 @@ void CGamDoc::SerializeGame(CArchive& ar)
         ASSERT(m_eState != stateNotRecording);  // Shouldn't save this state
         ar << (WORD)m_eState;
         ar << m_strCurMsg;
-        m_astrMsgHist.Serialize(ar);
+        ar << m_astrMsgHist;
         ASSERT(m_nCurMove == Invalid_v<size_t> ||
                 m_nCurMove < size_t(0xFFFF));
         ar << (m_nCurMove == Invalid_v<size_t> ? WORD(0xFFFF) : value_preserving_cast<WORD>(m_nCurMove));
@@ -265,7 +265,7 @@ void CGamDoc::SerializeGame(CArchive& ar)
         ASSERT(m_eState != stateNotRecording);  // Shouldn't save this state
         ar >> m_strCurMsg;
         if (CGamDoc::GetLoadingVersion() >= NumVersion(2, 90))
-            m_astrMsgHist.Serialize(ar);
+            ar >> m_astrMsgHist;
         else
             MsgParseLegacyHistory(m_strCurMsg, m_astrMsgHist, m_strCurMsg);
         ar >> wTmp; m_nCurMove = (wTmp == 0xFFFF ? Invalid_v<size_t> : value_preserving_cast<size_t>(wTmp));

--- a/GP/GamDoc3.cpp
+++ b/GP/GamDoc3.cpp
@@ -133,7 +133,9 @@ void CGamDoc::SerializeMoveSet(CArchive& ar, CHistRecord*& pHist)
         ar >> verMajor;
         ar >> verMinor;
         if (NumVersion(verMajor, verMinor) >
-            NumVersion(fileGmvVerMajor, fileGmvVerMinor))
+            NumVersion(fileGsnVerMajor, fileGsnVerMinor) &&
+            // file 3.90 is the same as 3.10
+            NumVersion(verMajor, verMinor) != NumVersion(3, 90))
         {
             AfxMessageBox(IDS_ERR_GAMENEWER, MB_OK | MB_ICONEXCLAMATION);
             AfxThrowArchiveException(CArchiveException::genericException);
@@ -505,7 +507,9 @@ void CGamDoc::SerializeScenarioOrGame(CArchive& ar)
         ar >> verMajor;
         ar >> verMinor;
         if (NumVersion(verMajor, verMinor) >
-            NumVersion(fileGsnVerMajor, fileGsnVerMinor))
+            NumVersion(fileGsnVerMajor, fileGsnVerMinor) &&
+            // file 3.90 is the same as 3.10
+            NumVersion(verMajor, verMinor) != NumVersion(3, 90))
         {
             AfxMessageBox(IDS_ERR_SCENARIONEWER, MB_OK | MB_ICONEXCLAMATION);
             AfxThrowArchiveException(CArchiveException::genericException);

--- a/GP/GamDoc3.cpp
+++ b/GP/GamDoc3.cpp
@@ -480,7 +480,7 @@ void CGamDoc::SerializeScenarioOrGame(CArchive& ar)
     {
         BYTE verMajor, verMinor;
         WORD wTmp;
-        DWORD dwCurFileSlot;
+        DWORD dwCurFileSlot = DWORD(0xffffffff);
 
         ar >> verMajor;
         ar >> verMinor;

--- a/GP/GamDoc3.cpp
+++ b/GP/GamDoc3.cpp
@@ -182,18 +182,28 @@ void CGamDoc::SerializeGame(CArchive& ar)
         ar << (WORD)m_eState;
         ar << m_strCurMsg;
         ar << m_astrMsgHist;
-        ASSERT(m_nCurMove == Invalid_v<size_t> ||
-                m_nCurMove < size_t(0xFFFF));
-        ar << (m_nCurMove == Invalid_v<size_t> ? WORD(0xFFFF) : value_preserving_cast<WORD>(m_nCurMove));
-        ASSERT(m_nFirstMove == Invalid_v<size_t> ||
-                m_nFirstMove < size_t(0xFFFF));
-        ar << (m_nFirstMove == Invalid_v<size_t> ? WORD(0xFFFF) : value_preserving_cast<WORD>(m_nFirstMove));
-        ASSERT(m_nCurHist == Invalid_v<size_t> ||
-                m_nCurHist < size_t(0xFFFF));
-        ar << (m_nCurHist == Invalid_v<size_t> ? WORD(0xFFFF) : value_preserving_cast<WORD>(m_nCurHist));
-        ASSERT(m_nMoveIdxAtBookMark == Invalid_v<size_t> ||
-                m_nMoveIdxAtBookMark < size_t(0xFFFF));
-        ar << (m_nMoveIdxAtBookMark == Invalid_v<size_t> ? WORD(0xFFFF) : value_preserving_cast<WORD>(m_nMoveIdxAtBookMark));
+        if (CB::GetVersion(ar) <= NumVersion(3, 90))
+        {
+            ASSERT(m_nCurMove == Invalid_v<size_t> ||
+                    m_nCurMove < size_t(0xFFFF));
+            ar << (m_nCurMove == Invalid_v<size_t> ? WORD(0xFFFF) : value_preserving_cast<WORD>(m_nCurMove));
+            ASSERT(m_nFirstMove == Invalid_v<size_t> ||
+                    m_nFirstMove < size_t(0xFFFF));
+            ar << (m_nFirstMove == Invalid_v<size_t> ? WORD(0xFFFF) : value_preserving_cast<WORD>(m_nFirstMove));
+            ASSERT(m_nCurHist == Invalid_v<size_t> ||
+                    m_nCurHist < size_t(0xFFFF));
+            ar << (m_nCurHist == Invalid_v<size_t> ? WORD(0xFFFF) : value_preserving_cast<WORD>(m_nCurHist));
+            ASSERT(m_nMoveIdxAtBookMark == Invalid_v<size_t> ||
+                    m_nMoveIdxAtBookMark < size_t(0xFFFF));
+            ar << (m_nMoveIdxAtBookMark == Invalid_v<size_t> ? WORD(0xFFFF) : value_preserving_cast<WORD>(m_nMoveIdxAtBookMark));
+        }
+        else
+        {
+            CB::WriteCount(ar, m_nCurMove);
+            CB::WriteCount(ar, m_nFirstMove);
+            CB::WriteCount(ar, m_nCurHist);
+            CB::WriteCount(ar, m_nMoveIdxAtBookMark);
+        }
 
         ar << (WORD)m_bStepToNextHist;
         ar << (WORD)m_bKeepSkipInd;
@@ -268,10 +278,20 @@ void CGamDoc::SerializeGame(CArchive& ar)
             ar >> m_astrMsgHist;
         else
             MsgParseLegacyHistory(m_strCurMsg, m_astrMsgHist, m_strCurMsg);
-        ar >> wTmp; m_nCurMove = (wTmp == 0xFFFF ? Invalid_v<size_t> : value_preserving_cast<size_t>(wTmp));
-        ar >> wTmp; m_nFirstMove = (wTmp == 0xFFFF ? Invalid_v<size_t> : value_preserving_cast<size_t>(wTmp));
-        ar >> wTmp; m_nCurHist = (wTmp == 0xFFFF ? Invalid_v<size_t> : value_preserving_cast<size_t>(wTmp));
-        ar >> wTmp; m_nMoveIdxAtBookMark = (wTmp == 0xFFFF ? Invalid_v<size_t> : value_preserving_cast<size_t>(wTmp));
+        if (CB::GetVersion(ar) <= NumVersion(3, 90))
+        {
+            ar >> wTmp; m_nCurMove = (wTmp == 0xFFFF ? Invalid_v<size_t> : value_preserving_cast<size_t>(wTmp));
+            ar >> wTmp; m_nFirstMove = (wTmp == 0xFFFF ? Invalid_v<size_t> : value_preserving_cast<size_t>(wTmp));
+            ar >> wTmp; m_nCurHist = (wTmp == 0xFFFF ? Invalid_v<size_t> : value_preserving_cast<size_t>(wTmp));
+            ar >> wTmp; m_nMoveIdxAtBookMark = (wTmp == 0xFFFF ? Invalid_v<size_t> : value_preserving_cast<size_t>(wTmp));
+        }
+        else
+        {
+            m_nCurMove = CB::ReadCount(ar);
+            m_nFirstMove = CB::ReadCount(ar);
+            m_nCurHist = CB::ReadCount(ar);
+            m_nMoveIdxAtBookMark = CB::ReadCount(ar);
+        }
 
         if (CGamDoc::GetLoadingVersion() >= NumVersion(2, 90))
         {

--- a/GP/GamDoc4.cpp
+++ b/GP/GamDoc4.cpp
@@ -101,7 +101,7 @@ void CGamDoc::LoadAndActivateMoveFile(LPCSTR pszPathName)
 
         {
             OwnerPtr<CGameStateRcd> pCurRcd = MakeOwner<CGameStateRcd>(pState);
-            pCurRcd->SetSeqNum(-1);             // Special number
+            pCurRcd->SetSeqNum(Invalid_v<size_t>);             // Special number
             pHist->m_pMList->PrependMoveRecord(std::move(pCurRcd), FALSE);
         }
 
@@ -154,7 +154,7 @@ void CGamDoc::LoadAndActivateMoveFile(LPCSTR pszPathName)
                     CGameState* pState = new CGameState(this);
                     pState->SaveState();
                     OwnerPtr<CGameStateRcd> pCurRcd = MakeOwner<CGameStateRcd>(pState);
-                    pCurRcd->SetSeqNum(0);
+                    pCurRcd->SetSeqNum(size_t(0));
                     pHist->m_pMList->insert(++CMoveList::iterator(pos), std::move(pCurRcd));
                     m_nFirstMove = size_t(1);       // Restart location (state rec)
                     m_nCurMove = size_t(2);         // Set to start of actual moves
@@ -249,7 +249,7 @@ BOOL CGamDoc::LoadAndActivateHistory(size_t nHistRec)
 
         {
             OwnerPtr<CGameStateRcd> pCurRcd = MakeOwner<CGameStateRcd>(pState);
-            pCurRcd->SetSeqNum(-1);             // Special number
+            pCurRcd->SetSeqNum(Invalid_v<size_t>);             // Special number
             m_pMoves->PrependMoveRecord(std::move(pCurRcd), FALSE);
         }
 

--- a/GP/GameBox.cpp
+++ b/GP/GameBox.cpp
@@ -115,7 +115,9 @@ BOOL CGameBox::Load(CGamDoc* pDoc, LPCSTR pszPathName, CString& strErr,
         ar >> verMajor;
         ar >> verMinor;
         if (NumVersion(verMajor, verMinor) >
-            NumVersion(fileGbxVerMajor, fileGbxVerMinor))
+            NumVersion(fileGsnVerMajor, fileGsnVerMinor) &&
+            // file 3.90 is the same as 3.10
+            NumVersion(verMajor, verMinor) != NumVersion(3, 90))
         {
             strErr.LoadString(IDS_ERR_GAMEBOXNEWER);
             return FALSE;

--- a/GP/GeoBoard.cpp
+++ b/GP/GeoBoard.cpp
@@ -190,21 +190,21 @@ void CGeomorphicBoard::CopyCells(CBoardArray* pBArryTo, CBoardArray* pBArryFrom,
             size_t nRowTo = nRow + nCellRowOffset;
             size_t nColTo = nCol + nCellColOffset;
 
-            BoardCell* pCellFrom = pBArryFrom->GetCell(nRow, nCol);
-            BoardCell* pCellTo = pBArryTo->GetCell(nRowTo, nColTo);
+            BoardCell& pCellFrom = pBArryFrom->GetCell(nRow, nCol);
+            BoardCell& pCellTo = pBArryTo->GetCell(nRowTo, nColTo);
             BOOL bMergeTheCell = FALSE;
-            if (pBArryTo->GetCellForm(fullScale)->GetCellType() == cformHexFlat)
+            if (pBArryTo->GetCellForm(fullScale).GetCellType() == cformHexFlat)
                 bMergeTheCell = nCol == size_t(0) && nColTo != size_t(0);
             else
                 bMergeTheCell = nRow == size_t(0) && nRowTo != size_t(0);
 
-            if (bMergeTheCell && memcmp(pCellFrom, pCellTo, sizeof(BoardCell)) != 0)
+            if (bMergeTheCell && pCellFrom != pCellTo)
             {
                 // We need to create a tile that has the half images of the
                 // two hex cells joined as one.
                 CBitmap bmapFull;
                 CBitmap bmapHalf;
-                if (pBArryTo->GetCellForm(fullScale)->GetCellType() == cformHexFlat)
+                if (pBArryTo->GetCellForm(fullScale).GetCellType() == cformHexFlat)
                 {
                     // Handle left and right halves
                     CombineLeftAndRight(bmapFull, fullScale, pBArryTo, pBArryFrom,
@@ -222,23 +222,23 @@ void CGeomorphicBoard::CopyCells(CBoardArray* pBArryTo, CBoardArray* pBArryFrom,
                 }
                 // Determine small cell color. Use the 'To' cell as value;
                 COLORREF crSmall;
-                if (pCellTo->IsTileID())
+                if (pCellTo.IsTileID())
                 {
                     CTile tile;
-                    pTMgr->GetTile(pCellTo->GetTID(), &tile, smallScale);
+                    pTMgr->GetTile(pCellTo.GetTID(), &tile, smallScale);
                     crSmall = tile.GetSmallColor();
                 }
                 else
-                    crSmall = pCellTo->GetColor();
+                    crSmall = pCellTo.GetColor();
                 CSize sizeFull = pBArryTo->GetCellSize(fullScale);
                 CSize sizeHalf = pBArryTo->GetCellSize(halfScale);
                 TileID tidNew = pTMgr->CreateTile(GetSpecialTileSet(),
                     sizeFull, sizeHalf, crSmall);
                 pTMgr->UpdateTile(tidNew, &bmapFull, &bmapHalf, crSmall);
-                pCellTo->SetTID(tidNew);
+                pCellTo.SetTID(tidNew);
             }
             else
-                memcpy(pCellTo, pCellFrom, sizeof(BoardCell));
+                pCellTo = pCellFrom;
         }
     }
 }
@@ -350,7 +350,7 @@ CPoint CGeomorphicBoard::ComputeGraphicalOffset(size_t nBoardRow, size_t nBoardC
         CBoard& pBrd = GetBoard(size_t(0), nCol);
         CBoardArray* pBArray = pBrd.GetBoardArray();
         pnt.x += pBArray->GetWidth(fullScale);
-        if (nBoardCol != size_t(0) && pBArray->GetCellForm(fullScale)->GetCellType() == cformHexFlat)
+        if (nBoardCol != size_t(0) && pBArray->GetCellForm(fullScale).GetCellType() == cformHexFlat)
             pnt.x -= sizeCell.cx;               // A column is shared
         else
             pnt.x -= sizeCell.cx / 2;           // A column is half shared
@@ -360,7 +360,7 @@ CPoint CGeomorphicBoard::ComputeGraphicalOffset(size_t nBoardRow, size_t nBoardC
         CBoard& pBrd = GetBoard(nRow, size_t(0));
         CBoardArray* pBArray = pBrd.GetBoardArray();
         pnt.y += pBArray->GetHeight(fullScale);
-        if (nBoardRow != size_t(0) && pBArray->GetCellForm(fullScale)->GetCellType() == cformHexPnt)
+        if (nBoardRow != size_t(0) && pBArray->GetCellForm(fullScale).GetCellType() == cformHexPnt)
             pnt.y -= sizeCell.cy;               // A row is shared
         else
             pnt.y -= sizeCell.cy / 2;           // A row is half shared
@@ -378,7 +378,7 @@ void CGeomorphicBoard::ComputeNewBoardDimensions(size_t& rnRows, size_t& rnCols)
         CBoard& pBrd = GetBoard(size_t(0), nBoardCol);
         CBoardArray* pBArray = pBrd.GetBoardArray();
         rnCols += pBArray->GetCols();
-        if (nBoardCol != size_t(0) && pBArray->GetCellForm(fullScale)->GetCellType() == cformHexFlat)
+        if (nBoardCol != size_t(0) && pBArray->GetCellForm(fullScale).GetCellType() == cformHexFlat)
             rnCols--;                   // A column is shared
     }
     for (size_t nBoardRow = size_t(0) ; nBoardRow < m_nBoardRowCount ; ++nBoardRow)
@@ -386,7 +386,7 @@ void CGeomorphicBoard::ComputeNewBoardDimensions(size_t& rnRows, size_t& rnCols)
         CBoard& pBrd = GetBoard(nBoardRow, size_t(0));
         CBoardArray* pBArray = pBrd.GetBoardArray();
         rnRows += pBArray->GetRows();
-        if (nBoardRow != size_t(0) && pBArray->GetCellForm(fullScale)->GetCellType() == cformHexPnt)
+        if (nBoardRow != size_t(0) && pBArray->GetCellForm(fullScale).GetCellType() == cformHexPnt)
             rnRows--;                   // A row is shared
     }
 }
@@ -402,7 +402,7 @@ void CGeomorphicBoard::ComputeCellOffset(size_t nBoardRow, size_t nBoardCol,
         CBoardArray* pBArray = pBrd.GetBoardArray();
         ASSERT(pBArray->GetCols() >= size_t(1));
         rnCellCol += pBArray->GetCols();
-        if (pBArray->GetCellForm(fullScale)->GetCellType() == cformHexFlat)
+        if (pBArray->GetCellForm(fullScale).GetCellType() == cformHexFlat)
             rnCellCol--;
     }
     for (size_t nRow = size_t(0) ; nRow < nBoardRow ; ++nRow)
@@ -411,7 +411,7 @@ void CGeomorphicBoard::ComputeCellOffset(size_t nBoardRow, size_t nBoardCol,
         CBoardArray* pBArray = pBrd.GetBoardArray();
         ASSERT(pBArray->GetRows() >= size_t(1));
         rnCellRow += pBArray->GetRows();
-        if (pBArray->GetCellForm(fullScale)->GetCellType() == cformHexPnt)
+        if (pBArray->GetCellForm(fullScale).GetCellType() == cformHexPnt)
             rnCellRow--;
     }
 }

--- a/GP/GeoBoard.cpp
+++ b/GP/GeoBoard.cpp
@@ -169,6 +169,16 @@ CBoard* CGeomorphicBoard::CreateBoard(CGamDoc* pDoc)
     return pBrdNew;
 }
 
+void CGeomorphicBoard::DeleteFromBoardManager()
+{
+    CBoardManager* pBMgr = m_pDoc->GetBoardManager();
+    if (pBMgr != NULL)
+    {
+        size_t nBrd = pBMgr->FindBoardBySerial(GetSerialNumber());
+        pBMgr->DeleteBoard(nBrd);
+    }
+}
+
 size_t CGeomorphicBoard::GetSpecialTileSet()
 {
     CTileManager* pTMgr = m_pDoc->GetTileManager();

--- a/GP/GeoBoard.cpp
+++ b/GP/GeoBoard.cpp
@@ -113,8 +113,8 @@ CBoard* CGeomorphicBoard::CreateBoard(CGamDoc* pDoc)
 
     CBoardArray* pBrdArrayNew = pBrdNew->GetBoardArray();
 
-    int nRows;
-    int nCols;
+    size_t nRows;
+    size_t nCols;
     ComputeNewBoardDimensions(nRows, nCols);
 
     pBrdArrayNew->ReshapeBoard(nRows, nCols, -1, -1, -1);
@@ -122,12 +122,12 @@ CBoard* CGeomorphicBoard::CreateBoard(CGamDoc* pDoc)
     // 3) Fill cells with content of cells from other boards.
     for (size_t nBoardRow = size_t(0) ; nBoardRow < m_nBoardRowCount ; ++nBoardRow)
     {
-        for (size_t nBoardCol = size_t(0); nBoardCol < m_nBoardColCount ; ++nBoardCol)
+        for (size_t nBoardCol = size_t(0) ; nBoardCol < m_nBoardColCount ; ++nBoardCol)
         {
             if (nBoardCol == size_t(0) && nBoardRow == size_t(0))
                 continue;                       // Skip this one since it is done already
-            int nCellRowOffset;
-            int nCellColOffset;
+            size_t nCellRowOffset;
+            size_t nCellColOffset;
             ComputeCellOffset(nBoardRow, nBoardCol, nCellRowOffset, nCellColOffset);
 
             CBoard& pBrd = GetBoard(nBoardRow, nBoardCol);
@@ -180,23 +180,23 @@ size_t CGeomorphicBoard::GetSpecialTileSet()
 }
 
 void CGeomorphicBoard::CopyCells(CBoardArray* pBArryTo, CBoardArray* pBArryFrom,
-    int nCellRowOffset, int nCellColOffset)
+    size_t nCellRowOffset, size_t nCellColOffset)
 {
     CTileManager* pTMgr = m_pDoc->GetTileManager();
-    for (int nRow = 0; nRow < pBArryFrom->GetRows(); nRow++)
+    for (size_t nRow = size_t(0) ; nRow < pBArryFrom->GetRows() ; ++nRow)
     {
-        for (int nCol = 0; nCol < pBArryFrom->GetCols(); nCol++)
+        for (size_t nCol = size_t(0) ; nCol < pBArryFrom->GetCols() ; ++nCol)
         {
-            int nRowTo = nRow + nCellRowOffset;
-            int nColTo = nCol + nCellColOffset;
+            size_t nRowTo = nRow + nCellRowOffset;
+            size_t nColTo = nCol + nCellColOffset;
 
             BoardCell* pCellFrom = pBArryFrom->GetCell(nRow, nCol);
             BoardCell* pCellTo = pBArryTo->GetCell(nRowTo, nColTo);
             BOOL bMergeTheCell = FALSE;
             if (pBArryTo->GetCellForm(fullScale)->GetCellType() == cformHexFlat)
-                bMergeTheCell = nCol == 0 && nColTo != 0;
+                bMergeTheCell = nCol == size_t(0) && nColTo != size_t(0);
             else
-                bMergeTheCell = nRow == 0 && nRowTo != 0;
+                bMergeTheCell = nRow == size_t(0) && nRowTo != size_t(0);
 
             if (bMergeTheCell && memcmp(pCellFrom, pCellTo, sizeof(BoardCell)) != 0)
             {
@@ -244,8 +244,8 @@ void CGeomorphicBoard::CopyCells(CBoardArray* pBArryTo, CBoardArray* pBArryFrom,
 }
 
 void CGeomorphicBoard::CombineLeftAndRight(CBitmap& bmap, TileScale eScale,
-    CBoardArray* pBALeft, CBoardArray* pBARight, int nRowLeft, int nColLeft,
-    int nRowRight, int nColRight)
+    CBoardArray* pBALeft, CBoardArray* pBARight, size_t nRowLeft, size_t nColLeft,
+    size_t nRowRight, size_t nColRight)
 {
     CDC dc;
     dc.CreateCompatibleDC(NULL);
@@ -282,8 +282,8 @@ void CGeomorphicBoard::CombineLeftAndRight(CBitmap& bmap, TileScale eScale,
 }
 
 void CGeomorphicBoard::CombineTopAndBottom(CBitmap& bmap, TileScale eScale,
-    CBoardArray* pBATop, CBoardArray* pBABottom, int nRowTop, int nColTop,
-    int nRowBottom, int nColBottom)
+    CBoardArray* pBATop, CBoardArray* pBABottom, size_t nRowTop, size_t nColTop,
+    size_t nRowBottom, size_t nColBottom)
 {
     CDC dc;
     dc.CreateCompatibleDC(NULL);
@@ -369,10 +369,10 @@ CPoint CGeomorphicBoard::ComputeGraphicalOffset(size_t nBoardRow, size_t nBoardC
     return pnt;
 }
 
-void CGeomorphicBoard::ComputeNewBoardDimensions(int& rnRows, int& rnCols)
+void CGeomorphicBoard::ComputeNewBoardDimensions(size_t& rnRows, size_t& rnCols)
 {
-    rnRows = 0;
-    rnCols = 0;
+    rnRows = size_t(0);
+    rnCols = size_t(0);
     for (size_t nBoardCol = size_t(0) ; nBoardCol < m_nBoardColCount ; ++nBoardCol)
     {
         CBoard& pBrd = GetBoard(size_t(0), nBoardCol);
@@ -392,14 +392,15 @@ void CGeomorphicBoard::ComputeNewBoardDimensions(int& rnRows, int& rnCols)
 }
 
 void CGeomorphicBoard::ComputeCellOffset(size_t nBoardRow, size_t nBoardCol,
-    int& rnCellRow, int& rnCellCol)
+    size_t& rnCellRow, size_t& rnCellCol)
 {
-    rnCellRow = 0;
-    rnCellCol = 0;
+    rnCellRow = size_t(0);
+    rnCellCol = size_t(0);
     for (size_t nCol = size_t(0) ; nCol < nBoardCol ; ++nCol)
     {
         CBoard& pBrd = GetBoard(size_t(0), nCol);
         CBoardArray* pBArray = pBrd.GetBoardArray();
+        ASSERT(pBArray->GetCols() >= size_t(1));
         rnCellCol += pBArray->GetCols();
         if (pBArray->GetCellForm(fullScale)->GetCellType() == cformHexFlat)
             rnCellCol--;
@@ -408,6 +409,7 @@ void CGeomorphicBoard::ComputeCellOffset(size_t nBoardRow, size_t nBoardCol,
     {
         CBoard& pBrd = GetBoard(nRow, size_t(0));
         CBoardArray* pBArray = pBrd.GetBoardArray();
+        ASSERT(pBArray->GetRows() >= size_t(1));
         rnCellRow += pBArray->GetRows();
         if (pBArray->GetCellForm(fullScale)->GetCellType() == cformHexPnt)
             rnCellRow--;

--- a/GP/GeoBoard.cpp
+++ b/GP/GeoBoard.cpp
@@ -66,8 +66,8 @@ void CGeoBoardElement::Serialize(CArchive& ar)
 
 CGeomorphicBoard::CGeomorphicBoard()
 {
-    m_nBoardRowCount = 0;
-    m_nBoardColCount = 0;
+    m_nBoardRowCount = size_t(0);
+    m_nBoardColCount = size_t(0);
     m_nSerialNum = BoardID(0);
     m_pDoc = NULL;
 }
@@ -87,7 +87,7 @@ CGeomorphicBoard::CGeomorphicBoard(const CGeomorphicBoard& pGeoBoard)
 
 /////////////////////////////////////////////////////////////////////////////
 
-int CGeomorphicBoard::AddElement(BoardID nBoardSerialNum)
+intptr_t CGeomorphicBoard::AddElement(BoardID nBoardSerialNum)
 {
     CGeoBoardElement geo(nBoardSerialNum);
     return Add(geo);
@@ -103,7 +103,7 @@ CBoard* CGeomorphicBoard::CreateBoard(CGamDoc* pDoc)
     // Procedure:
     // 1) Clone the root board to use as template
 
-    CBoard& pBrd = GetBoard(0, 0);
+    CBoard& pBrd = GetBoard(size_t(0), size_t(0));
     CBoard* pBrdNew = CloneBoard(pBrd);
 
     pBrdNew->SetName(m_strName);
@@ -120,11 +120,11 @@ CBoard* CGeomorphicBoard::CreateBoard(CGamDoc* pDoc)
     pBrdArrayNew->ReshapeBoard(nRows, nCols, -1, -1, -1);
 
     // 3) Fill cells with content of cells from other boards.
-    for (int nBoardRow = 0; nBoardRow < m_nBoardRowCount; nBoardRow++)
+    for (size_t nBoardRow = size_t(0) ; nBoardRow < m_nBoardRowCount ; ++nBoardRow)
     {
-        for (int nBoardCol = 0; nBoardCol < m_nBoardColCount; nBoardCol++)
+        for (size_t nBoardCol = size_t(0); nBoardCol < m_nBoardColCount ; ++nBoardCol)
         {
-            if (nBoardCol == 0 && nBoardRow == 0)
+            if (nBoardCol == size_t(0) && nBoardRow == size_t(0))
                 continue;                       // Skip this one since it is done already
             int nCellRowOffset;
             int nCellColOffset;
@@ -140,11 +140,11 @@ CBoard* CGeomorphicBoard::CreateBoard(CGamDoc* pDoc)
     // 4) Copy in drawing layers from other board. Offset them
     //    as required based on their board positions.
 
-    for (int nBoardRow = 0; nBoardRow < m_nBoardRowCount; nBoardRow++)
+    for (size_t nBoardRow = size_t(0) ; nBoardRow < m_nBoardRowCount ; ++nBoardRow)
     {
-        for (int nBoardCol = 0; nBoardCol < m_nBoardColCount; nBoardCol++)
+        for (size_t nBoardCol = size_t(0); nBoardCol < m_nBoardColCount ; ++nBoardCol)
         {
-            if (nBoardCol == 0 && nBoardRow == 0)
+            if (nBoardCol == size_t(0) && nBoardRow == size_t(0))
                 continue;                       // Skip this one since it is done already
             CPoint pntOffset = ComputeGraphicalOffset(nBoardRow, nBoardCol);
 
@@ -340,27 +340,27 @@ void CGeomorphicBoard::CreateBitmap(CBitmap& m_bmap, CSize size)
     dc.SelectPalette(prvPal, FALSE);
 }
 
-CPoint CGeomorphicBoard::ComputeGraphicalOffset(int nBoardRow, int nBoardCol)
+CPoint CGeomorphicBoard::ComputeGraphicalOffset(size_t nBoardRow, size_t nBoardCol)
 {
-    CBoard& pBrdRoot = GetBoard(0, 0);
+    CBoard& pBrdRoot = GetBoard(size_t(0), size_t(0));
     CSize sizeCell = pBrdRoot.GetBoardArray()->GetCellSize(fullScale);
     CPoint pnt(0, 0);
-    for (int nCol = 0; nCol < nBoardCol; nCol++)
+    for (size_t nCol = size_t(0) ; nCol < nBoardCol ; ++nCol)
     {
-        CBoard& pBrd = GetBoard(0, nCol);
+        CBoard& pBrd = GetBoard(size_t(0), nCol);
         CBoardArray* pBArray = pBrd.GetBoardArray();
         pnt.x += pBArray->GetWidth(fullScale);
-        if (nBoardCol != 0 && pBArray->GetCellForm(fullScale)->GetCellType() == cformHexFlat)
+        if (nBoardCol != size_t(0) && pBArray->GetCellForm(fullScale)->GetCellType() == cformHexFlat)
             pnt.x -= sizeCell.cx;               // A column is shared
         else
             pnt.x -= sizeCell.cx / 2;           // A column is half shared
     }
-    for (int nRow = 0; nRow < nBoardRow; nRow++)
+    for (size_t nRow = size_t(0) ; nRow < nBoardRow ; ++nRow)
     {
-        CBoard& pBrd = GetBoard(nRow, 0);
+        CBoard& pBrd = GetBoard(nRow, size_t(0));
         CBoardArray* pBArray = pBrd.GetBoardArray();
         pnt.y += pBArray->GetHeight(fullScale);
-        if (nBoardRow != 0 && pBArray->GetCellForm(fullScale)->GetCellType() == cformHexPnt)
+        if (nBoardRow != size_t(0) && pBArray->GetCellForm(fullScale)->GetCellType() == cformHexPnt)
             pnt.y -= sizeCell.cy;               // A row is shared
         else
             pnt.y -= sizeCell.cy / 2;           // A row is half shared
@@ -373,40 +373,40 @@ void CGeomorphicBoard::ComputeNewBoardDimensions(int& rnRows, int& rnCols)
 {
     rnRows = 0;
     rnCols = 0;
-    for (int nBoardCol = 0; nBoardCol < m_nBoardColCount; nBoardCol++)
+    for (size_t nBoardCol = size_t(0) ; nBoardCol < m_nBoardColCount ; ++nBoardCol)
     {
-        CBoard& pBrd = GetBoard(0, nBoardCol);
+        CBoard& pBrd = GetBoard(size_t(0), nBoardCol);
         CBoardArray* pBArray = pBrd.GetBoardArray();
         rnCols += pBArray->GetCols();
-        if (nBoardCol != 0 && pBArray->GetCellForm(fullScale)->GetCellType() == cformHexFlat)
+        if (nBoardCol != size_t(0) && pBArray->GetCellForm(fullScale)->GetCellType() == cformHexFlat)
             rnCols--;                   // A column is shared
     }
-    for (int nBoardRow = 0; nBoardRow < m_nBoardRowCount; nBoardRow++)
+    for (size_t nBoardRow = size_t(0) ; nBoardRow < m_nBoardRowCount ; ++nBoardRow)
     {
-        CBoard& pBrd = GetBoard(nBoardRow, 0);
+        CBoard& pBrd = GetBoard(nBoardRow, size_t(0));
         CBoardArray* pBArray = pBrd.GetBoardArray();
         rnRows += pBArray->GetRows();
-        if (nBoardRow != 0 && pBArray->GetCellForm(fullScale)->GetCellType() == cformHexPnt)
+        if (nBoardRow != size_t(0) && pBArray->GetCellForm(fullScale)->GetCellType() == cformHexPnt)
             rnRows--;                   // A row is shared
     }
 }
 
-void CGeomorphicBoard::ComputeCellOffset(int nBoardRow, int nBoardCol,
+void CGeomorphicBoard::ComputeCellOffset(size_t nBoardRow, size_t nBoardCol,
     int& rnCellRow, int& rnCellCol)
 {
     rnCellRow = 0;
     rnCellCol = 0;
-    for (int nCol = 0; nCol < nBoardCol; nCol++)
+    for (size_t nCol = size_t(0) ; nCol < nBoardCol ; ++nCol)
     {
-        CBoard& pBrd = GetBoard(0, nCol);
+        CBoard& pBrd = GetBoard(size_t(0), nCol);
         CBoardArray* pBArray = pBrd.GetBoardArray();
         rnCellCol += pBArray->GetCols();
         if (pBArray->GetCellForm(fullScale)->GetCellType() == cformHexFlat)
             rnCellCol--;
     }
-    for (int nRow = 0; nRow < nBoardRow; nRow++)
+    for (size_t nRow = size_t(0) ; nRow < nBoardRow ; ++nRow)
     {
-        CBoard& pBrd = GetBoard(nRow, 0);
+        CBoard& pBrd = GetBoard(nRow, size_t(0));
         CBoardArray* pBArray = pBrd.GetBoardArray();
         rnCellRow += pBArray->GetRows();
         if (pBArray->GetCellForm(fullScale)->GetCellType() == cformHexPnt)
@@ -414,11 +414,11 @@ void CGeomorphicBoard::ComputeCellOffset(int nBoardRow, int nBoardCol,
     }
 }
 
-CBoard& CGeomorphicBoard::GetBoard(int nBoardRow, int nBoardCol)
+CBoard& CGeomorphicBoard::GetBoard(size_t nBoardRow, size_t nBoardCol)
 {
-    int nGeoIndex = nBoardRow * m_nBoardColCount + nBoardCol;
+    size_t nGeoIndex = nBoardRow * m_nBoardColCount + nBoardCol;
     ASSERT(nGeoIndex < m_nBoardRowCount * m_nBoardColCount);
-    CGeoBoardElement geo = GetAt(nGeoIndex);
+    CGeoBoardElement geo = GetAt(value_preserving_cast<intptr_t>(nGeoIndex));
     size_t nBrdIndex = m_pDoc->GetBoardManager()->FindBoardBySerial(geo.m_nBoardSerialNum);
     CBoard& pBrd = m_pDoc->GetBoardManager()->GetBoard(nBrdIndex);
     return pBrd;
@@ -467,10 +467,10 @@ void CGeomorphicBoard::Serialize(CArchive& ar)
         ar << m_strName;
 
         ar << m_nSerialNum;
-        ar << (WORD)m_nBoardRowCount;
-        ar << (WORD)m_nBoardColCount;
+        ar << value_preserving_cast<WORD>(m_nBoardRowCount);
+        ar << value_preserving_cast<WORD>(m_nBoardColCount);
 
-        ar << (WORD)GetSize();
+        ar << value_preserving_cast<WORD>(GetSize());
         for (int i = 0; i < GetSize(); i++)
             ElementAt(i).Serialize(ar);
     }
@@ -481,8 +481,8 @@ void CGeomorphicBoard::Serialize(CArchive& ar)
         ar >> m_strName;
 
         ar >> m_nSerialNum;
-        ar >> wTmp; m_nBoardRowCount = (int)wTmp;
-        ar >> wTmp; m_nBoardColCount = (int)wTmp;
+        ar >> wTmp; m_nBoardRowCount = value_preserving_cast<size_t>(wTmp);
+        ar >> wTmp; m_nBoardColCount = value_preserving_cast<size_t>(wTmp);
 
         RemoveAll();
         WORD wCount;

--- a/GP/GeoBoard.cpp
+++ b/GP/GeoBoard.cpp
@@ -54,10 +54,29 @@ void CGeoBoardElement::Serialize(CArchive& ar)
     if (ar.IsStoring())
     {
         ar << m_nBoardSerialNum;
+        if (CB::GetVersion(ar) <= NumVersion(3, 90))
+        {
+            if (m_nReserved != uint8_t(0))
+            {
+                AfxThrowArchiveException(CArchiveException::badSchema);
+            }
+        }
+        else
+        {
+            ar << m_nReserved;
+        }
     }
     else
     {
         ar >> m_nBoardSerialNum;
+        if (CB::GetVersion(ar) <= NumVersion(3, 90))
+        {
+            m_nReserved = uint8_t(0);
+        }
+        else
+        {
+            ar >> m_nReserved;
+        }
     }
 }
 

--- a/GP/GeoBoard.cpp
+++ b/GP/GeoBoard.cpp
@@ -469,10 +469,25 @@ void CGeomorphicBoard::Serialize(CArchive& ar)
         ar << m_strName;
 
         ar << m_nSerialNum;
-        ar << value_preserving_cast<WORD>(m_nBoardRowCount);
-        ar << value_preserving_cast<WORD>(m_nBoardColCount);
+        if (CB::GetVersion(ar) <= NumVersion(3, 90))
+        {
+            ar << value_preserving_cast<WORD>(m_nBoardRowCount);
+            ar << value_preserving_cast<WORD>(m_nBoardColCount);
+        }
+        else
+        {
+            CB::WriteCount(ar, m_nBoardRowCount);
+            CB::WriteCount(ar, m_nBoardColCount);
+        }
 
-        ar << value_preserving_cast<WORD>(GetSize());
+        if (CB::GetVersion(ar) <= NumVersion(3, 90))
+        {
+            ar << value_preserving_cast<WORD>(GetSize());
+        }
+        else
+        {
+            CB::WriteCount(ar, value_preserving_cast<size_t>(GetSize()));
+        }
         for (int i = 0; i < GetSize(); i++)
             ElementAt(i).Serialize(ar);
     }
@@ -483,12 +498,28 @@ void CGeomorphicBoard::Serialize(CArchive& ar)
         ar >> m_strName;
 
         ar >> m_nSerialNum;
-        ar >> wTmp; m_nBoardRowCount = value_preserving_cast<size_t>(wTmp);
-        ar >> wTmp; m_nBoardColCount = value_preserving_cast<size_t>(wTmp);
+        if (CB::GetVersion(ar) <= NumVersion(3, 90))
+        {
+            ar >> wTmp; m_nBoardRowCount = value_preserving_cast<size_t>(wTmp);
+            ar >> wTmp; m_nBoardColCount = value_preserving_cast<size_t>(wTmp);
+        }
+        else
+        {
+            m_nBoardRowCount = CB::ReadCount(ar);
+            m_nBoardColCount = CB::ReadCount(ar);
+        }
 
         RemoveAll();
-        WORD wCount;
-        ar >> wCount;
+        size_t wCount;
+        if (CB::GetVersion(ar) <= NumVersion(3, 90))
+        {
+            ar >> wTmp;
+            wCount = wTmp;
+        }
+        else
+        {
+            wCount = CB::ReadCount(ar);
+        }
         while (wCount--)
         {
              CGeoBoardElement geo;

--- a/GP/GeoBoard.cpp
+++ b/GP/GeoBoard.cpp
@@ -72,18 +72,17 @@ CGeomorphicBoard::CGeomorphicBoard()
     m_pDoc = NULL;
 }
 
-CGeomorphicBoard::CGeomorphicBoard(CGeomorphicBoard* pGeoBoard)
+CGeomorphicBoard::CGeomorphicBoard(const CGeomorphicBoard& pGeoBoard)
 {
-    ASSERT(pGeoBoard != NULL);
-    m_strName = pGeoBoard->m_strName;
-    m_nSerialNum = pGeoBoard->m_nSerialNum;
-    m_nBoardRowCount = pGeoBoard->m_nBoardRowCount;
-    m_nBoardColCount = pGeoBoard->m_nBoardColCount;
-    m_pDoc = pGeoBoard->m_pDoc;
+    m_strName = pGeoBoard.m_strName;
+    m_nSerialNum = pGeoBoard.m_nSerialNum;
+    m_nBoardRowCount = pGeoBoard.m_nBoardRowCount;
+    m_nBoardColCount = pGeoBoard.m_nBoardColCount;
+    m_pDoc = pGeoBoard.m_pDoc;
 
     RemoveAll();
-    for (int i = 0; i < pGeoBoard->GetSize(); i++)
-         Add(pGeoBoard->GetAt(i));
+    for (int i = 0; i < pGeoBoard.GetSize(); i++)
+         Add(pGeoBoard.GetAt(i));
 }
 
 /////////////////////////////////////////////////////////////////////////////

--- a/GP/GeoBoard.h
+++ b/GP/GeoBoard.h
@@ -35,6 +35,7 @@ class CGamDoc;
 struct CGeoBoardElement
 {
     BoardID m_nBoardSerialNum;
+    uint8_t m_nReserved = uint8_t(0);    // for board rotation
 
 public:
     CGeoBoardElement();

--- a/GP/GeoBoard.h
+++ b/GP/GeoBoard.h
@@ -69,6 +69,7 @@ public:
 // Methods...
 public:
     CBoard* CreateBoard(CGamDoc* pDoc);
+    void DeleteFromBoardManager();
 
     intptr_t  AddElement(BoardID nBoardSerialNum);
 

--- a/GP/GeoBoard.h
+++ b/GP/GeoBoard.h
@@ -78,16 +78,16 @@ public:
 protected:
     CBoard& GetBoard(size_t nBoardRow, size_t nBoardCol);
     CBoard* CloneBoard(CBoard& pOrigBoard);
-    void    ComputeNewBoardDimensions(int& rnRows, int& rnCols);
+    void    ComputeNewBoardDimensions(size_t& rnRows, size_t& rnCols);
     CPoint  ComputeGraphicalOffset(size_t nBoardRow, size_t nBoardCol);
-    void    ComputeCellOffset(size_t nBoardRow, size_t nBoardCol, int& rnCellRow, int& rnCellCol);
+    void    ComputeCellOffset(size_t nBoardRow, size_t nBoardCol, size_t& rnCellRow, size_t& rnCellCol);
     void    CopyCells(CBoardArray* pBArryTo, CBoardArray* pBArryFrom,
-                int nCellRowOffset, int nCellColOffset);
+                size_t nCellRowOffset, size_t nCellColOffset);
     void    CreateBitmap(CBitmap& m_bmap, CSize size);
     void    CombineLeftAndRight(CBitmap& bmap, TileScale eScale, CBoardArray* pBALeft,
-                CBoardArray* pBARight, int nRowLeft, int nColLeft, int nRowRight, int nColRight);
+                CBoardArray* pBARight, size_t nRowLeft, size_t nColLeft, size_t nRowRight, size_t nColRight);
     void    CombineTopAndBottom(CBitmap& bmap, TileScale eScale, CBoardArray* pBATop,
-                CBoardArray* pBABottom, int nRowTop, int nColTop, int nRowBottom, int nColBottom);
+                CBoardArray* pBABottom, size_t nRowTop, size_t nColTop, size_t nRowBottom, size_t nColBottom);
     size_t  GetSpecialTileSet();
 
 // Implementation - vars

--- a/GP/GeoBoard.h
+++ b/GP/GeoBoard.h
@@ -47,11 +47,11 @@ public:
 
 /////////////////////////////////////////////////////////////////////////////
 
-class CGeomorphicBoard : public CArray< CGeoBoardElement, CGeoBoardElement& >
+class CGeomorphicBoard : public CArray< CGeoBoardElement >
 {
 public:
     CGeomorphicBoard();
-    CGeomorphicBoard(CGeomorphicBoard* pGeoBoard);
+    CGeomorphicBoard(const CGeomorphicBoard& pGeoBoard);
 
 // Atributes...
 public:

--- a/GP/GeoBoard.h
+++ b/GP/GeoBoard.h
@@ -60,27 +60,27 @@ public:
     void SetSerialNumber(BoardID nBoardSerialNumber) { m_nSerialNum = nBoardSerialNumber; }
     BoardID GetSerialNumber() const { return m_nSerialNum; }
 
-    void SetBoardRowCount(int nBoardRowCount) { m_nBoardRowCount = nBoardRowCount; }
-    void SetBoardColCount(int nBoardColCount) { m_nBoardColCount = nBoardColCount; }
+    void SetBoardRowCount(size_t nBoardRowCount) { m_nBoardRowCount = nBoardRowCount; }
+    void SetBoardColCount(size_t nBoardColCount) { m_nBoardColCount = nBoardColCount; }
 
-    int  GetBoardRowCount() { return m_nBoardRowCount; }
-    int  GetBoardColCount() { return m_nBoardColCount; }
+    size_t GetBoardRowCount() { return m_nBoardRowCount; }
+    size_t GetBoardColCount() { return m_nBoardColCount; }
 
 // Methods...
 public:
     CBoard* CreateBoard(CGamDoc* pDoc);
 
-    int  AddElement(BoardID nBoardSerialNum);
+    intptr_t  AddElement(BoardID nBoardSerialNum);
 
     void Serialize(CArchive& ar);
 
 // Implementation - methods
 protected:
-    CBoard& GetBoard(int nBoardRow, int nBoardCol);
+    CBoard& GetBoard(size_t nBoardRow, size_t nBoardCol);
     CBoard* CloneBoard(CBoard& pOrigBoard);
     void    ComputeNewBoardDimensions(int& rnRows, int& rnCols);
-    CPoint  ComputeGraphicalOffset(int nBoardRow, int nBoardCol);
-    void    ComputeCellOffset(int nBoardRow, int nBoardCol, int& rnCellRow, int& rnCellCol);
+    CPoint  ComputeGraphicalOffset(size_t nBoardRow, size_t nBoardCol);
+    void    ComputeCellOffset(size_t nBoardRow, size_t nBoardCol, int& rnCellRow, int& rnCellCol);
     void    CopyCells(CBoardArray* pBArryTo, CBoardArray* pBArryFrom,
                 int nCellRowOffset, int nCellColOffset);
     void    CreateBitmap(CBitmap& m_bmap, CSize size);
@@ -92,11 +92,11 @@ protected:
 
 // Implementation - vars
 protected:
-    CString m_strName;                  // The board's name
-    BoardID m_nSerialNum;               // The issued serial number
+    CString  m_strName;                 // The board's name
+    BoardID  m_nSerialNum;              // The issued serial number
 
-    int     m_nBoardRowCount;           // Number of boards vertically
-    int     m_nBoardColCount;           // Number of boards horizontally
+    size_t m_nBoardRowCount;          // Number of boards vertically
+    size_t m_nBoardColCount;          // Number of boards horizontally
 
     CGamDoc* m_pDoc;                    // Used internally
 };

--- a/GP/Gp.cpp
+++ b/GP/Gp.cpp
@@ -155,7 +155,7 @@ BOOL CGpApp::InitInstance()
 
     m_bDisableHtmlHelp = GetProfileInt(szSectSettings, szSectDisableHtmlHelp, 0);
     if (!m_bDisableHtmlHelp)
-        ::HtmlHelp(NULL, NULL, HH_INITIALIZE, (DWORD)&m_dwHtmlHelpCookie);
+        ::HtmlHelp(NULL, NULL, HH_INITIALIZE, reinterpret_cast<uintptr_t>(&m_dwHtmlHelpCookie));
 
     g_gt.InitGdiTools();
     g_res.InitResourceTable(m_hInstance);
@@ -368,7 +368,7 @@ void CGpApp::DoHelpContents()
         DoHelpShellLaunch();
 }
 
-void CGpApp::DoHelpContext(DWORD dwContextData)
+void CGpApp::DoHelpContext(uintptr_t dwContextData)
 {
     if (!m_bDisableHtmlHelp)
         ::HtmlHelp(0, m_pszHelpFilePath, HH_HELP_CONTEXT, dwContextData);
@@ -396,7 +396,7 @@ BOOL CGpApp::DoHelpTipHelp(HELPINFO* pHelpInfo, DWORD* dwIDArray)
         CString strHelpPath = m_pszHelpFilePath;
         strHelpPath += HELP_TIP_CONTEXT_FILE;
         return ::HtmlHelp((HWND)pHelpInfo->hItemHandle,
-            strHelpPath, HH_TP_HELP_WM_HELP, (DWORD)(LPVOID)dwIDArray) != NULL;
+            strHelpPath, HH_TP_HELP_WM_HELP, reinterpret_cast<uintptr_t>(dwIDArray)) != NULL;
     }
     return TRUE;
 }
@@ -412,7 +412,7 @@ void CGpApp::DoHelpWhatIsHelp(CWnd* pWndCtrl, DWORD* dwIDArray)
     CString strHelpPath = m_pszHelpFilePath;
     strHelpPath += HELP_TIP_CONTEXT_FILE;
     ::HtmlHelp(pWndCtrl->GetSafeHwnd(), strHelpPath,
-        HH_TP_HELP_CONTEXTMENU, (DWORD)(LPVOID)dwIDArray);
+        HH_TP_HELP_CONTEXTMENU, reinterpret_cast<uintptr_t>(dwIDArray));
 }
 
 /////////////////////////////////////////////////////////////////////////////

--- a/GP/Gp.h
+++ b/GP/Gp.h
@@ -103,7 +103,7 @@ public:
 public:
     void DoHelpShellLaunch();
     void DoHelpContents();
-    void DoHelpContext(DWORD dwContextData);
+    void DoHelpContext(uintptr_t dwContextData);
     void DoHelpTopic(LPCTSTR pszTopic);
     BOOL DoHelpTipHelp(HELPINFO* pHelpInfo, DWORD* dwIDArray);
     void DoHelpWhatIsHelp(CWnd* pWndCtrl, DWORD* dwIDArray);

--- a/GP/MapFace.cpp
+++ b/GP/MapFace.cpp
@@ -55,7 +55,7 @@ TileID CTileFacingMap::CreateFacingTileID(ElementState state, TileID baseTileID)
     CDib    dibSrc;
     CTile   tile;
     CBitmap bmap;
-    int nAngleDegCW = GetElementFacingAngle(state);
+    uint16_t nAngleDegCW = state.GetFacing();
 
     // Generate rotated full scale bitmap of tile...
 

--- a/GP/MoveHist.cpp
+++ b/GP/MoveHist.cpp
@@ -48,16 +48,32 @@ void CHistoryTable::Serialize(CArchive& ar)
 {
     if (ar.IsStoring())
     {
-        ar << value_preserving_cast<WORD>(size());
-        for (size_t i = 0; i < size(); i++)
+        if (CB::GetVersion(ar) <= NumVersion(3, 90))
+        {
+            ar << value_preserving_cast<WORD>(size());
+        }
+        else
+        {
+            CB::WriteCount(ar, size());
+        }
+        for (size_t i = size_t(0); i < size(); i++)
             GetHistRecord(i).Serialize(ar);
     }
     else
     {
         Clear();
-        WORD wSize;
-        ar >> wSize;
-        for (WORD i = 0; i < wSize; i++)
+        size_t wSize;
+        if (CB::GetVersion(ar) <= NumVersion(3, 90))
+        {
+            WORD temp;
+            ar >> temp;
+            wSize = temp;
+        }
+        else
+        {
+            wSize = CB::ReadCount(ar);
+        }
+        for (size_t i = size_t(0) ; i < wSize ; ++i)
         {
             OwnerPtr<CHistRecord> pRcd = new CHistRecord;
             pRcd->Serialize(ar);

--- a/GP/MoveMgr.cpp
+++ b/GP/MoveMgr.cpp
@@ -764,7 +764,7 @@ void CObjectSetText::DoMove(CGamDoc* pDoc, int nMoveWithinGroup)
 {
     CPlayBoard* pPBoard;
     CTraySet* pTray;
-    CDrawObj* pObj;
+    CDrawObj* pObj = nullptr;
     CPieceObj* pPObj;
 
     pDoc->SetGameElementString(m_elem,

--- a/GP/MoveMgr.cpp
+++ b/GP/MoveMgr.cpp
@@ -1787,7 +1787,7 @@ void CMoveList::Serialize(CArchive& ar, BOOL bSaveUndo)
 
         ar << (short)m_nSeqNum;
         ar << (WORD)m_bCompoundMove;
-        ar << value_preserving_cast<DWORD>(m_nCompoundBaseIndex);
+        ar << (m_nCompoundBaseIndex != Invalid_v<size_t> ? value_preserving_cast<uint32_t>(m_nCompoundBaseIndex) : uint32_t(INT32_C(-1)));
         ar << (BYTE)(m_pCompoundBaseBookMark != NULL ? 1 : 0);
         if (m_pCompoundBaseBookMark)
             m_pCompoundBaseBookMark->Serialize(ar);
@@ -1813,9 +1813,9 @@ void CMoveList::Serialize(CArchive& ar, BOOL bSaveUndo)
         {
             BYTE  cTmp;
             WORD  wTmp;
-            DWORD dwTmp;
+            uint32_t dwTmp;
             ar >> wTmp; m_bCompoundMove = (BOOL)wTmp;
-            ar >> dwTmp; m_nCompoundBaseIndex = value_preserving_cast<size_t>(dwTmp);
+            ar >> dwTmp; m_nCompoundBaseIndex = (dwTmp != uint32_t(INT32_C(-1)) ? value_preserving_cast<size_t>(dwTmp) : Invalid_v<size_t>);
             ar >> cTmp;             // Check for a bookmark
             if (cTmp)
             {

--- a/GP/MoveMgr.cpp
+++ b/GP/MoveMgr.cpp
@@ -1012,12 +1012,15 @@ void CMovePlotList::Serialize(CArchive& ar)
 {
     CMoveRecord::Serialize(ar);
     if (ar.IsStoring())
+    {
         ar << m_nBrdNum;
+        ar << m_tblPlot;
+    }
     else
     {
         ar >> m_nBrdNum;
+        ar >> m_tblPlot;
     }
-    m_tblPlot.Serialize(ar);
 }
 
 #ifdef _DEBUG

--- a/GP/MoveMgr.cpp
+++ b/GP/MoveMgr.cpp
@@ -404,22 +404,20 @@ void CPieceSetFacing::Serialize(CArchive& ar)
     if (ar.IsStoring())
     {
         ar << m_pid;
-        ar << (WORD)m_nFacingDegCW;
+        ar << m_nFacingDegCW;
     }
     else
     {
-        WORD wTmp;
         ar >> m_pid;
         if (CGamDoc::GetLoadingVersion() < NumVersion(2, 90))   //Ver2.90
         {
             BYTE cTmp;
             ar >> cTmp;
-            m_nFacingDegCW = 5 * (int)cTmp;
+            m_nFacingDegCW = value_preserving_cast<uint16_t>(5 * cTmp);
         }
         else
         {
-            ar >> wTmp;
-            m_nFacingDegCW = (int)wTmp;
+            ar >> m_nFacingDegCW;
         }
     }
 }
@@ -502,7 +500,7 @@ void CPieceSetOwnership::DumpToTextFile(CFile& file)
 /////////////////////////////////////////////////////////////////////
 // CMarkerSetFacing methods....
 
-CMarkerSetFacing::CMarkerSetFacing(ObjectID dwObjID, MarkID mid, int nFacingDegCW)
+CMarkerSetFacing::CMarkerSetFacing(ObjectID dwObjID, MarkID mid, uint16_t nFacingDegCW)
 {
     m_eType = mrecMFacing;
     m_dwObjID = dwObjID;
@@ -545,16 +543,15 @@ void CMarkerSetFacing::Serialize(CArchive& ar)              // VER2.0 is first t
     {
         ar << m_dwObjID;
         ar << m_mid;
-        ar << value_preserving_cast<WORD>(m_nFacingDegCW);
+        ar << m_nFacingDegCW;
     }
     else
     {
         ar >> m_dwObjID;
-        WORD wTmp;
         ar >> m_mid;
-        ar >> wTmp; m_nFacingDegCW = value_preserving_cast<int>(wTmp);
+        ar >> m_nFacingDegCW;
         if (CGamDoc::GetLoadingVersion() < NumVersion(2, 90))   //Ver2.90
-            m_nFacingDegCW *= 5;                                // Convert old values to degrees
+            m_nFacingDegCW *= uint16_t(5);                                // Convert old values to degrees
     }
 }
 

--- a/GP/MoveMgr.h
+++ b/GP/MoveMgr.h
@@ -46,14 +46,14 @@ public:
         mrecMax };
 
 public:
-    CMoveRecord() { m_nSeqNum = -1; m_eType = mrecUnknown; }
+    CMoveRecord() { m_nSeqNum = Invalid_v<size_t>; m_eType = mrecUnknown; }
     virtual ~CMoveRecord() {}
 
 public:
     RcdType GetType() { return m_eType; }
     // -------- //
-    void SetSeqNum(int nSeq) { m_nSeqNum = nSeq; }
-    int  GetSeqNum() { return m_nSeqNum; }
+    void   SetSeqNum(size_t nSeq) { m_nSeqNum = nSeq; }
+    size_t GetSeqNum() { return m_nSeqNum; }
 
 public:
     virtual BOOL IsMoveHidden(CGamDoc* pDoc, int nMoveWithinGroup) { return FALSE; }
@@ -69,7 +69,7 @@ public:
     virtual void DumpToTextFile(CFile& file) = 0;
 #endif
 protected:
-    int     m_nSeqNum;              // Used to group move records
+    size_t  m_nSeqNum;              // Used to group move records
     RcdType m_eType;                // Type of record
 };
 
@@ -548,7 +548,7 @@ protected:
     BOOL        m_bQuietPlaybackSave;
 
     // Serialize the following...
-    int         m_nSeqNum;
+    size_t      m_nSeqNum;
 
     BOOL        m_bCompoundMove;        // Recording a compound move.
     CGameState* m_pCompoundBaseBookMark;// Game state at start of compound move

--- a/GP/MoveMgr.h
+++ b/GP/MoveMgr.h
@@ -157,7 +157,7 @@ class CPieceSetFacing : public CMoveRecord
 {
 public:
     CPieceSetFacing() { m_eType = mrecPFacing; }
-    CPieceSetFacing(PieceID pid, int nFacingDegCW)
+    CPieceSetFacing(PieceID pid, uint16_t nFacingDegCW)
         { m_eType = mrecPFacing; m_pid = pid; m_nFacingDegCW = nFacingDegCW; }
 
     virtual void DoMoveSetup(CGamDoc* pDoc, int nMoveWithinGroup);
@@ -173,7 +173,7 @@ public:
 #endif
 protected:
     PieceID     m_pid;
-    int         m_nFacingDegCW;
+    uint16_t    m_nFacingDegCW;
 };
 
 ///////////////////////////////////////////////////////////////////////
@@ -205,7 +205,7 @@ class CMarkerSetFacing : public CMoveRecord
 {
 public:
     CMarkerSetFacing() { m_eType = mrecMFacing; }
-    CMarkerSetFacing(ObjectID dwObjID, MarkID mid, int nFacingDegCW);
+    CMarkerSetFacing(ObjectID dwObjID, MarkID mid, uint16_t nFacingDegCW);
 
     virtual void DoMoveSetup(CGamDoc* pDoc, int nMoveWithinGroup);
     virtual void DoMove(CGamDoc* pDoc, int nMoveWithinGroup);
@@ -219,7 +219,7 @@ public:
 protected:
     ObjectID    m_dwObjID;
     MarkID      m_mid;
-    int         m_nFacingDegCW;
+    uint16_t    m_nFacingDegCW;
 };
 
 ///////////////////////////////////////////////////////////////////////

--- a/GP/PBoard.cpp
+++ b/GP/PBoard.cpp
@@ -102,7 +102,7 @@ CPlayBoard::CPlayBoard()
     m_crTextColor = RGB(0, 0, 0);
     m_crTextBoxColor = RGB(255, 255, 255);
     m_fontID = CGameBox::GetFontManager()->AddFont(
-        TenthPointsToScreenPixels(100), taBold, FF_SWISS, "Arial");
+        TenthPointsToScreenPixels(100), taBold, uint8_t(FF_SWISS), "Arial");
 
     m_bLockedDrawnBeneath = TRUE;
     m_bPVisible = TRUE;

--- a/GP/PBoard.cpp
+++ b/GP/PBoard.cpp
@@ -587,16 +587,16 @@ void CPBoardManager::AddBoard(BoardID nSerialNum, BOOL bInheritSettings)
 
 void CPBoardManager::AddBoard(CBoard* pBoard, BOOL bInheritSettings)
 {
-    resize(size() + size_t(1));
-    back().SetDocument(m_pDoc);
-    back().SetBoard(CheckedDeref(pBoard), bInheritSettings);
+    push_back(new CPlayBoard);
+    back()->SetDocument(m_pDoc);
+    back()->SetBoard(CheckedDeref(pBoard), bInheritSettings);
 }
 
 void CPBoardManager::AddBoard(CGeomorphicBoard* pGeoBoard, BOOL bInheritSettings)
 {
-    resize(size() + size_t(1));
-    back().SetDocument(m_pDoc);
-    back().SetBoard(CheckedDeref(pGeoBoard), bInheritSettings);
+    push_back(new CPlayBoard);
+    back()->SetDocument(m_pDoc);
+    back()->SetBoard(CheckedDeref(pGeoBoard), bInheritSettings);
 }
 
 void CPBoardManager::DeletePBoard(size_t nBrd)
@@ -718,8 +718,9 @@ CPBoardManager* CPBoardManager::Clone(CGamDoc *pDoc)
 {
     CPBoardManager* pMgr = new CPBoardManager;
     pMgr->reserve(GetNumPBoards());
-    for (size_t i = 0; i < GetNumPBoards(); i++)
-        pMgr->push_back(GetPBoard(i).Clone(pDoc));
+    for (size_t i = size_t(0); i < GetNumPBoards(); i++)
+        // Clone() returns obj, not pointer
+        pMgr->push_back(new CPlayBoard(GetPBoard(i).Clone(pDoc)));
     return pMgr;
 }
 
@@ -790,9 +791,9 @@ void CPBoardManager::Serialize(CArchive& ar)
         {
             wTmp = CB::ReadCount(ar);
         }
-        resize(wTmp);
-        for (size_t i = size_t(0); i < size(); i++)
+        for (size_t i = size_t(0); i < wTmp; i++)
         {
+            push_back(new CPlayBoard);
             GetPBoard(i).SetDocument(m_pDoc);
             GetPBoard(i).Serialize(ar);
         }

--- a/GP/PBoard.cpp
+++ b/GP/PBoard.cpp
@@ -769,13 +769,20 @@ void CPBoardManager::Serialize(CArchive& ar)
         ar << m_wReserved3;
         ar << m_wReserved4;
 
-        ar << value_preserving_cast<WORD>(GetNumPBoards());
-        for (size_t i = 0; i < GetNumPBoards(); i++)
+        if (CB::GetVersion(ar) <= NumVersion(3, 90))
+        {
+            ar << value_preserving_cast<WORD>(GetNumPBoards());
+        }
+        else
+        {
+            CB::WriteCount(ar, GetNumPBoards());
+        }
+        for (size_t i = size_t(0); i < GetNumPBoards(); i++)
             GetPBoard(i).Serialize(ar);
     }
     else
     {
-        WORD wTmp;
+        size_t wTmp;
         DestroyAllElements();
         m_pDoc = (CGamDoc*)ar.m_pDocument;
 
@@ -788,9 +795,18 @@ void CPBoardManager::Serialize(CArchive& ar)
         ar >> m_wReserved3;
         ar >> m_wReserved4;
 
-        ar >> wTmp;
-        resize(value_preserving_cast<size_t>(wTmp));
-        for (size_t i = 0; i < size(); i++)
+        if (CB::GetVersion(ar) <= NumVersion(3, 90))
+        {
+            WORD tmp;
+            ar >> tmp;
+            wTmp = tmp;
+        }
+        else
+        {
+            wTmp = CB::ReadCount(ar);
+        }
+        resize(wTmp);
+        for (size_t i = size_t(0); i < size(); i++)
         {
             GetPBoard(i).SetDocument(m_pDoc);
             GetPBoard(i).Serialize(ar);

--- a/GP/PBoard.cpp
+++ b/GP/PBoard.cpp
@@ -252,10 +252,10 @@ void CPlayBoard::LimitRectToBoard(CRect& rct)
 
 //////////////////////////////////////////////////////////////////////
 
-void CPlayBoard::SetBoard(CGeomorphicBoard& pGeoBoard, BOOL bInheritSettings /* = FALSE */)
+void CPlayBoard::SetBoard(const CGeomorphicBoard& pGeoBoard, BOOL bInheritSettings /* = FALSE */)
 {
     ASSERT(!m_pGeoBoard);
-    m_pGeoBoard.Reset(new CGeomorphicBoard(&pGeoBoard), &m_pDoc);
+    m_pGeoBoard.Reset(new CGeomorphicBoard(pGeoBoard), &m_pDoc);
     CBoard& pBrd = CreateGeoBoard();
     SetBoard(pBrd, bInheritSettings);
 }

--- a/GP/PBoard.h
+++ b/GP/PBoard.h
@@ -198,7 +198,7 @@ protected:
 
 //////////////////////////////////////////////////////////////////
 
-class CPBoardManager : private std::vector<CPlayBoard>
+class CPBoardManager : private std::vector<OwnerPtr<CPlayBoard>>
 {
 public:
     CPBoardManager();
@@ -211,7 +211,7 @@ public:
     CBoardManager* GetBoardManager() { return m_pBMgr; }
     size_t GetNumPBoards() const { return size(); }
     bool IsEmpty() const { return empty(); }
-    const CPlayBoard& GetPBoard(size_t nBrd) const { return at(nBrd); }
+    const CPlayBoard& GetPBoard(size_t nBrd) const { return *at(nBrd); }
     CPlayBoard& GetPBoard(size_t nBrd) { return const_cast<CPlayBoard&>(std::as_const(*this).GetPBoard(nBrd)); }
     BoardID IssueGeoSerialNumber();
 

--- a/GP/PBoard.h
+++ b/GP/PBoard.h
@@ -80,7 +80,7 @@ public:
     void SetLocksEnforced(BOOL bEnforce = TRUE) { m_bEnforceLocks = bEnforce; }
     BOOL GetLocksEnforced() { return m_bEnforceLocks; }
 
-    void SetBoard(CGeomorphicBoard& pGeoBoard, BOOL bInheritSettings = FALSE);
+    void SetBoard(const CGeomorphicBoard& pGeoBoard, BOOL bInheritSettings = FALSE);
     void SetBoard(CBoard& pBoard, BOOL bInheritSettings = FALSE);
     CBoard* GetBoard() { return m_pBoard; }
 

--- a/GP/PBoard.h
+++ b/GP/PBoard.h
@@ -171,38 +171,12 @@ public:
 
     // allow default move operations to work right
 private:
-    class UniqueGeoBoard
+    class DeleteGeoBoard
     {
     public:
-        UniqueGeoBoard() noexcept = default;
-        UniqueGeoBoard(const UniqueGeoBoard&) = delete;
-        UniqueGeoBoard& operator=(const UniqueGeoBoard&) = delete;
-        UniqueGeoBoard(UniqueGeoBoard&& other) noexcept
-        {
-            pGeoBoard = other.pGeoBoard;
-            other.pGeoBoard = nullptr;
-            pDoc = other.pDoc;
-        }
-        UniqueGeoBoard& operator=(UniqueGeoBoard&& other) noexcept
-        {
-            std::swap(pGeoBoard, other.pGeoBoard);
-            std::swap(pDoc, other.pDoc);
-            return *this;
-        }
-        ~UniqueGeoBoard() { Reset(); }
-
-        explicit operator bool() const { return pGeoBoard; }
-
-        void Reset(CGeomorphicBoard* p = nullptr, CGamDoc** gd = nullptr);
-
-        CGeomorphicBoard* Get() const { return pGeoBoard; }
-        CGeomorphicBoard* operator->() { return Get(); }
-    private:
-        CGeomorphicBoard* pGeoBoard = nullptr;
-        CGamDoc** pDoc;
+        void operator()(CGeomorphicBoard* p) const;
     };
-public:
-    UniqueGeoBoard m_pGeoBoard; // If not NULL. Board is generated on each load
+    std::unique_ptr<CGeomorphicBoard, DeleteGeoBoard> m_pGeoBoard; // If not NULL. Board is generated on each load
 
 // Implementation
 protected:

--- a/GP/PPieces.cpp
+++ b/GP/PPieces.cpp
@@ -98,7 +98,7 @@ void CPieceTable::SetPieceListAsFrontUp(const std::vector<PieceID>& pPTbl)
     for (size_t i = 0; i < pPTbl.size(); i++)
     {
         PieceID pid = pPTbl.at(i);
-        GetPiece(pid).SetSide(0);          // Front is up
+        GetPiece(pid).SetSide(uint8_t(0));          // Front is up
     }
 }
 
@@ -167,12 +167,12 @@ void CPieceTable::CreatePlayingPieceTable()
 
 ///////////////////////////////////////////////////////////////////////
 
-void CPieceTable::SetPieceFacing(PieceID pid, int nFacingDegCW)
+void CPieceTable::SetPieceFacing(PieceID pid, uint16_t nFacingDegCW)
 {
     GetPiece(pid).SetFacing(nFacingDegCW);
 }
 
-int  CPieceTable::GetPieceFacing(PieceID pid)
+uint16_t CPieceTable::GetPieceFacing(PieceID pid)
 {
     return GetPiece(pid).GetFacing();
 }
@@ -243,7 +243,7 @@ void CPieceTable::SetOwnerMask(PieceID pid, DWORD dwMask)
 
 ///////////////////////////////////////////////////////////////////////
 
-void CPieceTable::SetPiece(PieceID pid, int nSide, int nFacing)
+void CPieceTable::SetPiece(PieceID pid, uint8_t nSide, uint16_t nFacing)
 {
     Piece& pPce = GetPiece(pid);
     pPce.SetSide(nSide);
@@ -300,7 +300,7 @@ TileID CPieceTable::GetFrontTileID(PieceID pid, BOOL bWithFacing)
         return tidBase;
 
     // Handle rotated pieces...
-    return GetFacedTileID(pid, tidBase, pPce->GetFacing(), 0);
+    return GetFacedTileID(pid, tidBase, pPce->GetFacing(), uint8_t(0));
 }
 
 TileID CPieceTable::GetBackTileID(PieceID pid, BOOL bWithFacing)
@@ -315,7 +315,7 @@ TileID CPieceTable::GetBackTileID(PieceID pid, BOOL bWithFacing)
         return tidBase;
 
     // Handle rotated pieces...
-    return GetFacedTileID(pid, tidBase, pPce->GetFacing(), 0);
+    return GetFacedTileID(pid, tidBase, pPce->GetFacing(), uint8_t(0));
 }
 
 ///////////////////////////////////////////////////////////////////////
@@ -360,7 +360,7 @@ TileID CPieceTable::GetInactiveTileID(PieceID pid, BOOL bWithFacing)
 
 ///////////////////////////////////////////////////////////////////////
 
-TileID CPieceTable::GetFacedTileID(PieceID pid, TileID tidBase, int nFacing, int nSide) const
+TileID CPieceTable::GetFacedTileID(PieceID pid, TileID tidBase, uint16_t nFacing, uint8_t nSide) const
 {
     // Handle rotated pieces...
     ElementState state = MakePieceState(pid, nFacing, nSide);
@@ -508,7 +508,7 @@ void Piece::Serialize(CArchive& ar)
             BYTE chVal;
             ar >> chVal;
             m_nFacing = chVal;
-            m_nFacing *= 5;             // Convert to new degree format
+            m_nFacing *= uint16_t(5);             // Convert to new degree format
         }
         else
             ar >> m_nFacing;
@@ -554,8 +554,8 @@ void CPieceTable::DumpToTextFile(CFile& file)
 
 void Piece::SetUnused()
 {
-    m_nSide = 0xFF;
-    m_nFacing = 0;
+    m_nSide = uint8_t(0xFF);
+    m_nFacing = uint16_t(0);
 }
 
 

--- a/GP/PPieces.cpp
+++ b/GP/PPieces.cpp
@@ -363,7 +363,7 @@ TileID CPieceTable::GetInactiveTileID(PieceID pid, BOOL bWithFacing)
 TileID CPieceTable::GetFacedTileID(PieceID pid, TileID tidBase, uint16_t nFacing, uint8_t nSide) const
 {
     // Handle rotated pieces...
-    ElementState state = MakePieceState(pid, nFacing, nSide);
+    ElementState state(pid, nFacing, nSide);
     CTileFacingMap* pMapFacing = m_pDoc->GetFacingMap();
     TileID tidFacing = pMapFacing->GetFacingTileID(state);
     if (tidFacing != nullTid)

--- a/GP/PPieces.h
+++ b/GP/PPieces.h
@@ -57,14 +57,14 @@ public:
     BOOL IsUsed() const         { return m_nSide != 0xFF; }
     void SetUnused();
 
-    void SetSide(int nSide)     { m_nSide = (BYTE)nSide; }
-    void InvertSide()           { m_nSide ^= 1; }
-    int  GetSide() const        { return (int)m_nSide; }
+    void SetSide(uint8_t nSide) { m_nSide = nSide; }
+    void InvertSide()           { m_nSide ^= uint8_t(1); }
+    uint8_t GetSide() const     { return m_nSide; }
     BOOL IsFrontUp() const      { return m_nSide == 0; }
     BOOL IsBackUp() const       { return m_nSide == 1; }
 
-    void SetFacing(int nFacing) { m_nFacing = (WORD)nFacing; }
-    int  GetFacing() const      { return (int)m_nFacing; }
+    void SetFacing(uint16_t nFacing) { m_nFacing = nFacing; }
+    uint16_t GetFacing() const  { return m_nFacing; }
 
     DWORD GetOwnerMask() const  { return m_dwOwnerMask; }
     void SetOwnerMask(DWORD dwMask) { m_dwOwnerMask = dwMask; }
@@ -114,8 +114,8 @@ public:
 
     void FlipPieceOver(PieceID pid);
 
-    void SetPieceFacing(PieceID pid, int nFacingDegCW);
-    int  GetPieceFacing(PieceID pid);
+    void SetPieceFacing(PieceID pid, uint16_t nFacingDegCW);
+    uint16_t GetPieceFacing(PieceID pid);
 
     BOOL IsFrontUp(PieceID pid);
     BOOL Is2Sided(PieceID pid) const;
@@ -140,7 +140,7 @@ public:
     CSize GetStackedSize(const std::vector<PieceID>& pTbl, int xDelta, int yDelta, BOOL bWithFacing = FALSE);
 
     void CreatePlayingPieceTable();
-    void SetPiece(PieceID pid, int nSide = 0, int nFacing = 0);
+    void SetPiece(PieceID pid, uint8_t nSide = uint8_t(0), uint16_t nFacing = uint16_t(0));
     void SetPieceUnused(PieceID pid);
 
     void PurgeUndefinedPieceIDs();
@@ -182,7 +182,7 @@ protected:
         pPce = const_cast<Piece*>(temp);
     }
 
-    TileID GetFacedTileID(PieceID pid, TileID tidBase, int nFacing, int nSide) const;
+    TileID GetFacedTileID(PieceID pid, TileID tidBase, uint16_t nFacing, uint8_t nSide) const;
 };
 
 #endif

--- a/GP/PalReadMsg.cpp
+++ b/GP/PalReadMsg.cpp
@@ -97,7 +97,7 @@ END_MESSAGE_MAP()
 CReadMsgWnd::CReadMsgWnd()
 {
     m_pDoc = NULL;
-    m_nMsgCount = 0;
+    m_nMsgCount = size_t(0);
 }
 
 CReadMsgWnd::~CReadMsgWnd()
@@ -177,7 +177,7 @@ void CReadMsgWnd::SetText(CGamDoc* pDoc)
     {
         m_editCtrl.SetWindowText("");
         m_pDoc = pDoc;
-        m_nMsgCount = 0;
+        m_nMsgCount = size_t(0);
     }
     if (m_pDoc != NULL)
         ProcessMessages();
@@ -188,22 +188,22 @@ void CReadMsgWnd::SetText(CGamDoc* pDoc)
 void CReadMsgWnd::ProcessMessages()
 {
     CStringArray& astrHist = m_pDoc->MsgGetMessageHistory();
-    if (astrHist.GetSize() <= 0 || astrHist.GetSize() < m_nMsgCount)
+    if (astrHist.GetSize() <= 0 || astrHist.GetSize() < value_preserving_cast<intptr_t>(m_nMsgCount))
     {
-        m_nMsgCount = 0;
+        m_nMsgCount = size_t(0);
         m_editCtrl.SetWindowText("");
     }
 
-    int nOldCount = m_nMsgCount;            // Save previous length for a moment
-    m_nMsgCount = astrHist.GetSize();       // Set new high water mark
-    for (int i = nOldCount; i < m_nMsgCount; i++)
+    size_t nOldCount = m_nMsgCount;            // Save previous length for a moment
+    m_nMsgCount = value_preserving_cast<size_t>(astrHist.GetSize());       // Set new high water mark
+    for (size_t i = nOldCount ; i < m_nMsgCount ; ++i)
     {
-        CString strBfr = astrHist.GetAt(i);
+        CString strBfr = astrHist.GetAt(value_preserving_cast<intptr_t>(i));
         if (strBfr.IsEmpty() || strBfr.GetAt(strBfr.GetLength()-1) != '\n')
         {
             strBfr += "\r\n";
         }
-        if (i > 0)
+        if (i > size_t(0))
         {
             SetTextStyle(MSG_DIVIDER_COLOR, MSG_DIVIDER_EFFECT);
             InsertText(STR_MESSAGE_DIVIDER);

--- a/GP/PalReadMsg.h
+++ b/GP/PalReadMsg.h
@@ -50,7 +50,7 @@ public:
 // Implementation - variables
 protected:
     CGamDoc*        m_pDoc;                 // Doc of current messages
-    int             m_nMsgCount;            // Number of messages already processed
+    size_t          m_nMsgCount;            // Number of messages already processed
 
     CRichEditCtrl   m_editCtrl;
 

--- a/GP/PalTray.cpp
+++ b/GP/PalTray.cpp
@@ -854,16 +854,16 @@ void CTrayPalette::OnPieceTrayShuffleSelected()
 
     // Generate a shuffled index vector for the number of selected items
     UINT nRandSeed = m_pDoc->GetRandomNumberSeed();
-    int nNumIndices = tblListSel.GetSize();
-    std::vector<int> pnIndices = AllocateAndCalcRandomIndexVector(nNumIndices,
-        nNumIndices, nRandSeed, &nRandSeed);
+    ASSERT(nNumSelected == tblListSel.GetSize());
+    std::vector<int> pnIndices = AllocateAndCalcRandomIndexVector(nNumSelected,
+        nNumSelected, nRandSeed, &nRandSeed);
     m_pDoc->SetRandomNumberSeed(nRandSeed);
 
     // Build table of shuffled pieces
     std::vector<PieceID> tblPids;
-    tblPids.reserve(value_preserving_cast<size_t>(nNumIndices));
-    for (int i = 0; i < nNumIndices; i++)
-        tblPids.push_back(m_listTray.MapIndexToItem(value_preserving_cast<size_t>(tblListSel[pnIndices[i]])));
+    tblPids.reserve(value_preserving_cast<size_t>(nNumSelected));
+    for (int i = 0; i < nNumSelected; i++)
+        tblPids.push_back(m_listTray.MapIndexToItem(value_preserving_cast<size_t>(tblListSel[pnIndices[value_preserving_cast<size_t>(i)]])));
 
     m_pDoc->AssignNewMoveGroup();
 

--- a/GP/PalTray.cpp
+++ b/GP/PalTray.cpp
@@ -325,7 +325,7 @@ void CTrayPalette::Serialize(CArchive& ar)
         int nNumSelected = m_listTray.GetSelCount();
         m_tblListBoxSel.SetSize(nNumSelected);
         m_listTray.GetSelItems(nNumSelected, m_tblListBoxSel.GetData());
-        m_tblListBoxSel.Serialize(ar);
+        ar << m_tblListBoxSel;
     }
     else
     {
@@ -334,7 +334,7 @@ void CTrayPalette::Serialize(CArchive& ar)
             DWORD dwTmp;
             ar >> dwTmp; m_nComboIndex = (int)dwTmp;
             ar >> dwTmp; m_nListTopindex = (int)dwTmp;
-            m_tblListBoxSel.Serialize(ar);
+            ar >> m_tblListBoxSel;
             m_bStateVarsArmed = TRUE;           // Inform Create() data is good
         }
         else if (CGamDoc::GetLoadingVersion() >= NumVersion(2, 0))  // V2.0
@@ -342,7 +342,7 @@ void CTrayPalette::Serialize(CArchive& ar)
             DWORD dwTmp;
             ar >> dwTmp; m_nComboIndex = (int)dwTmp;
             ar >> dwTmp; m_nListTopindex = (int)dwTmp;
-            m_tblListBoxSel.Serialize(ar);
+            ar >> m_tblListBoxSel;
             CWinPlacement wndSink;
             ar >> wndSink;                      // Eat this puppy
             m_bStateVarsArmed = TRUE;           // Inform Create() data is good

--- a/GP/Player.cpp
+++ b/GP/Player.cpp
@@ -25,7 +25,7 @@
 #include    "stdafx.h"
 #include    "Player.h"
 
-int CPlayerManager::AddPlayer(LPCTSTR pszName)
+intptr_t CPlayerManager::AddPlayer(LPCTSTR pszName)
 {
     Player player(pszName);
     return Add(player);

--- a/GP/Player.h
+++ b/GP/Player.h
@@ -44,7 +44,7 @@ struct Player
 class CPlayerManager : public CArray< Player, Player& >
 {
 public:
-    int AddPlayer(LPCTSTR pszName);
+    intptr_t AddPlayer(LPCTSTR pszName);
     Player& GetPlayerUsingMask(DWORD dwMask);
 
     static DWORD GetMaskFromPlayerNum(int nPlayerNumber);

--- a/GP/SelOPlay.cpp
+++ b/GP/SelOPlay.cpp
@@ -200,6 +200,7 @@ HCURSOR CSelLine::GetHandleCursor(int nHandleID) const
             id = IDC_CROSS;
             break;
         default: ASSERT(FALSE);
+            id = nullptr;
     }
     return AfxGetApp()->LoadStandardCursor(id);
 }
@@ -214,6 +215,7 @@ CPoint CSelLine::GetHandleLoc(int nHandleID) const
         case hitPtA: x = m_rect.left;  y = m_rect.top;    break;
         case hitPtB: x = m_rect.right; y = m_rect.bottom; break;
         default: ASSERT(FALSE);
+            x = -1; y = -1;
     }
     return CPoint(x, y);
 }
@@ -302,6 +304,7 @@ CPoint CSelGeneric::GetHandleLoc(int nHandleID) const
         case hitBottomRight: x = m_rect.right; y = m_rect.bottom; break;
         case hitBottomLeft:  x = m_rect.left;  y = m_rect.bottom; break;
         default: ASSERT(FALSE);
+            x = -1; y = -1;
     }
     return CPoint(x, y);
 }

--- a/GP/ToolPlay.cpp
+++ b/GP/ToolPlay.cpp
@@ -215,7 +215,7 @@ void CPSelectTool::OnMouseMove(CPlayBoardView* pView, UINT nFlags, CPoint point)
             if (!rct.PtInRect(pt))
             {
                 // It's in the scroll zone
-                if (m_nTimerID == 0)        // Only start if not scrolling
+                if (m_nTimerID == uintptr_t(0))        // Only start if not scrolling
                     StartScrollTimer(pView);
             }
             else
@@ -306,7 +306,7 @@ void CPSelectTool::OnLButtonUp(CPlayBoardView* pView, UINT nFlags, CPoint point)
     CPlayTool::OnLButtonUp(pView, nFlags, point);
 }
 
-void CPSelectTool::OnTimer(CPlayBoardView* pView, UINT nIDEvent)
+void CPSelectTool::OnTimer(CPlayBoardView* pView, uintptr_t nIDEvent)
 {
     if (CWnd::GetCapture() != pView)
     {
@@ -541,10 +541,10 @@ void CPSelectTool::StartDragTimer(CPlayBoardView* pView)
 
 void CPSelectTool::KillDragTimer(CPlayBoardView* pView)
 {
-    if (m_nTimerID != 0)
+    if (m_nTimerID != uintptr_t(0))
     {
         pView->KillTimer(m_nTimerID);
-        m_nTimerID = 0;
+        m_nTimerID = uintptr_t(0);
     }
 }
 
@@ -555,10 +555,10 @@ void CPSelectTool::StartScrollTimer(CPlayBoardView* pView)
 
 void CPSelectTool::KillScrollTimer(CPlayBoardView* pView)
 {
-    if (m_nTimerID != 0)
+    if (m_nTimerID != uintptr_t(0))
     {
         pView->KillTimer(m_nTimerID);
-        m_nTimerID = 0;
+        m_nTimerID = uintptr_t(0);
     }
 }
 
@@ -666,7 +666,7 @@ void CPShapeTool::OnMouseMove(CPlayBoardView* pView, UINT nFlags, CPoint point)
         s_plySelectTool.OnMouseMove(pView, nFlags, point);
 }
 
-void CPShapeTool::OnTimer(CPlayBoardView* pView, UINT nIDEvent)
+void CPShapeTool::OnTimer(CPlayBoardView* pView, uintptr_t nIDEvent)
 {
     s_plySelectTool.OnTimer(pView, nIDEvent);
 }

--- a/GP/ToolPlay.h
+++ b/GP/ToolPlay.h
@@ -59,7 +59,7 @@ public:
     virtual void OnLButtonDblClk(CPlayBoardView* pView, UINT nFlags, CPoint point) {}
     virtual void OnLButtonUp(CPlayBoardView* pView, UINT nFlags, CPoint point);
     virtual void OnMouseMove(CPlayBoardView* pView, UINT nFlags, CPoint point);
-    virtual void OnTimer(CPlayBoardView* pView, UINT nIDEvent) {}
+    virtual void OnTimer(CPlayBoardView* pView, uintptr_t nIDEvent) /*override*/ {}
     virtual BOOL OnSetCursor(CPlayBoardView* pView, UINT nHitTest)
         { return FALSE; }
 
@@ -80,7 +80,7 @@ class CPSelectTool : public CPlayTool
 {
 // Constructors
 public:
-    CPSelectTool() : CPlayTool(ptypeSelect) { m_nTimerID = 0; }
+    CPSelectTool() : CPlayTool(ptypeSelect) { m_nTimerID = uintptr_t(0); }
 
 // Attributes
 public:
@@ -99,12 +99,12 @@ public:
     virtual void OnLButtonDblClk(CPlayBoardView* pView, UINT nFlags, CPoint point);
     virtual void OnLButtonUp(CPlayBoardView* pView, UINT nFlags, CPoint point);
     virtual void OnMouseMove(CPlayBoardView* pView, UINT nFlags, CPoint point);
-    virtual void OnTimer(CPlayBoardView* pView, UINT nIDEvent);
+    virtual void OnTimer(CPlayBoardView* pView, uintptr_t nIDEvent) override;
     virtual BOOL OnSetCursor(CPlayBoardView* pView, UINT nHitTest);
 
 // Implementation
 public:
-    UINT    m_nTimerID;
+    uintptr_t m_nTimerID;
     CRect   m_rectMultiBorder;
     // ------- //
     BOOL ProcessAutoScroll(CPlayBoardView* pView);
@@ -140,7 +140,7 @@ public:
     virtual void OnLButtonDblClk(CPlayBoardView* pView, UINT nFlags, CPoint point) {}
     virtual void OnLButtonUp(CPlayBoardView* pView, UINT nFlags, CPoint point);
     virtual void OnMouseMove(CPlayBoardView* pView, UINT nFlags, CPoint point);
-    virtual void OnTimer(CPlayBoardView* pView, UINT nIDEvent);
+    virtual void OnTimer(CPlayBoardView* pView, uintptr_t nIDEvent) override;
     virtual BOOL OnSetCursor(CPlayBoardView* pView, UINT nHitTest);
 
 // Implementation
@@ -183,7 +183,7 @@ public:
     virtual void OnLButtonDblClk(CPlayBoardView* pView, UINT nFlags, CPoint point) {}
     virtual void OnLButtonUp(CPlayBoardView* pView, UINT nFlags, CPoint point) {}
     virtual void OnMouseMove(CPlayBoardView* pView, UINT nFlags, CPoint point) {}
-    virtual void OnTimer(CPlayBoardView* pView, UINT nIDEvent) {}
+    virtual void OnTimer(CPlayBoardView* pView, uintptr_t nIDEvent) override {}
     virtual BOOL OnSetCursor(CPlayBoardView* pView, UINT nHitTest);
 
 // Implementation
@@ -206,7 +206,7 @@ public:
     virtual void OnLButtonDblClk(CPlayBoardView* pView, UINT nFlags, CPoint point) {}
     virtual void OnLButtonUp(CPlayBoardView* pView, UINT nFlags, CPoint point) {}
     virtual void OnMouseMove(CPlayBoardView* pView, UINT nFlags, CPoint point) {}
-    virtual void OnTimer(CPlayBoardView* pView, UINT nIDEvent) {}
+    virtual void OnTimer(CPlayBoardView* pView, uintptr_t nIDEvent) override {}
     virtual BOOL OnSetCursor(CPlayBoardView* pView, UINT nHitTest);
 
 // Implementation

--- a/GP/Trays.cpp
+++ b/GP/Trays.cpp
@@ -342,14 +342,30 @@ void CTrayManager::SerializeTraySets(CArchive& ar)
 {
     if (ar.IsStoring())
     {
-        ar << value_preserving_cast<WORD>(GetNumTraySets());
-        for (size_t i = 0; i < GetNumTraySets(); i++)
+        if (CB::GetVersion(ar) <= NumVersion(3, 90))
+        {
+            ar << value_preserving_cast<WORD>(GetNumTraySets());
+        }
+        else
+        {
+            CB::WriteCount(ar, GetNumTraySets());
+        }
+        for (size_t i = size_t(0); i < GetNumTraySets(); i++)
             GetTraySet(i).Serialize(ar);
     }
     else
     {
-        WORD wSize;
-        ar >> wSize;
+        size_t wSize;
+        if (CB::GetVersion(ar) <= NumVersion(3, 90))
+        {
+            WORD temp;
+            ar >> temp;
+            wSize = temp;
+        }
+        else
+        {
+            wSize = CB::ReadCount(ar);
+        }
         m_YSetTbl.reserve(wSize);
         for (size_t i = 0; i < wSize; i++)
         {

--- a/GP/VwPbrd.cpp
+++ b/GP/VwPbrd.cpp
@@ -159,7 +159,7 @@ CPlayBoardView::CPlayBoardView() :
     m_nCurToolID = ID_PTOOL_SELECT;
     m_bInDrag = FALSE;
     m_pDragSelList = NULL;
-    m_nTimerID = 0;
+    m_nTimerID = uintptr_t(0);
 }
 
 CPlayBoardView::~CPlayBoardView()
@@ -868,14 +868,14 @@ void CPlayBoardView::DragCheckAutoScroll()
     ScreenToClient(&point);
     if (CheckAutoScroll(point))
     {
-        if (m_nTimerID == 0)
+        if (m_nTimerID == uintptr_t(0))
             m_nTimerID = SetTimer(timerIDAutoScroll, timerAutoScroll, NULL);
     }
-    else if (m_nTimerID != 0)
+    else if (m_nTimerID != uintptr_t(0))
     {
-        if (m_nTimerID != 0)
+        if (m_nTimerID != uintptr_t(0))
             KillTimer(m_nTimerID);
-        m_nTimerID = 0;
+        m_nTimerID = uintptr_t(0);
     }
 }
 
@@ -883,9 +883,9 @@ void CPlayBoardView::DragKillAutoScroll()
 {
     m_bInDrag = FALSE;
     m_pDragSelList = NULL;
-    if (m_nTimerID != 0)
+    if (m_nTimerID != uintptr_t(0))
         KillTimer(m_nTimerID);
-    m_nTimerID = 0;
+    m_nTimerID = uintptr_t(0);
 }
 
 /////////////////////////////////////////////////////////////////////////////
@@ -1085,7 +1085,7 @@ void CPlayBoardView::OnLButtonDblClk(UINT nFlags, CPoint point)
         CScrollView::OnLButtonDblClk(nFlags, point);
 }
 
-void CPlayBoardView::OnTimer(UINT nIDEvent)
+void CPlayBoardView::OnTimer(uintptr_t nIDEvent)
 {
     if (m_nTimerID == nIDEvent)
     {
@@ -2072,7 +2072,7 @@ void CPlayBoardView::OnUpdateSelectGroupMarkers(CCmdUI* pCmdUI, UINT nID)
             MF_BYPOSITION));
         VERIFY(pCmdUI->m_pMenu->ModifyMenu(pCmdUI->m_nIndex,
             MF_BYPOSITION | MF_ENABLED | MF_POPUP | MF_STRING,
-            (UINT)menu.Detach(), str));
+            reinterpret_cast<UINT_PTR>(menu.Detach()), str));
     }
     else
         pCmdUI->Enable();

--- a/GP/VwPbrd.h
+++ b/GP/VwPbrd.h
@@ -141,7 +141,7 @@ protected:
     // -------- //
     BOOL        m_bInDrag;          // Currently being dragged over
     CSelList*   m_pDragSelList;     // Pointer the select list being dragged
-    UINT        m_nTimerID;         // Used to control autoscrolls
+    uintptr_t    m_nTimerID;         // Used to control autoscrolls
     // -------- //
     UINT        m_nCurToolID;       // Current tool ID
     // -------- //
@@ -208,7 +208,7 @@ protected:
     afx_msg void OnLButtonDown(UINT nFlags, CPoint point);
     afx_msg void OnMouseMove(UINT nFlags, CPoint point);
     afx_msg void OnLButtonUp(UINT nFlags, CPoint point);
-    afx_msg void OnTimer(UINT nIDEvent);
+    afx_msg void OnTimer(uintptr_t nIDEvent);
     afx_msg void OnLButtonDblClk(UINT nFlags, CPoint point);
     afx_msg BOOL OnSetCursor(CWnd* pWnd, UINT nHitTest, UINT message);
     afx_msg void OnKeyDown(UINT nChar, UINT nRepCnt, UINT nFlags);

--- a/GP/VwPbrd.h
+++ b/GP/VwPbrd.h
@@ -152,7 +152,7 @@ protected:
     // Tables used to process relative piece rotations. DON'T Serialize!
     BOOL        m_bWheelRotation;   // Indicates the type of rotation being done
     CPoint      m_pntWheelMid;      // The wheel rotation point
-    CUIntArray  m_tblCurAngles;     // Original angles of pieces
+    std::vector<uint16_t> m_tblCurAngles;     // Original angles of pieces
     std::vector<CB::not_null<CDrawObj*>> m_tblCurPieces;     // Pieces being rotated
     CUIntArray  m_tblXMidPnt;       // X coord of piece midpoint
     CUIntArray  m_tblYMidPnt;       // Y coord of piece midpoint

--- a/GShr/Arclib.cpp
+++ b/GShr/Arclib.cpp
@@ -29,7 +29,7 @@
 #define new DEBUG_NEW
 #endif
 
-void ReadArchivePoints(CArchive& ar, POINT* pPnts, int nPnts)
+void ReadArchivePoints(CArchive& ar, POINT* pPnts, size_t nPnts)
 {
     while (nPnts--)
     {
@@ -40,7 +40,7 @@ void ReadArchivePoints(CArchive& ar, POINT* pPnts, int nPnts)
     }
 }
 
-void WriteArchivePoints(CArchive& ar, POINT* pPnts, int nPnts)
+void WriteArchivePoints(CArchive& ar, const POINT* pPnts, size_t nPnts)
 {
     while (nPnts--)
     {

--- a/GShr/Board.cpp
+++ b/GShr/Board.cpp
@@ -546,8 +546,15 @@ void CBoardManager::Serialize(CArchive& ar)
         ar << m_wReserved3;
         ar << m_wReserved4;
 
-        ar << value_preserving_cast<WORD>(GetNumBoards());
-        for (size_t i = 0; i < GetNumBoards(); i++)
+        if (CB::GetVersion(ar) <= NumVersion(3, 90))
+        {
+            ar << value_preserving_cast<WORD>(GetNumBoards());
+        }
+        else
+        {
+            CB::WriteCount(ar, GetNumBoards());
+        }
+        for (size_t i = size_t(0); i < GetNumBoards(); i++)
             GetBoard(i).Serialize(ar);
     }
     else
@@ -571,9 +578,19 @@ void CBoardManager::Serialize(CArchive& ar)
         ar >> m_wReserved2;
         ar >> m_wReserved3;
         ar >> m_wReserved4;
-        ar >> wTmp;
-        reserve(wTmp);
-        for (size_t i = 0; i < wTmp; i++)
+        size_t count;
+        if (CB::GetVersion(ar) <= NumVersion(3, 90))
+        {
+            ar >> wTmp;
+            count = wTmp;
+        }
+        else
+        {
+            ASSERT(CB::GetVersion(ar) == NumVersion(4, 0));
+            count = CB::ReadCount(ar);
+        }
+        reserve(count);
+        for (size_t i = size_t(0) ; i < count ; i++)
         {
             push_back(MakeOwner<CBoard>());
             back()->Serialize(ar);

--- a/GShr/Board.cpp
+++ b/GShr/Board.cpp
@@ -460,7 +460,7 @@ CBoardManager::CBoardManager()
     SetBackColor(RGB(255, 255, 255));
     SetLineWidth(3);
     m_fontID = CGamDoc::GetFontManager()->AddFont(TenthPointsToScreenPixels(100),
-        taBold, FF_SWISS, "Arial");
+        taBold, uint8_t(FF_SWISS), "Arial");
     // ------ //
     m_wReserved1 = 0;
     m_wReserved2 = 0;

--- a/GShr/BrdCell.cpp
+++ b/GShr/BrdCell.cpp
@@ -45,7 +45,7 @@ static char THIS_FILE[] = __FILE__;
 
 CBoardArray::CBoardArray()
 {
-    m_nRows = m_nCols = 0;
+    m_nRows = m_nCols = size_t(0);
     m_pMap = NULL;
     m_pTsa = NULL;
     m_bTransparentCells = FALSE;
@@ -65,7 +65,7 @@ CBoardArray::CBoardArray()
 
 ///////////////////////////////////////////////////////////////////////
 
-void CBoardArray::CreateBoard(CellFormType eType, int nRows, int nCols,
+void CBoardArray::CreateBoard(CellFormType eType, size_t nRows, size_t nCols,
     int nParm1, int nParm2, int nStagger)
 {
     BoardCell* pMap = (BoardCell*)GlobalAllocPtr(GHND,
@@ -73,15 +73,15 @@ void CBoardArray::CreateBoard(CellFormType eType, int nRows, int nCols,
     if (pMap == NULL)
         AfxThrowMemoryException();
 
-    for (int i = 0; i < nRows * nCols; i++)
-        pMap[i].Clear();
+    for (size_t i = size_t(0) ; i < nRows * nCols ; ++i)
+        pMap[value_preserving_cast<ptrdiff_t>(i)].Clear();
 
     GenerateBoard(eType, nRows, nCols, nParm1, nParm2, nStagger, pMap);
 }
 
 // ----------------------------------------------------- //
 
-void CBoardArray::ReshapeBoard(int nRows, int nCols, int nParm1, int nParm2,
+void CBoardArray::ReshapeBoard(size_t nRows, size_t nCols, int nParm1, int nParm2,
         int nStagger)
 {
     ASSERT(m_pMap != NULL);
@@ -92,16 +92,16 @@ void CBoardArray::ReshapeBoard(int nRows, int nCols, int nParm1, int nParm2,
         (DWORD)sizeof(BoardCell) * nRows * nCols);
     if (pMap == NULL)
         AfxThrowMemoryException();
-    for (int i = 0; i < nRows * nCols; i++)
-        pMap[i].Clear();
+    for (size_t i = size_t(0) ; i < nRows * nCols ; ++i)
+        pMap[value_preserving_cast<ptrdiff_t>(i)].Clear();
 
-    int maxRows = CB::min(m_nRows, nRows);
-    int maxCols = CB::min(m_nCols, nCols);
+    size_t maxRows = CB::min(m_nRows, nRows);
+    size_t maxCols = CB::min(m_nCols, nCols);
 
-    for (int r = 0; r < maxRows; r++)
+    for (size_t r = size_t(0) ; r < maxRows ; ++r)
     {
-        for (int c = 0; c < maxCols; c++)
-            pMap[r*nCols + c] = m_pMap[r*m_nCols + c];
+        for (size_t c = size_t(0) ; c < maxCols ; ++c)
+            pMap[value_preserving_cast<ptrdiff_t>(r*nCols + c)] = m_pMap[value_preserving_cast<ptrdiff_t>(r*m_nCols + c)];
     }
 
     // OK we've copied over the old data destroy the old and
@@ -125,7 +125,7 @@ void CBoardArray::ReshapeBoard(int nRows, int nCols, int nParm1, int nParm2,
 
 // ----------------------------------------------------- //
 
-void CBoardArray::GenerateBoard(CellFormType eType, int nRows, int nCols,
+void CBoardArray::GenerateBoard(CellFormType eType, size_t nRows, size_t nCols,
     int nParm1, int nParm2, int nStagger, BoardCell* pMap)
 {
     DestroyBoard();             // Wipe out current board info.
@@ -198,8 +198,8 @@ void CBoardArray::GetBoardScaling(TileScale eScale, CSize& worldSize,
 void CBoardArray::DrawCells(CDC* pDC, CRect* pCellRct, TileScale eScale)
 {
     // Fill the cells with tile bitmaps or solid color or nothing
-    for (int row = pCellRct->top; row <= pCellRct->bottom; row++)
-        for (int col = pCellRct->left; col <= pCellRct->right; col++)
+    for (size_t row = value_preserving_cast<size_t>(pCellRct->top) ; row <= value_preserving_cast<size_t>(pCellRct->bottom) ; ++row)
+        for (size_t col = value_preserving_cast<size_t>(pCellRct->left) ; col <= value_preserving_cast<size_t>(pCellRct->right) ; ++col)
             FillCell(pDC, row, col, eScale);
 }
 
@@ -209,8 +209,8 @@ void CBoardArray::DrawCellLines(CDC* pDC, CRect* pCellRct, TileScale eScale)
 {
 //  CPen* pPrvPen = (CPen*)pDC->SelectStockObject(BLACK_PEN);
     CPen* pPrvPen = pDC->SelectObject(&m_pnCellFrame);
-    for (int row = pCellRct->top; row <= pCellRct->bottom; row++)
-        for (int col = pCellRct->left; col <= pCellRct->right; col++)
+    for (size_t row = value_preserving_cast<size_t>(pCellRct->top) ; row <= value_preserving_cast<size_t>(pCellRct->bottom) ; ++row)
+        for (size_t col = value_preserving_cast<size_t>(pCellRct->left) ; col <= value_preserving_cast<size_t>(pCellRct->right) ; ++col)
             FrameCell(pDC, row, col, eScale);
     pDC->SelectObject(pPrvPen);
 }
@@ -221,35 +221,35 @@ BOOL CBoardArray::MapPixelsToCellBounds(CRect* pPxlRct, CRect* pCellRct,
     TileScale eScale)
 {
     BOOL bOutOfRange;
-    int row, col;
+    size_t row, col;
     bOutOfRange = !FindCell(pPxlRct->left, pPxlRct->top, row, col, eScale);
-    pCellRct->top = row;
-    pCellRct->left = col;
+    pCellRct->top = value_preserving_cast<LONG>(row);
+    pCellRct->left = value_preserving_cast<LONG>(col);
     bOutOfRange |= !FindCell(pPxlRct->right, pPxlRct->bottom, row, col, eScale);
-    pCellRct->bottom = row;
-    pCellRct->right = col;
+    pCellRct->bottom = value_preserving_cast<LONG>(row);
+    pCellRct->right = value_preserving_cast<LONG>(col);
 
     // Expand the rectangle for good measure.
     pCellRct->left--;
     if (pCellRct->left < 0) pCellRct->left = 0;
     pCellRct->right++;
-    if (pCellRct->right >= m_nCols) pCellRct->right = m_nCols - 1;
+    if (pCellRct->right >= value_preserving_cast<LONG>(m_nCols)) pCellRct->right = value_preserving_cast<LONG>(m_nCols - size_t(1));
     pCellRct->top--;
     if (pCellRct->top < 0) pCellRct->top = 0;
     pCellRct->bottom++;
-    if (pCellRct->bottom >= m_nRows) pCellRct->bottom = m_nRows - 1;
+    if (pCellRct->bottom >= value_preserving_cast<LONG>(m_nRows)) pCellRct->bottom = value_preserving_cast<LONG>(m_nRows - size_t(1));
     return !bOutOfRange;
 }
 
 // ----------------------------------------------------- //
 
-void CBoardArray::FillCell(CDC *pDC, int row, int col, TileScale eScale)
+void CBoardArray::FillCell(CDC *pDC, size_t row, size_t col, TileScale eScale)
 {
     BoardCell* pCell = GetCell(row, col);
     CCellForm* pCF = GetCellForm(eScale);
 
     CRect rct;
-    pCF->GetRect(row, col, &rct);
+    pCF->GetRect(value_preserving_cast<CB::ssize_t>(row), value_preserving_cast<CB::ssize_t>(col), &rct);
 
     if (!pDC->RectVisible(&rct))
         return;
@@ -306,9 +306,9 @@ void CBoardArray::FillCell(CDC *pDC, int row, int col, TileScale eScale)
 
 // ----------------------------------------------------- //
 
-void CBoardArray::GetCellRect(int row, int col, CRect* pRct, TileScale eScale)
+void CBoardArray::GetCellRect(size_t row, size_t col, CRect* pRct, TileScale eScale)
 {
-    GetCellForm(eScale)->GetRect(row, col, pRct);
+    GetCellForm(eScale)->GetRect(value_preserving_cast<CB::ssize_t>(row), value_preserving_cast<CB::ssize_t>(col), pRct);
 }
 
 // ----------------------------------------------------- //
@@ -320,12 +320,12 @@ CSize CBoardArray::GetCellSize(TileScale eScale)
 
 // ----------------------------------------------------- //
 
-void CBoardArray::FrameCell(CDC *pDC, int row, int col, TileScale eScale)
+void CBoardArray::FrameCell(CDC *pDC, size_t row, size_t col, TileScale eScale)
 {
     BoardCell* pCell = GetCell(row, col);
     CRect rct;
     CCellForm *pCF = GetCellForm(eScale);
-    pCF->GetRect(row, col, &rct);
+    pCF->GetRect(value_preserving_cast<CB::ssize_t>(row), value_preserving_cast<CB::ssize_t>(col), &rct);
     if (!pDC->RectVisible(&rct))
         return;
     pCF->FrameCell(pDC, rct.left, rct.top);
@@ -356,67 +356,70 @@ int CBoardArray::GetHeight(TileScale eScale)
 
 // ----------------------------------------------------- //
 
-void CBoardArray::SetCellColor(int row, int col, COLORREF cr)
+void CBoardArray::SetCellColor(size_t row, size_t col, COLORREF cr)
 {
-    int nCellIdx = CellIndex(row, col);
-    m_pMap[nCellIdx].SetColor(cr);
+    size_t nCellIdx = CellIndex(row, col);
+    m_pMap[value_preserving_cast<ptrdiff_t>(nCellIdx)].SetColor(cr);
 }
 
 // ----------------------------------------------------- //
 
-void CBoardArray::SetCellTile(int row, int col, TileID tid)
+void CBoardArray::SetCellTile(size_t row, size_t col, TileID tid)
 {
-    int nCellIdx = CellIndex(row, col);
-    m_pMap[nCellIdx].SetTID(tid);
+    size_t nCellIdx = CellIndex(row, col);
+    m_pMap[value_preserving_cast<ptrdiff_t>(nCellIdx)].SetTID(tid);
 }
 
 // ----------------------------------------------------- //
 
-void CBoardArray::SetCellColorInRange(int rowBeg, int colBeg, int rowEnd,
-    int colEnd, COLORREF cr)
+void CBoardArray::SetCellColorInRange(size_t rowBeg, size_t colBeg, size_t rowEnd,
+    size_t colEnd, COLORREF cr)
 {
-    for (int r = rowBeg; r <= rowEnd; r++)
-        for (int c = colBeg; c <= colEnd; c++)
+    for (size_t r = rowBeg ; r <= rowEnd ; ++r)
+        for (size_t c = colBeg ; c <= colEnd ; ++c)
             SetCellColor(r, c, cr);
 }
 
 // ----------------------------------------------------- //
 
-BoardCell* CBoardArray::GetCell(int row, int col)
+BoardCell* CBoardArray::GetCell(size_t row, size_t col)
 {
     ASSERT(m_pMap != NULL);
-    return &m_pMap[CellIndex(row, col)];
+    return &m_pMap[value_preserving_cast<ptrdiff_t>(CellIndex(row, col))];
 }
 
 // ----------------------------------------------------- //
 // X and Y is in pixels
 
-BOOL CBoardArray::FindCell(int x, int y, int& rRow, int& rCol, TileScale eScale)
+BOOL CBoardArray::FindCell(long x, long y, size_t& rRow, size_t& rCol, TileScale eScale)
 {
+    CB::ssize_t sRow, sCol;
     BOOL bRet = TRUE;
-    GetCellForm(eScale)->FindCell(x, y, rRow, rCol);
+    GetCellForm(eScale)->FindCell(x, y, sRow, sCol);
     // Make sure result is in bounds. Return FALSE if row and
     // column is forced to be in range.
-    if (rRow < 0)
+    if (sRow < 0)
     {
-        rRow = 0;
+        sRow = 0;
         bRet = FALSE;
     }
-    else if (rRow >= m_nRows)
+    else if (sRow >= value_preserving_cast<CB::ssize_t>(m_nRows))
     {
-        rRow = m_nRows - 1;
+        sRow = value_preserving_cast<CB::ssize_t>(m_nRows) - 1;
         bRet = FALSE;
     }
-    if (rCol < 0)
+    if (sCol < 0)
     {
-        rCol = 0;
+        sCol = 0;
         bRet = FALSE;
     }
-    else if (rCol >= m_nCols)
+    else if (sCol >= value_preserving_cast<CB::ssize_t>(m_nCols))
     {
-        rCol = m_nCols - 1;
+        sCol = value_preserving_cast<CB::ssize_t>(m_nCols) - 1;
         bRet = FALSE;
     }
+    rRow = value_preserving_cast<size_t>(sRow);
+    rCol = value_preserving_cast<size_t>(sCol);
     return bRet;
 }
 
@@ -425,9 +428,9 @@ BOOL CBoardArray::FindCell(int x, int y, int& rRow, int& rCol, TileScale eScale)
 BOOL CBoardArray::PurgeMissingTileIDs()
 {
     BOOL bPurged = FALSE;
-    for (int r = 0; r < m_nRows; r++)
+    for (size_t r = size_t(0) ; r < m_nRows ; ++r)
     {
-        for (int c = 0; c < m_nCols; c++)
+        for (size_t c = size_t(0) ; c < m_nCols ; ++c)
         {
             BoardCell *pCell = GetCell(r, c);
             if (pCell->IsTileID())
@@ -447,9 +450,9 @@ BOOL CBoardArray::PurgeMissingTileIDs()
 
 BOOL CBoardArray::IsTileInUse(TileID tid)
 {
-    for (int r = 0; r < m_nRows; r++)
+    for (size_t r = size_t(0) ; r < m_nRows ; ++r)
     {
-        for (int c = 0; c < m_nCols; c++)
+        for (size_t c = size_t(0) ; c < m_nCols ; ++c)
         {
             BoardCell *pCell = GetCell(r, c);
             if (pCell->IsTileID() && pCell->GetTID() == tid)
@@ -484,27 +487,27 @@ void CBoardArray::SetCellFrameColor(COLORREF cr)
 
 void CBoardArray::GetCellNumberStr(CPoint pnt, CString& str, TileScale eScale)
 {
-    int row, col;
+    size_t row, col;
     str.Empty();
     if (!FindCell(pnt.x, pnt.y, row, col, eScale))
         return;
     GetCellNumberStr(row, col, str);
 }
 
-void CBoardArray::GetCellNumberStr(int row, int col, CString& str)
+void CBoardArray::GetCellNumberStr(size_t row, size_t col, CString& str)
 {
     str.Empty();
-    if (row < 0 || row >= m_nRows || col < 0 || col >= m_nCols)
+    if (row >= m_nRows || col >= m_nCols)
         return;
 
     if (m_bRowTrkInvert)
-        row = m_nRows - row - 1;
+        row = m_nRows - row - size_t(1);
     if (m_bColTrkInvert)
-        col = m_nCols - col - 1;
+        col = m_nCols - col - size_t(1);
 
     // Only computer wonks start counting at zero...
-    CCellForm::GetCellNumberStr(m_eNumStyle, row + m_nRowTrkOffset + 1,
-        col + m_nColTrkOffset + 1, str);
+    CCellForm::GetCellNumberStr(m_eNumStyle, row + value_preserving_cast<size_t>(m_nRowTrkOffset + 1),
+        col + value_preserving_cast<size_t>(m_nColTrkOffset + 1), str);
 }
 
 ///////////////////////////////////////////////////////////////////////////
@@ -576,12 +579,12 @@ void CBoardArray::Serialize(CArchive& ar)
         ar << m_wReserved2;
         ar << m_wReserved3;
         ar << m_wReserved4;
-        ar << (WORD)m_nRowTrkOffset;
-        ar << (WORD)m_nColTrkOffset;
+        ar << value_preserving_cast<WORD>(m_nRowTrkOffset);
+        ar << value_preserving_cast<WORD>(m_nColTrkOffset);
         ar << (WORD)m_bRowTrkInvert;
         ar << (WORD)m_bColTrkInvert;
-        ar << (WORD)m_nRows;
-        ar << (WORD)m_nCols;
+        ar << value_preserving_cast<WORD>(m_nRows);
+        ar << value_preserving_cast<WORD>(m_nCols);
         ar << (WORD)m_bTransparentCells;
         ar << (WORD)m_eNumStyle;
         ar << (WORD)m_bTrackCellNum;
@@ -598,14 +601,14 @@ void CBoardArray::Serialize(CArchive& ar)
         ar >> m_wReserved2;
         ar >> m_wReserved3;
         ar >> m_wReserved4;
-        ar >> wVal; m_nRowTrkOffset = (short)wVal;  // (was int cast)
-        ar >> wVal; m_nColTrkOffset = (short)wVal;  // (was int cast)
+        ar >> wVal; m_nRowTrkOffset = wVal;  // (was int cast)
+        ar >> wVal; m_nColTrkOffset = wVal;  // (was int cast)
         ar >> wVal; m_bRowTrkInvert = (BOOL)wVal;
         ar >> wVal; m_bColTrkInvert = (BOOL)wVal;
-        ar >> wVal; m_nRows = (int)wVal;
-        ar >> wVal; m_nCols = (int)wVal;
+        ar >> wVal; m_nRows = wVal;
+        ar >> wVal; m_nCols = wVal;
         ar >> wVal; m_bTransparentCells = (BOOL)wVal;
-        ar >> wVal; m_eNumStyle = (CellNumStyle)wVal;
+        ar >> wVal; m_eNumStyle = static_cast<CellNumStyle>(wVal);
         ar >> wVal; m_bTrackCellNum = (BOOL)wVal;
 
 #ifdef GPLAY
@@ -630,9 +633,9 @@ void CBoardArray::Serialize(CArchive& ar)
     m_cfHalf.Serialize(ar);
     m_cfSmall.Serialize(ar);
 
-    for (int r = 0; r < m_nRows; r++)
+    for (size_t r = size_t(0) ; r < m_nRows ; ++r)
     {
-        for (int c = 0; c < m_nCols; c++)
+        for (size_t c = size_t(0) ; c < m_nCols ; ++c)
             GetCell(r, c)->Serialize(ar);
     }
 }

--- a/GShr/BrdCell.cpp
+++ b/GShr/BrdCell.cpp
@@ -583,8 +583,16 @@ void CBoardArray::Serialize(CArchive& ar)
         ar << value_preserving_cast<WORD>(m_nColTrkOffset);
         ar << (WORD)m_bRowTrkInvert;
         ar << (WORD)m_bColTrkInvert;
-        ar << value_preserving_cast<WORD>(m_nRows);
-        ar << value_preserving_cast<WORD>(m_nCols);
+        if (CB::GetVersion(ar) <= NumVersion(3, 90))
+        {
+            ar << value_preserving_cast<WORD>(m_nRows);
+            ar << value_preserving_cast<WORD>(m_nCols);
+        }
+        else
+        {
+            CB::WriteCount(ar, m_nRows);
+            CB::WriteCount(ar, m_nCols);
+        }
         ar << (WORD)m_bTransparentCells;
         ar << (WORD)m_eNumStyle;
         ar << (WORD)m_bTrackCellNum;
@@ -605,8 +613,16 @@ void CBoardArray::Serialize(CArchive& ar)
         ar >> wVal; m_nColTrkOffset = wVal;  // (was int cast)
         ar >> wVal; m_bRowTrkInvert = (BOOL)wVal;
         ar >> wVal; m_bColTrkInvert = (BOOL)wVal;
-        ar >> wVal; m_nRows = wVal;
-        ar >> wVal; m_nCols = wVal;
+        if (CB::GetVersion(ar) <= NumVersion(3, 90))
+        {
+            ar >> wVal; m_nRows = wVal;
+            ar >> wVal; m_nCols = wVal;
+        }
+        else
+        {
+            m_nRows = CB::ReadCount(ar);
+            m_nCols = CB::ReadCount(ar);
+        }
         ar >> wVal; m_bTransparentCells = (BOOL)wVal;
         ar >> wVal; m_eNumStyle = static_cast<CellNumStyle>(wVal);
         ar >> wVal; m_bTrackCellNum = (BOOL)wVal;

--- a/GShr/BrdCell.h
+++ b/GShr/BrdCell.h
@@ -71,9 +71,9 @@ public:
 
 // Attributes
 public:
-    COLORREF GetCellColor(int row, int col)
+    COLORREF GetCellColor(size_t row, size_t col)
         { return GetCell(row, col)->m_crCell; }
-    TileID GetCellTile(int row, int col)
+    TileID GetCellTile(size_t row, size_t col)
         { return GetCell(row, col)->GetTID(); }
     BOOL IsTransparentCellTilesEnabled()
         { return m_bTransparentCells; }
@@ -94,18 +94,18 @@ public:
     CellNumStyle GetCellNumStyle() { return m_eNumStyle; }
     // ------ //
     void GetCellNumberStr(CPoint pnt, CString& str, TileScale eScale);
-    void GetCellNumberStr(int row, int col, CString& str);
+    void GetCellNumberStr(size_t row, size_t col, CString& str);
     // ------ //
     COLORREF GetCellFrameColor() { return m_crCellFrame; }
     void SetCellFrameColor(COLORREF cr);
     // ------ //
-    BoardCell* GetCell(int row, int col);
+    BoardCell* GetCell(size_t row, size_t col);
     CCellForm* GetCellForm(TileScale eScale);
     void SetTileManager(CTileManager *pTsa) { m_pTsa = pTsa; }
     CTileManager *GetTileManager() { return m_pTsa; }
     // ------ //
-    int GetRows() const { return m_nRows; }
-    int GetCols() const { return m_nCols; }
+    size_t GetRows() const { return m_nRows; }
+    size_t GetCols() const { return m_nCols; }
     int GetWidth(TileScale eScale);     // Board's pixel width
     int GetHeight(TileScale eScale);    // Board's pixel height
     CSize GetSize(TileScale eScale);    // Board's pixel size
@@ -113,29 +113,29 @@ public:
 
 // Operations
 public:
-    void CreateBoard(CellFormType eType, int nRows, int nCols, int nParm1,
+    void CreateBoard(CellFormType eType, size_t nRows, size_t nCols, int nParm1,
         int nParm2, int nStagger);
-    void ReshapeBoard(int nRows, int nCols, int nParm1, int nParm2,
+    void ReshapeBoard(size_t nRows, size_t nCols, int nParm1, int nParm2,
         int nStagger);
     void DestroyBoard();
-    void GenerateBoard(CellFormType eType, int nRows, int nCols,
+    void GenerateBoard(CellFormType eType, size_t nRows, size_t nCols,
         int nParm1, int nParm2, int nStagger, BoardCell* pMap);
     static void GenerateCellDefs(CellFormType eType, int nParm1, int nParm2,
         int nStagger, CCellForm& cfFull, CCellForm& cfHalf, CCellForm& cfSmall);
     // ------- //
     void DrawCells(CDC* pDC, CRect* pCellRct, TileScale eScale);
     void DrawCellLines(CDC* pDC, CRect* pCellRct, TileScale eScale);
-    void FillCell(CDC *pDC, int row, int col, TileScale eScale);
-    void FrameCell(CDC *pDC, int row, int col, TileScale eScale);
+    void FillCell(CDC *pDC, size_t row, size_t col, TileScale eScale);
+    void FrameCell(CDC *pDC, size_t row, size_t col, TileScale eScale);
     // ------- //
-    void SetCellTile(int row, int col, TileID tid);
-    void SetCellColor(int row, int col, COLORREF cr);
-    void SetCellColorInRange(int rowBeg, int colBeg, int rowEnd,
-        int colEnd, COLORREF cr);
+    void SetCellTile(size_t row, size_t col, TileID tid);
+    void SetCellColor(size_t row, size_t col, COLORREF cr);
+    void SetCellColorInRange(size_t rowBeg, size_t colBeg, size_t rowEnd,
+        size_t colEnd, COLORREF cr);
     // ------- //
     void GetBoardScaling(TileScale eScale, CSize& worldsize, CSize& viewSize);
-    BOOL FindCell(int x, int y, int& rRow, int& rCol, TileScale eScale);
-    void GetCellRect(int row, int col, CRect* pRct, TileScale eScale);
+    BOOL FindCell(long x, long y, size_t& rRow, size_t& rCol, TileScale eScale);
+    void GetCellRect(size_t row, size_t col, CRect* pRct, TileScale eScale);
     BOOL MapPixelsToCellBounds(CRect* pPxlRct, CRect* pCellRct,
         TileScale eScale);
     // ------- //
@@ -154,8 +154,8 @@ protected:
     int     m_nColTrkOffset;    // Col track num offset
     int     m_bRowTrkInvert;    // Row track num invert direction
     int     m_bColTrkInvert;    // Col track num invert direction
-    int     m_nRows;            // Number of cell rows in board
-    int     m_nCols;            // Number of cell columns in board
+    size_t  m_nRows;            // Number of cell rows in board
+    size_t  m_nCols;            // Number of cell columns in board
     BOOL    m_bTransparentCells;// (Not currently used)
     BOOL    m_bTrackCellNum;    // Mouse traking of cell number
     CellNumStyle m_eNumStyle;   // Cell numbering style
@@ -171,7 +171,7 @@ protected:
     // -------- //
     CTileManager* m_pTsa;       // For reference only! Don't destroy!
     // -------- //
-    int CellIndex(int row, int col) { return row*m_nCols + col; }
+    size_t CellIndex(size_t row, size_t col) { return row*m_nCols + col; }
 };
 
 ////////////////////////////////////////////////////////////////////

--- a/GShr/CDib.cpp
+++ b/GShr/CDib.cpp
@@ -304,8 +304,11 @@ BOOL CDib::AppendDIB(CDib *pDib)
 
 CArchive& AFXAPI operator<<(CArchive& ar, const CDib& dib)
 {
+    /* TODO:  Are bmps >= 2g possible?  If so, and we support
+                them, then file format must change */
     if (dib.m_hDib)
     {
+        static_assert(sizeof(uLongf) == sizeof(uint32_t), "compress can support large blobs");
         uint32_t dwSize = value_preserving_cast<uint32_t>(GlobalSize(dib.m_hDib));
         ASSERT(dwSize > uint32_t(0));
         ASSERT(dib.m_nCompressLevel >= Z_NO_COMPRESSION

--- a/GShr/CDib.cpp
+++ b/GShr/CDib.cpp
@@ -161,7 +161,7 @@ void CDib::SetDibHandle(HANDLE hDib)
     }
 }
 
-BOOL CDib::BitmapToDIB(const CBitmap* pBM, const CPalette* pPal, int nBPP/* = 16*/)
+BOOL CDib::BitmapToDIB(const CBitmap* pBM, const CPalette* pPal, uint16_t nBPP/* = uint16_t(16)*/)
 {
     ClearDib();
     if (pBM->m_hObject != NULL)

--- a/GShr/CDib.h
+++ b/GShr/CDib.h
@@ -41,7 +41,7 @@ public:
     void ReadDIBFile(CFile& file);
     BOOL WriteDIBFile(CFile& file);
     void CloneDIB(CDib *pDib);
-    BOOL BitmapToDIB(const CBitmap* pBM, const CPalette* pPal = NULL, int nBPP = 16);
+    BOOL BitmapToDIB(const CBitmap* pBM, const CPalette* pPal = NULL, uint16_t nBPP = uint16_t(16));
     OwnerPtr<CBitmap> DIBToBitmap(const CPalette *pPal, BOOL bDibSect = TRUE);
     BOOL AppendDIB(CDib *pDib);
     BOOL RemoveDIBSlice(int y, int ht);

--- a/GShr/CalcLib.cpp
+++ b/GShr/CalcLib.cpp
@@ -166,7 +166,7 @@ BOOL StrDecimalChecked(const char **psp, int *pnVal, int *pnScale)
 {
     int nWholePart = 0;
     int nFracPart = 0;
-    int nFracDigs = 0;
+    ptrdiff_t nFracDigs = 0;
 
     BOOL bMinus = **psp == '-';
     if (bMinus) (*psp)++;       // Step past minus character

--- a/GShr/CellForm.cpp
+++ b/GShr/CellForm.cpp
@@ -446,7 +446,7 @@ void CCellForm::GetCellNumberStr(CellNumStyle eStyle, int row, int col,
         case cns0101ByRows:
             _itoa(row, szNum1, 10);
             _itoa(col, szNum2, 10);
-            nTmp = CB::max(strlen(szNum1), strlen(szNum2));
+            nTmp = value_preserving_cast<int>(CB::max(strlen(szNum1), strlen(szNum2)));
             nTmp = CB::max(nTmp, 2);            // Make sure at least 2 digits
             StrLeadZeros(szNum1, nTmp);
             StrLeadZeros(szNum2, nTmp);

--- a/GShr/CellForm.cpp
+++ b/GShr/CellForm.cpp
@@ -172,15 +172,15 @@ void CCellForm::CreateHexMask()
     //mskFile.Close();
 }
 
-void CCellForm::FindCell(int x, int y, int& row, int& col)
+void CCellForm::FindCell(LONG x, LONG y, CB::ssize_t& row, CB::ssize_t& col)
 {
     if (m_eType == cformHexPnt)
     {
         CRect rct;
         row = y / m_pPoly[3].y;
 
-        int xBase = CellPhase(row) * m_pPoly[1].x;
-        col = x < xBase ? -1 : (x - xBase) / m_pPoly[2].x;
+        CB::ssize_t xBase = CellPhase(row) * m_pPoly[1].x;
+        col = x < xBase ? CB::ssize_t(-1) : (x - xBase) / m_pPoly[2].x;
 
         GetRect(row, col, &rct);
         g_gt.mDC1.SelectObject(m_pMask);
@@ -199,8 +199,8 @@ void CCellForm::FindCell(int x, int y, int& row, int& col)
     {
         CRect rct;
         col = x / m_pPoly[2].x;
-        int yBase = CellPhase(col) * m_pPoly[3].y;
-        row = y < yBase ? -1 : (y - yBase) / m_pPoly[4].y;
+        CB::ssize_t yBase = CellPhase(col) * m_pPoly[3].y;
+        row = y < yBase ? CB::ssize_t(-1) : (y - yBase) / m_pPoly[4].y;
 
         GetRect(row, col, &rct);
 
@@ -224,102 +224,102 @@ void CCellForm::FindCell(int x, int y, int& row, int& col)
     else if (m_eType == cformBrickHorz)
     {
         row = y / m_rct.bottom;
-        int xBase = (CellPhase(row) * m_rct.right) / 2;
-        col = x < xBase ? -1 : (x - xBase) / m_rct.right;
+        CB::ssize_t xBase = (CellPhase(row) * m_rct.right) / 2;
+        col = x < xBase ? CB::ssize_t(-1) : (x - xBase) / m_rct.right;
     }
     else    // m_eType == cformBrickVert
     {
         col = x / m_rct.right;
-        int yBase = (CellPhase(col) * m_rct.bottom) / 2;
-        row = y < yBase ? -1 : (y - yBase) / m_rct.bottom;
+        CB::ssize_t yBase = (CellPhase(col) * m_rct.bottom) / 2;
+        row = y < yBase ? CB::ssize_t(-1) : (y - yBase) / m_rct.bottom;
     }
 }
 
 // Trial calculate the size of a board to see if it exceeds
 // 32k. Return FALSE if too large.
 
-BOOL CCellForm::CalcTrialBoardSize(int nRows, int nCols)
+BOOL CCellForm::CalcTrialBoardSize(size_t nRows, size_t nCols)
 {
-    long x, y;
+    size_t x, y;
     if (m_eType == cformRect)
     {
-        x = (long)nCols * m_rct.right;
-        y = (long)nRows * m_rct.bottom;
+        x = nCols * value_preserving_cast<size_t>(m_rct.right);
+        y = nRows * value_preserving_cast<size_t>(m_rct.bottom);
     }
     else if (m_eType == cformBrickHorz)
     {
-        x = (long)nCols * m_rct.right + m_rct.right / 2;
-        y = (long)nRows * m_rct.bottom;
+        x = nCols * value_preserving_cast<size_t>(m_rct.right) + value_preserving_cast<size_t>(m_rct.right / 2);
+        y = nRows * value_preserving_cast<size_t>(m_rct.bottom);
     }
     else if (m_eType == cformBrickVert)
     {
-        x = (long)nCols * m_rct.right;
-        y = (long)nRows * m_rct.bottom + m_rct.bottom / 2;
+        x = nCols * value_preserving_cast<size_t>(m_rct.right);
+        y = nRows * value_preserving_cast<size_t>(m_rct.bottom) + value_preserving_cast<size_t>(m_rct.bottom / 2);
     }
     else if (m_eType == cformHexPnt)
     {
-        x = (long)nCols * m_pPoly[2].x + m_pPoly[1].x;
-        y = (long)nRows * m_pPoly[3].y + m_pPoly[0].y;
+        x = nCols * value_preserving_cast<size_t>(m_pPoly[2].x) + value_preserving_cast<size_t>(m_pPoly[1].x);
+        y = nRows * value_preserving_cast<size_t>(m_pPoly[3].y) + value_preserving_cast<size_t>(m_pPoly[0].y);
     }
     else
     {
-        x = (long)nCols * m_pPoly[2].x + m_pPoly[1].x;
-        y = (long)nRows * m_pPoly[4].y + m_pPoly[3].y;
+        x = nCols * value_preserving_cast<size_t>(m_pPoly[2].x) + value_preserving_cast<size_t>(m_pPoly[1].x);
+        y = nRows * value_preserving_cast<size_t>(m_pPoly[4].y) + value_preserving_cast<size_t>(m_pPoly[3].y);
     }
-    return x < 32000 && y < 32000;
+    return x < size_t(32000) && y < size_t(32000);
 }
 
-CSize CCellForm::CalcBoardSize(int nRows, int nCols)
+CSize CCellForm::CalcBoardSize(size_t nRows, size_t nCols)
 {
     if (m_eType == cformRect)
-        return CSize(nCols * m_rct.right, nRows * m_rct.bottom);
+        return CSize(value_preserving_cast<long>(nCols) * m_rct.right, value_preserving_cast<long>(nRows) * m_rct.bottom);
     else if (m_eType == cformBrickHorz)
     {
-        return CSize(nCols * m_rct.right + m_rct.right / 2,
-            nRows * m_rct.bottom);
+        return CSize(value_preserving_cast<long>(nCols) * m_rct.right + m_rct.right / 2,
+            value_preserving_cast<long>(nRows) * m_rct.bottom);
     }
     else if (m_eType == cformBrickVert)
     {
-        return CSize(nCols * m_rct.right,
-            nRows * m_rct.bottom + m_rct.bottom / 2);
+        return CSize(value_preserving_cast<long>(nCols) * m_rct.right,
+            value_preserving_cast<long>(nRows) * m_rct.bottom + m_rct.bottom / 2);
     }
     else if (m_eType == cformHexPnt)
     {
-        return CSize(nCols * m_pPoly[2].x + m_pPoly[1].x,
-            nRows * m_pPoly[3].y + m_pPoly[0].y);
+        return CSize(value_preserving_cast<long>(nCols) * m_pPoly[2].x + m_pPoly[1].x,
+            value_preserving_cast<long>(nRows) * m_pPoly[3].y + m_pPoly[0].y);
     }
     else
     {
-        return CSize(nCols * m_pPoly[2].x + m_pPoly[1].x,
-            nRows * m_pPoly[4].y + m_pPoly[3].y);
+        return CSize(value_preserving_cast<long>(nCols) * m_pPoly[2].x + m_pPoly[1].x,
+            value_preserving_cast<long>(nRows) * m_pPoly[4].y + m_pPoly[3].y);
     }
 }
 
-CRect* CCellForm::GetRect(int row, int col, CRect* pRct)
+CRect* CCellForm::GetRect(CB::ssize_t row, CB::ssize_t col, CRect* pRct)
 {
     *pRct = m_rct;          // Copy master rect
     if (m_eType == cformRect)
-        pRct->OffsetRect(col * m_rct.right, row * m_rct.bottom);
+        pRct->OffsetRect(value_preserving_cast<int>(col * m_rct.right), value_preserving_cast<int>(row * m_rct.bottom));
     else if (m_eType == cformBrickHorz)
     {
-        pRct->OffsetRect(col * m_rct.right + (CellPhase(row) * m_rct.right) / 2,
-            row * m_rct.bottom);
+        pRct->OffsetRect(value_preserving_cast<int>(col * m_rct.right + (CellPhase(row) * m_rct.right) / 2),
+            value_preserving_cast<int>(row * m_rct.bottom));
     }
     else if (m_eType == cformBrickVert)
     {
-        pRct->OffsetRect(col * m_rct.right,
-            row * m_rct.bottom + (CellPhase(col) * m_rct.bottom) / 2);
+        pRct->OffsetRect(value_preserving_cast<int>(col * m_rct.right),
+            value_preserving_cast<int>(row * m_rct.bottom + (CellPhase(col) * m_rct.bottom) / 2));
     }
     else if (m_eType == cformHexPnt)
     {
 
-        pRct->OffsetRect(col * m_pPoly[2].x + CellPhase(row) * m_pPoly[1].x,
-            row * m_pPoly[3].y);
+        pRct->OffsetRect(value_preserving_cast<int>(col * m_pPoly[2].x + CellPhase(row) * m_pPoly[1].x),
+            value_preserving_cast<int>(row * m_pPoly[3].y));
     }
     else
     {
-        pRct->OffsetRect(col * m_pPoly[2].x,
-            row * m_pPoly[4].y + CellPhase(col) * m_pPoly[3].y);
+        pRct->OffsetRect(value_preserving_cast<int>(col * m_pPoly[2].x),
+            value_preserving_cast<int>(row * m_pPoly[4].y + CellPhase(col) * m_pPoly[3].y));
     }
     return pRct;
 }
@@ -417,12 +417,12 @@ void CCellForm::Serialize(CArchive& ar)
     }
 }
 
-void CCellForm::GetCellNumberStr(CellNumStyle eStyle, int row, int col,
+void CCellForm::GetCellNumberStr(CellNumStyle eStyle, size_t row, size_t col,
     CString& str)
 {
-    int nTmp;
-    char szNum1[20];
-    char szNum2[20];
+    size_t nTmp;
+    char szNum1[_MAX_U64TOSTR_BASE10_COUNT];
+    char szNum2[_MAX_U64TOSTR_BASE10_COUNT];
     str.Empty();
     switch (eStyle)
     {
@@ -432,8 +432,8 @@ void CCellForm::GetCellNumberStr(CellNumStyle eStyle, int row, int col,
             col = nTmp;
             // Fall through to cnsRowCol processing.
         case cnsRowCol:
-            _itoa(row, szNum1, 10);
-            _itoa(col, szNum2, 10);
+            _ui64toa(row, szNum1, 10);
+            _ui64toa(col, szNum2, 10);
             str = szNum1;
             str += ", ";
             str += szNum2;
@@ -444,10 +444,10 @@ void CCellForm::GetCellNumberStr(CellNumStyle eStyle, int row, int col,
             col = nTmp;
             // Fall through to cns0101ByRows processing.
         case cns0101ByRows:
-            _itoa(row, szNum1, 10);
-            _itoa(col, szNum2, 10);
-            nTmp = value_preserving_cast<int>(CB::max(strlen(szNum1), strlen(szNum2)));
-            nTmp = CB::max(nTmp, 2);            // Make sure at least 2 digits
+            _ui64toa(row, szNum1, 10);
+            _ui64toa(col, szNum2, 10);
+            nTmp = CB::max(strlen(szNum1), strlen(szNum2));
+            nTmp = CB::max(nTmp, size_t(2));            // Make sure at least 2 digits
             StrLeadZeros(szNum1, nTmp);
             StrLeadZeros(szNum2, nTmp);
             str = szNum1;
@@ -460,7 +460,7 @@ void CCellForm::GetCellNumberStr(CellNumStyle eStyle, int row, int col,
             // Fall through to cnsAA01ByRows processing.
         case cnsAA01ByRows:
             StrGetAAAFormat(szNum1, row);
-            _itoa(col, szNum2, 10);
+            _ui64toa(col, szNum2, 10);
             str = szNum1;
             str += szNum2;
             break;

--- a/GShr/CellForm.cpp
+++ b/GShr/CellForm.cpp
@@ -386,7 +386,7 @@ void CCellForm::Serialize(CArchive& ar)
         ar << (short)m_rct.right;
         ar << (short)m_rct.bottom;
         WriteArchivePoints(ar, m_pPoly, (m_eType == cformHexFlat ||
-            m_eType == cformHexPnt) ? 7 : 5);
+            m_eType == cformHexPnt) ? size_t(7) : size_t(5));
     }
     else
     {
@@ -405,13 +405,13 @@ void CCellForm::Serialize(CArchive& ar)
         {
             m_pPoly = new POINT[7];
             m_pWrk  = new POINT[7];
-            ReadArchivePoints(ar, m_pPoly, 7);
+            ReadArchivePoints(ar, m_pPoly, size_t(7));
         }
         else
         {
             m_pPoly = new POINT[5];
             m_pWrk  = new POINT[5];
-            ReadArchivePoints(ar, m_pPoly, 5);
+            ReadArchivePoints(ar, m_pPoly, size_t(5));
         }
         CreateHexMask();
     }

--- a/GShr/CellForm.cpp
+++ b/GShr/CellForm.cpp
@@ -172,7 +172,7 @@ void CCellForm::CreateHexMask()
     //mskFile.Close();
 }
 
-void CCellForm::FindCell(LONG x, LONG y, CB::ssize_t& row, CB::ssize_t& col)
+void CCellForm::FindCell(long x, long y, CB::ssize_t& row, CB::ssize_t& col)
 {
     if (m_eType == cformHexPnt)
     {

--- a/GShr/CellForm.h
+++ b/GShr/CellForm.h
@@ -70,7 +70,7 @@ public:
     void Clear();
     void CreateCell(CellFormType eType, int nParm1, int nParm2 = 0,
         int nStagger = 0);
-    void FindCell(LONG x, LONG y, CB::ssize_t& row, CB::ssize_t& col);
+    void FindCell(long x, long y, CB::ssize_t& row, CB::ssize_t& col);
     void FillCell(CDC* pDC, int xPos, int yPos);
     void FrameCell(CDC* pDC, int xPos, int yPos);
     CSize CalcBoardSize(size_t nRows, size_t nCols);

--- a/GShr/CellForm.h
+++ b/GShr/CellForm.h
@@ -60,7 +60,7 @@ public:
     BITMAP*  GetMaskMemoryInfo() { return m_pMask != NULL ? &m_bmapMask : NULL; }
     BOOL     HasMask() { return m_pMask != NULL; }
 
-    CRect* GetRect(int row, int col, CRect* pRct);
+    CRect* GetRect(CB::ssize_t row, CB::ssize_t col, CRect* pRct);
     CSize GetCellSize() { return CSize(m_rct.right, m_rct.bottom); }
     CellFormType GetCellType() { return m_eType; }
     BOOL GetCellStagger() { return m_nStagger != 0; }
@@ -70,16 +70,16 @@ public:
     void Clear();
     void CreateCell(CellFormType eType, int nParm1, int nParm2 = 0,
         int nStagger = 0);
-    void FindCell(int x, int y, int& row, int& col);
+    void FindCell(LONG x, LONG y, CB::ssize_t& row, CB::ssize_t& col);
     void FillCell(CDC* pDC, int xPos, int yPos);
     void FrameCell(CDC* pDC, int xPos, int yPos);
-    CSize CalcBoardSize(int nRows, int nCols);
-    BOOL CalcTrialBoardSize(int nRows, int nCols);
+    CSize CalcBoardSize(size_t nRows, size_t nCols);
+    BOOL CalcTrialBoardSize(size_t nRows, size_t nCols);
 
     BOOL CompareEqual(CCellForm& cf);
 
     // ------- //
-    static void GetCellNumberStr(CellNumStyle eStyle, int row, int col,
+    static void GetCellNumberStr(CellNumStyle eStyle, size_t row, size_t col,
         CString& str);
     // ------- //
     void Serialize(CArchive& ar);
@@ -97,7 +97,7 @@ protected:
     // ------- //
     void OffsetPoly(POINT* pPoly, int nPts, int xOff, int yOff);
     // ------- //
-    int CellPhase(int val) { return ((val ^ m_nStagger) & 1); }
+    CB::ssize_t CellPhase(CB::ssize_t val) { return ((val ^ m_nStagger) & 1); }
     void CreateHexMask();
 };
 

--- a/GShr/CyberBoard.h
+++ b/GShr/CyberBoard.h
@@ -116,6 +116,12 @@ static_assert(std::is_unsigned_v<int32_t> == std::is_unsigned_v<LONG> &&
     #undef min
 #endif
 
+namespace CB
+{
+    // unfortunately, some, but not all, systems declare ssize_t
+    using ssize_t = std::make_signed_t<size_t>;
+}
+
 /////////////////////////////////////////////////////////////////////////////
 
 // emulate c++20 std::remove_cvref_t

--- a/GShr/CyberBoard.h
+++ b/GShr/CyberBoard.h
@@ -36,6 +36,7 @@
 
 #include <WinExt.h>
 
+#if defined(_MSC_VER)
 // warning C4239 : nonstandard extension used : 'argument' : conversion from 'xxx' to 'xxx &'
 #pragma warning(error:  4239)
 // warning C4244 : 'initializing' : conversion from 'xxx' to 'yyy', possible loss of data
@@ -65,6 +66,14 @@
 #pragma warning(1:  5205)
 // WARNING:  for some reason, this won't become an error, even at level 4!
 #pragma warning(error:  5205)
+
+// warning C4100 : 'xxx' : unreferenced formal parameter
+#pragma warning(disable:  4100)
+// warning C4189 : 'xxx' : local variable is initialized but not referenced
+#pragma warning(disable:  4189)
+// warning C4456 : declaration of 'xxx' hides previous local declaration
+#pragma warning(disable:  4456)
+#endif
 
 #if defined(max)
     #undef max

--- a/GShr/CyberBoard.h
+++ b/GShr/CyberBoard.h
@@ -36,6 +36,38 @@
 
 #include <WinExt.h>
 
+static_assert(std::is_same_v<uint8_t, BYTE>, "wrong standard replacement for BYTE");
+static_assert(std::is_same_v<uint16_t, WORD>, "wrong standard replacement for WORD");
+static_assert(std::is_same_v<unsigned int, UINT>, "wrong standard replacement for UINT");
+static_assert(std::is_same_v<long, LONG>, "wrong standard replacement for LONG");
+static_assert(std::is_same_v<intptr_t, INT_PTR>, "wrong standard replacement for INT_PTR");
+static_assert(std::is_same_v<uintptr_t, UINT_PTR>, "wrong standard replacement for UINT_PTR");
+#if defined(_WIN64)
+// unfortunately, these aren't true in 32bit
+static_assert(std::is_same_v<UINT_PTR, DWORD_PTR>, "inconsistent unsigned *_PTR types");
+static_assert(std::is_same_v<uintptr_t, DWORD_PTR>, "wrong standard replacement for DWORD_PTR");
+#else
+/* best we can do in 32bit, but this means we can't always use
+    uintptr_t, e.g., virtual function override doesn't work when
+    types aren't same */
+static_assert(std::is_unsigned_v<uintptr_t> == std::is_unsigned_v<DWORD_PTR> &&
+                    sizeof(uintptr_t) == sizeof(DWORD_PTR),
+                "wrong standard replacement for DWORD_PTR");
+#endif
+#if 0
+// unfortunately, these aren't true
+static_assert(std::is_same_v<uint32_t, DWORD>, "wrong standard replacement for DWORD");
+static_assert(std::is_same_v<int32_t, LONG>, "wrong standard replacement for LONG");
+#else
+// best we can do
+static_assert(std::is_unsigned_v<uint32_t> == std::is_unsigned_v<DWORD> &&
+                    sizeof(uint32_t) == sizeof(DWORD),
+                "wrong standard replacement for DWORD");
+static_assert(std::is_unsigned_v<int32_t> == std::is_unsigned_v<LONG> &&
+                    sizeof(int32_t) == sizeof(LONG),
+                "wrong standard replacement for DWORD");
+#endif
+
 #if defined(_MSC_VER)
 // warning C4239 : nonstandard extension used : 'argument' : conversion from 'xxx' to 'xxx &'
 #pragma warning(error:  4239)

--- a/GShr/CyberBoard.h
+++ b/GShr/CyberBoard.h
@@ -38,8 +38,24 @@
 
 // warning C4239 : nonstandard extension used : 'argument' : conversion from 'xxx' to 'xxx &'
 #pragma warning(error:  4239)
+// warning C4244 : 'initializing' : conversion from 'xxx' to 'yyy', possible loss of data
+#pragma warning(error:  4244)
+// warning C4245 : 'initializing' : conversion from 'xxx' to 'yyy', signed / unsigned mismatch
+#pragma warning(error:  4245)
 // warning C4310 : cast truncates constant value
 #pragma warning(error:  4310)
+// warning C4311 : 'type cast' : pointer truncation from 'xxx' to 'yyy'
+#pragma warning(error:  4311)
+// warning C4312 : 'type cast' : conversion from 'xxx' to 'yyy' of greater size
+#pragma warning(error:  4312)
+// warning C4701 : potentially uninitialized local variable 'xxx' used
+#pragma warning(error:  4701)
+// warning C4703 : potentially uninitialized local pointer variable 'xxx' used
+#pragma warning(error:  4703)
+// warning C4715 : 'xxx' : not all control paths return a value
+#pragma warning(error:  4715)
+// warning C4805 : '|=' : unsafe mix of type 'bool' and type 'BOOL' in operation
+#pragma warning(error:  4805)
 // warning C4840 : non - portable use of class 'xxx' as an argument to a variadic function
 #pragma warning(error:  4840)
 // warning C5205 : delete of an abstract class 'xxx' that has a non - virtual destructor results in undefined behavior

--- a/GShr/CyberBoard.h
+++ b/GShr/CyberBoard.h
@@ -75,6 +75,8 @@ static_assert(std::is_unsigned_v<int32_t> == std::is_unsigned_v<LONG> &&
 #pragma warning(error:  4244)
 // warning C4245 : 'initializing' : conversion from 'xxx' to 'yyy', signed / unsigned mismatch
 #pragma warning(error:  4245)
+// warning C4267 : 'initializing' : conversion from 'xxx' to 'yyy', possible loss of data
+#pragma warning(error:  4267)
 // warning C4302 : 'type cast' : truncation from 'xxx' to 'yyy'
 #pragma warning(error:  4302)
 // warning C4310 : cast truncates constant value

--- a/GShr/CyberBoard.h
+++ b/GShr/CyberBoard.h
@@ -42,6 +42,8 @@
 #pragma warning(error:  4244)
 // warning C4245 : 'initializing' : conversion from 'xxx' to 'yyy', signed / unsigned mismatch
 #pragma warning(error:  4245)
+// warning C4302 : 'type cast' : truncation from 'xxx' to 'yyy'
+#pragma warning(error:  4302)
 // warning C4310 : cast truncates constant value
 #pragma warning(error:  4310)
 // warning C4311 : 'type cast' : pointer truncation from 'xxx' to 'yyy'

--- a/GShr/DibApi.cpp
+++ b/GShr/DibApi.cpp
@@ -859,7 +859,7 @@ HANDLE CopyHandle (HANDLE h)
     BYTE*       lpCopy;
     BYTE*       lp;
     HANDLE      hCopy;
-    DWORD       dwLen;
+    size_t      dwLen;
 
     if (h == NULL)
         return NULL;

--- a/GShr/DibApi.cpp
+++ b/GShr/DibApi.cpp
@@ -624,7 +624,7 @@ HBITMAP DIBToBitmap (HANDLE hDIB, HPALETTE hPal)
 
 ///////////////////////////////////////////////////////////////////////
 
-HANDLE BitmapToDIB(HBITMAP hBitmap, HPALETTE hPal, int nBPP)
+HANDLE BitmapToDIB(HBITMAP hBitmap, HPALETTE hPal, uint16_t nBPP)
 {
     HANDLE hDIB = NULL;
     if (!hBitmap)
@@ -664,7 +664,7 @@ HANDLE BitmapToDIB(HBITMAP hBitmap, HPALETTE hPal, int nBPP)
         BYTE bmapInfo[sizeof(BITMAPINFOHEADER) + 3 * sizeof(RGBQUAD)];
         BITMAPINFO* pbmi = (BITMAPINFO*)&bmapInfo;      // Convenience pointer
         InitBitmapInfoHeader((BITMAPINFOHEADER*)pbmi,
-            bmapSrc.bmWidth, bmapSrc.bmHeight, 16);
+            bmapSrc.bmWidth, bmapSrc.bmHeight, uint16_t(16));
         InitColorTableMasksIfReqd(pbmi);
 
         // We need a reference DC for palette bitmaps
@@ -725,7 +725,7 @@ HANDLE BitmapToDIB(HBITMAP hBitmap, HPALETTE hPal, int nBPP)
 
         // Changed to allow forces bits per pixel.
         InitBitmapInfoHeader(&bmInfoHdr, Bitmap.bmWidth, Bitmap.bmHeight,
-            nBPP == 0 ? Bitmap.bmPlanes * Bitmap.bmBitsPixel : nBPP);
+            nBPP == 0 ? value_preserving_cast<uint16_t>(Bitmap.bmPlanes * Bitmap.bmBitsPixel) : nBPP);
 
         // Now allocate memory for the DIB.  Then, set the BITMAPINFOHEADER
         // into this memory, and find out where the bitmap bits go.
@@ -811,7 +811,7 @@ HANDLE ConvertDIBSectionToDIB(HBITMAP hDibSect)
 ///////////////////////////////////////////////////////////////////////
 
 void InitBitmapInfoHeader(LPBITMAPINFOHEADER lpBmInfoHdr, DWORD dwWidth,
-    DWORD dwHeight, int nBPP)
+    DWORD dwHeight, uint16_t nBPP)
 {
     memset(lpBmInfoHdr, 0, sizeof(BITMAPINFOHEADER));
 
@@ -820,19 +820,19 @@ void InitBitmapInfoHeader(LPBITMAPINFOHEADER lpBmInfoHdr, DWORD dwWidth,
     lpBmInfoHdr->biHeight    = dwHeight;
     lpBmInfoHdr->biPlanes    = 1;
 
-    if (nBPP <= 1)
-        nBPP = 1;
-    else if (nBPP <= 4)
-        nBPP = 4;
-    else if (nBPP <= 8)
-        nBPP = 8;
-    else if (nBPP <= 16)
+    if (nBPP <= uint16_t(1))
+        nBPP = uint16_t(1);
+    else if (nBPP <= uint16_t(4))
+        nBPP = uint16_t(4);
+    else if (nBPP <= uint16_t(8))
+        nBPP = uint16_t(8);
+    else if (nBPP <= uint16_t(16))
     {
-        nBPP = 16;
+        nBPP = uint16_t(16);
         lpBmInfoHdr->biCompression = BI_BITFIELDS;
     }
     else
-        nBPP = 24;
+        nBPP = uint16_t(24);
 
     lpBmInfoHdr->biBitCount  = nBPP;
     lpBmInfoHdr->biSizeImage = WIDTHBYTES(dwWidth * nBPP) * dwHeight;

--- a/GShr/DibApi.h
+++ b/GShr/DibApi.h
@@ -49,9 +49,9 @@ WORD    PaletteSize(LPSTR lpbi);
 WORD    DIBNumColors(LPSTR lpbi);
 HANDLE  CopyHandle(HANDLE h);
 HBITMAP DIBToBitmap(HANDLE hDIB, HPALETTE hPal);
-HANDLE  BitmapToDIB(HBITMAP hBitmap, HPALETTE hPal, int nBPP = 0);
+HANDLE  BitmapToDIB(HBITMAP hBitmap, HPALETTE hPal, uint16_t nBPP = uint16_t(0));
 void    InitBitmapInfoHeader(LPBITMAPINFOHEADER lpBmInfoHdr,
-            DWORD dwWidth, DWORD dwHeight, int nBPP);
+            DWORD dwWidth, DWORD dwHeight, uint16_t nBPP);
 void    InitColorTableMasksIfReqd(LPBITMAPINFO lpBmInfo);
 LPBYTE  DibXY(LPSTR lpbi, int x, int y);
 BOOL    IsColorNumInDIB(LPSTR lpbi, UINT iColor);

--- a/GShr/DrawObj.cpp
+++ b/GShr/DrawObj.cpp
@@ -1486,7 +1486,7 @@ TileID CMarkObj::GetCurrentTileID()
     if (m_nFacingDegCW != 0)
     {
         // Handle rotated markers...
-        ElementState state = MakeMarkerState(m_mid, (WORD)m_nFacingDegCW);
+        ElementState state(m_mid, m_nFacingDegCW);
         CTileFacingMap* pMapFacing = m_pDoc->GetFacingMap();
         TileID tidFacing = pMapFacing->GetFacingTileID(state);
         if (tidFacing == nullTid)

--- a/GShr/DrawObj.cpp
+++ b/GShr/DrawObj.cpp
@@ -1547,23 +1547,21 @@ void CMarkObj::Serialize(CArchive& ar)
     {
         ar << m_dwObjectID;
         ar << m_mid;
-        ar << (WORD)m_nFacingDegCW;                                 //Ver2.0
+        ar << m_nFacingDegCW;                                 //Ver2.0
     }
     else
     {
-        WORD wTmp;
         m_pDoc = ((CGamDoc*)ar.m_pDocument);
         ar >> m_dwObjectID;
         ar >> m_mid;
         if (CGamDoc::GetLoadingVersion() >= NumVersion(2, 0))       //Ver2.0
         {
-            ar >> wTmp;
-            m_nFacingDegCW = wTmp;
+            ar >> m_nFacingDegCW;
             if (CGamDoc::GetLoadingVersion() < NumVersion(2, 90))   //Ver2.90
-                m_nFacingDegCW *= 5;                                // Convert old value to degrees
+                m_nFacingDegCW *= uint16_t(5);                                // Convert old value to degrees
         }
         else
-            m_nFacingDegCW = 0;
+            m_nFacingDegCW = uint16_t(0);
     }
 }
 

--- a/GShr/DrawObj.h
+++ b/GShr/DrawObj.h
@@ -300,7 +300,7 @@ private:
             Subtype subtype : 4;
 
             constexpr Invalid() :
-                pad1(0),
+                pad1(0),     // GameElement32 Hash() won't work properly if bits uninitialized
                 pad2(0),
                 subtype(stInvalid)
             {
@@ -444,12 +444,15 @@ private:
         } pieceObj;
         struct Invalid
         {
-            uint32_t : 32;
-            uint16_t : 16;
-            uint16_t : 12;
+            uint32_t pad1 : 32;
+            uint16_t pad2 : 16;
+            uint16_t pad3 : 12;
             Subtype subtype : 4;
 
             constexpr Invalid() :
+                pad1(0),     // GameElement64 Hash() won't work properly if bits uninitialized
+                pad2(0),
+                pad3(0),
                 subtype(stInvalid)
             {
             }

--- a/GShr/DrawObj.h
+++ b/GShr/DrawObj.h
@@ -875,9 +875,9 @@ class CMarkObj : public CDrawObj
 {
 // Constructors
 public:
-    CMarkObj() { m_mid = nullMid; m_pDoc = NULL; m_nFacingDegCW = 0; }
+    CMarkObj() { m_mid = nullMid; m_pDoc = NULL; m_nFacingDegCW = uint16_t(0); }
     CMarkObj(CGamDoc* pDoc)
-        { m_mid = nullMid; m_pDoc = pDoc; m_nFacingDegCW = 0; }
+        { m_mid = nullMid; m_pDoc = pDoc; m_nFacingDegCW = uint16_t(0); }
 
 // Attributes
 public:
@@ -886,8 +886,8 @@ public:
 
     void SetMark(CRect& rct, MarkID mid);
 
-    void SetFacing(int nFacingDegCW) { m_nFacingDegCW = nFacingDegCW; }
-    int  GetFacing() { return m_nFacingDegCW; }
+    void SetFacing(uint16_t nFacingDegCW) { m_nFacingDegCW = nFacingDegCW; }
+    uint16_t GetFacing() { return m_nFacingDegCW; }
 
     void    SetObjectID(ObjectID dwID) { m_dwObjectID = dwID; }
     virtual ObjectID GetObjectID() const override { return m_dwObjectID; }
@@ -897,7 +897,7 @@ public:
     virtual enum CDrawObjType GetType() const override { return drawMarkObj; }
 protected:
     ObjectID m_dwObjectID;
-    int      m_nFacingDegCW;           // Rotation of marker (degrees)
+    uint16_t m_nFacingDegCW;           // Rotation of marker (degrees)
 
 // Operations
 public:

--- a/GShr/Font.cpp
+++ b/GShr/Font.cpp
@@ -49,7 +49,7 @@ CFontTbl::~CFontTbl(void)
 
 // ----------------------------------------------------- //
 
-FontID CFontTbl::AddFont(int iSize, int taFlgs, int iFamily,
+FontID CFontTbl::AddFont(int iSize, int taFlgs, uint8_t iFamily,
     const char *pszFName)
 {
     FNameID fnID = oFName.AddFaceName(pszFName, iFamily);
@@ -123,7 +123,7 @@ void CFontTbl::FillLogFontStruct(FontID id, LPLOGFONT pLF)
     pLF->lfItalic = opFnt->IsItalic();
     pLF->lfUnderline = opFnt->IsULine();
     pLF->lfCharSet = DEFAULT_CHARSET;
-    pLF->lfPitchAndFamily = value_preserving_cast<BYTE>(oFName.GetFaceFamily(opFnt->fnID));
+    pLF->lfPitchAndFamily = oFName.GetFaceFamily(opFnt->fnID);
     if ((pszFace = oFName.GetFaceName(opFnt->fnID)) != NULL)
     {
         strcpy(pLF->lfFaceName, pszFace);
@@ -187,7 +187,7 @@ void CFontTbl::Archive(CArchive& ar, FontID& rfontID)
         ar >> wFamily;
         CString str;
         ar >> str;
-        rfontID = AddFont((int)wSize, (int)wFlags, (int)wFamily, str);
+        rfontID = AddFont((int)wSize, (int)wFlags, value_preserving_cast<uint8_t>(wFamily), str);
     }
 }
 

--- a/GShr/Font.h
+++ b/GShr/Font.h
@@ -69,7 +69,7 @@ public:
     // -------- //
     FNameTbl& GetFNameTbl(void) { return oFName; }
     // -------- //
-    FontID AddFont(int iSize, int taFlgs, int iFamily, const char *pszFName);
+    FontID AddFont(int iSize, int taFlgs, uint8_t iFamily, const char *pszFName);
     void FillLogFontStruct(FontID id, LPLOGFONT pLF);
     HFONT GetFontHandle(FontID id);
     void ReleaseFontHandle(FontID id);

--- a/GShr/FontName.cpp
+++ b/GShr/FontName.cpp
@@ -41,7 +41,7 @@ static char THIS_FILE[] = __FILE__;
 
 // ====================================================== //
 
-FNameID FNameTbl::AddFaceName(const char *pszFName, int iFamily)
+FNameID FNameTbl::AddFaceName(const char *pszFName, uint8_t iFamily)
 {
     FName oFName(pszFName, iFamily);
     return Register(std::move(oFName));
@@ -60,7 +60,7 @@ FNameID FNameTbl::operator[](size_t iFaceNum) const
 
 // ====================================================== //
 
-FName::FName(const char *pszFName, int iFamily)
+FName::FName(const char *pszFName, uint8_t iFamily)
 {
     strcpy(szFName, pszFName);
     this->iFamily = iFamily;

--- a/GShr/FontName.h
+++ b/GShr/FontName.h
@@ -36,14 +36,14 @@ class FName
 {
     friend class FNameTbl;
 protected:
-    int iFamily;                    // See LOGFONT FF_*
+    uint8_t iFamily;                    // See LOGFONT FF_*
     char szFName[LF_FACESIZE];      // Name of font
 public:
     // ---------- //
     bool operator==(const FName& rhs) const;
     // ---------- //
-    FName(void) { iFamily = 0; *szFName = 0; }
-    FName(const char *pszFName, int iFamily);
+    FName(void) { iFamily = uint8_t(0); *szFName = 0; }
+    FName(const char *pszFName, uint8_t iFamily);
     std::string ToString() const { return szFName; }
 };
 
@@ -52,11 +52,11 @@ public:
 class FNameTbl : private AtomList<FName>
 {
 public:
-    FNameID AddFaceName(const char *pszFName, int iFamily);
+    FNameID AddFaceName(const char *pszFName, uint8_t iFamily);
     const char *GetFaceName(FNameID id) const
         { return id == NULL ? NULL : (*id)->szFName;}
-    int GetFaceFamily(FNameID id) const
-        { return id == NULL ? 0 : (*id)->iFamily;}
+    uint8_t GetFaceFamily(FNameID id) const
+        { return id == NULL ? uint8_t(0) : (*id)->iFamily;}
     size_t GetSize() const { return size(); }
     FNameID operator[](size_t iFaceNum) const;
 };

--- a/GShr/GMisc.h
+++ b/GShr/GMisc.h
@@ -80,8 +80,8 @@ inline DWORD UPGRADE_OWNER_MASK(WORD wOldMask)
     return dwNewMask;
 }
 
-void WriteArchivePoints(CArchive& ar, POINT* pPnts, int nPnts);
-void ReadArchivePoints(CArchive& ar, POINT* pPnts, int nPnts);
+void WriteArchivePoints(CArchive& ar, const POINT* pPnts, size_t nPnts);
+void ReadArchivePoints(CArchive& ar, POINT* pPnts, size_t nPnts);
 
 #endif
 

--- a/GShr/GdiTools.cpp
+++ b/GShr/GdiTools.cpp
@@ -58,7 +58,7 @@ FontID DoFontDialog(FontID fid, CWnd *pParentWnd, BOOL bScreenOK)
         return (FontID)0;
     return pFontTbl->AddFont(TenthPointsToScreenPixels(dlg.GetSize()),
         (dlg.IsBold()?taBold:0)|(dlg.IsItalic()?taItalic:0),
-        lf.lfPitchAndFamily & 0xF0, dlg.GetFaceName());
+        static_cast<uint8_t>(lf.lfPitchAndFamily & 0xF0), dlg.GetFaceName());
 }
 
 /////////////////////////////////////////////////////////////////
@@ -152,7 +152,7 @@ HBITMAP Create16BitDIBSection(HDC hDC, int nWidth, int nHeight)
 {
     BYTE bih[sizeof(BITMAPINFOHEADER) + 3 * sizeof(DWORD)];
     BITMAPINFO* pbmi = (BITMAPINFO*)&bih;
-    InitBitmapInfoHeader((BITMAPINFOHEADER*)pbmi, nWidth, nHeight, 16);
+    InitBitmapInfoHeader((BITMAPINFOHEADER*)pbmi, nWidth, nHeight, uint16_t(16));
     InitColorTableMasksIfReqd(pbmi);
 
     HDC hLocalDC = hDC == NULL ? GetDC(NULL) : hDC;   // Get a DC if one not supplied
@@ -173,7 +173,7 @@ HBITMAP Create16BitDIBSection(HDC hDC, int nWidth, int nHeight)
 HBITMAP CreateRGBDIBSection(HDC hDC, int nWidth, int nHeight)
 {
     BITMAPINFOHEADER bih;
-    InitBitmapInfoHeader(&bih, nWidth, nHeight, 24);
+    InitBitmapInfoHeader(&bih, nWidth, nHeight, uint16_t(24));
 
     HDC hLocalDC = hDC == NULL ? GetDC(NULL) : hDC;   // Get a DC if one not supplied
 
@@ -857,7 +857,7 @@ CPalette* GetAppPalette()
 CPalette* CreateMergedPalette(CPalette* palPri, CPalette* palSec)
 {
     short nSizePri, nSizeSec;
-    int nPalSize = 256;
+    uint16_t nPalSize = uint16_t(256);
 
     palSec->GetObject(sizeof(short), &nSizeSec);
     palPri->GetObject(sizeof(short), &nSizePri);
@@ -971,7 +971,7 @@ static BYTE sysColors[20*3] =
     255, 255, 255,
 };
 
-void SetupIdentityPalette(int nNumColors, LPLOGPALETTE pPal)
+void SetupIdentityPalette(uint16_t nNumColors, LPLOGPALETTE pPal)
 {
     pPal->palVersion = 0x300;
     pPal->palNumEntries = nNumColors;

--- a/GShr/GdiTools.h
+++ b/GShr/GdiTools.h
@@ -51,7 +51,7 @@ inline WORD RGB565(COLORREF cref)
 inline COLORREF RGB565_TO_24(WORD clr16)
 {
     BYTE r = (((clr16 & 0xF800) >> 11) * 0xFF) / 0x1F;
-    BYTE g = (((clr16 & 0x7E0) >> 5) * 0xFF) / 0x3F;
+    BYTE g = static_cast<BYTE>((((clr16 & 0x7E0) >> 5) * 0xFF) / 0x3F);
     BYTE b = (( clr16 & 0x1F) * 0xFF) / 0x1F;
     return RGB(r, g, b);
 }
@@ -201,7 +201,7 @@ void AppendBitmap(CBitmap *pBMapTo, CBitmap *pBMapFrm, CPalette *pPalTo,
 void RemoveBitmapSlice(CBitmap *pBMap, int yPos, int iHt, CPalette *pPal = NULL);
 CPalette* BuildMasterPalette(CObArray* pPalTbl, BOOL bAppend = TRUE);
 CPalette* CreateMergedPalette(CPalette* palPri, CPalette* palSec);
-void SetupIdentityPalette(int nNumColors, LPLOGPALETTE pPal);
+void SetupIdentityPalette(uint16_t nNumColors, LPLOGPALETTE pPal);
 void AddEntryToPalette(LPPALETTEENTRY pPal, int nSize, PALETTEENTRY& pe);
 void SetPaletteEntryFromColorref(PALETTEENTRY& pe, COLORREF cr);
 void BltThruDIB(CDC* pDCDst, int xDst, int yDst, int cx, int cy,

--- a/GShr/LBoxGfx2.cpp
+++ b/GShr/LBoxGfx2.cpp
@@ -41,7 +41,7 @@ const unsigned defaultItemHeight = 16;
 const int scrollZonePixels = 7;         // size of autoscroll trigger zone
 const int timerScrollStart = 180;
 const int timerScroll = 125;
-const int timerScrollIDStart = 900;
+const uintptr_t timerScrollIDStart = 900;
 const int timerScrollID = 901;
 
 /////////////////////////////////////////////////////////////////////////////
@@ -62,7 +62,7 @@ END_MESSAGE_MAP()
 CGrafixListBox2::CGrafixListBox2()
 {
     m_nLastInsert = -1;
-    m_nTimerID = 0;
+    m_nTimerID = uintptr_t(0);
     m_bAllowDrag = FALSE;
     m_bAllowSelfDrop = FALSE;
     m_bAllowDropScroll = FALSE;
@@ -345,7 +345,7 @@ void CGrafixListBox2::OnLButtonUp(UINT nFlags, CPoint point)
     if (m_nTimerID)
     {
         KillTimer(m_nTimerID);
-        m_nTimerID = 0;
+        m_nTimerID = uintptr_t(0);
     }
     if (m_bAllowDrag)
     {
@@ -500,7 +500,7 @@ int CGrafixListBox2::OnCreate(LPCREATESTRUCT lpCreateStruct)
         return -1;
 
     m_pItemMap = NULL;
-    m_nTimerID = 0;
+    m_nTimerID = uintptr_t(0);
 
     return 0;
 }
@@ -535,7 +535,7 @@ void CGrafixListBox2::DoInsertLineProcessing(UINT nPhase, DragInfo* pdi)
 
 void CGrafixListBox2::DoAutoScrollProcessing(DragInfo* pdi)
 {
-    if (m_bAllowDropScroll && m_nTimerID == 0)
+    if (m_bAllowDropScroll && m_nTimerID == uintptr_t(0))
     {
         CRect rct;
         GetClientRect(&rct);
@@ -565,9 +565,9 @@ LRESULT CGrafixListBox2::OnDragItem(WPARAM wParam, LPARAM lParam)
     return lResult;
 }
 
-void CGrafixListBox2::OnTimer(UINT nIDEvent)
+void CGrafixListBox2::OnTimer(uintptr_t nIDEvent)
 {
-    if (nIDEvent != (UINT)m_nTimerID)
+    if (nIDEvent != m_nTimerID)
         return;
 
     CPoint point;
@@ -623,7 +623,7 @@ void CGrafixListBox2::OnTimer(UINT nIDEvent)
     else
     {
         KillTimer(m_nTimerID);
-        m_nTimerID = 0;
+        m_nTimerID = uintptr_t(0);
     }
 }
 

--- a/GShr/LBoxGfx2.h
+++ b/GShr/LBoxGfx2.h
@@ -120,7 +120,7 @@ protected:
     BOOL    m_bAllowDropScroll;     // Scroll on OnDragItem
 
     CPoint  m_clickPoint;
-    int     m_nTimerID;
+    uintptr_t m_nTimerID;
     BOOL    m_triggeredCursor;
     HWND    m_hLastWnd;
 
@@ -144,7 +144,7 @@ protected:
     afx_msg void OnLButtonDown(UINT nFlags, CPoint point);
     afx_msg void OnMouseMove(UINT nFlags, CPoint point);
     afx_msg void OnLButtonUp(UINT nFlags, CPoint point);
-    afx_msg void OnTimer(UINT nIDEvent);
+    afx_msg void OnTimer(uintptr_t nIDEvent);
     afx_msg int OnCreate(LPCREATESTRUCT lpCreateStruct);
     afx_msg LRESULT OnDragItem(WPARAM wParam, LPARAM lParam);
     //}}AFX_MSG

--- a/GShr/LBoxGrfx.cpp
+++ b/GShr/LBoxGrfx.cpp
@@ -39,7 +39,7 @@ const unsigned defaultItemHeight = 16;
 const int scrollZonePixels = 7;         // size of autoscroll trigger zone
 const int timerScrollStart = 180;
 const int timerScroll = 125;
-const int timerScrollIDStart = 900;
+const uintptr_t timerScrollIDStart = 900;
 const int timerScrollID = 901;
 
 /////////////////////////////////////////////////////////////////////////////
@@ -61,7 +61,7 @@ CGrafixListBox::CGrafixListBox() :
     m_nCurItemCode(Invalid_v<GameElement>)
 {
     m_nLastInsert = -1;
-    m_nTimerID = 0;
+    m_nTimerID = uintptr_t(0);
     m_bAllowDrag = FALSE;
     m_bAllowSelfDrop = FALSE;
     m_bAllowDropScroll = FALSE;
@@ -298,7 +298,7 @@ void CGrafixListBox::OnLButtonUp(UINT nFlags, CPoint point)
     if (m_nTimerID)
     {
         KillTimer(m_nTimerID);
-        m_nTimerID = 0;
+        m_nTimerID = uintptr_t(0);
     }
     if (m_bAllowDrag)
     {
@@ -409,7 +409,7 @@ int CGrafixListBox::OnCreate(LPCREATESTRUCT lpCreateStruct)
     if (CListBox::OnCreate(lpCreateStruct) == -1)
         return -1;
 
-    m_nTimerID = 0;
+    m_nTimerID = uintptr_t(0);
 
     return 0;
 }
@@ -444,7 +444,7 @@ void CGrafixListBox::DoInsertLineProcessing(UINT nPhase, DragInfo* pdi)
 
 void CGrafixListBox::DoAutoScrollProcessing(DragInfo* pdi)
 {
-    if (m_bAllowDropScroll && m_nTimerID == 0)
+    if (m_bAllowDropScroll && m_nTimerID == uintptr_t(0))
     {
         CRect rct;
         GetClientRect(&rct);
@@ -474,9 +474,9 @@ LRESULT CGrafixListBox::OnDragItem(WPARAM wParam, LPARAM lParam)
     return lResult;
 }
 
-void CGrafixListBox::OnTimer(UINT nIDEvent)
+void CGrafixListBox::OnTimer(uintptr_t nIDEvent)
 {
-    if (nIDEvent != (UINT)m_nTimerID)
+    if (nIDEvent != m_nTimerID)
         return;
 
     CPoint point;
@@ -533,7 +533,7 @@ void CGrafixListBox::OnTimer(UINT nIDEvent)
     else
     {
         KillTimer(m_nTimerID);
-        m_nTimerID = 0;
+        m_nTimerID = uintptr_t(0);
     }
 }
 

--- a/GShr/LBoxGrfx.h
+++ b/GShr/LBoxGrfx.h
@@ -250,6 +250,7 @@ public:
 
     void SetItemMap(const std::vector<T>* pMap, BOOL bKeepPosition = TRUE)
     {
+        ASSERT(!pMap || pMap->size() < size_t(0x10000) || !"LB_ITEMFROMPOINT/ItemFromPoint() is WORD-limited");
         m_pItemMap = pMap;
         UpdateList(bKeepPosition);
     }

--- a/GShr/LBoxGrfx.h
+++ b/GShr/LBoxGrfx.h
@@ -170,7 +170,7 @@ protected:
     BOOL    m_bAllowDropScroll;     // Scroll on OnDragItem
 
     CPoint  m_clickPoint;
-    int     m_nTimerID;
+    uintptr_t m_nTimerID;
     BOOL    m_triggeredCursor;
     HWND    m_hLastWnd;
 
@@ -197,7 +197,7 @@ protected:
     afx_msg void OnLButtonDown(UINT nFlags, CPoint point);
     afx_msg void OnMouseMove(UINT nFlags, CPoint point);
     afx_msg void OnLButtonUp(UINT nFlags, CPoint point);
-    afx_msg void OnTimer(UINT nIDEvent);
+    afx_msg void OnTimer(uintptr_t nIDEvent);
     afx_msg int OnCreate(LPCREATESTRUCT lpCreateStruct);
     afx_msg LRESULT OnDragItem(WPARAM wParam, LPARAM lParam);
     //}}AFX_MSG

--- a/GShr/LBoxProj.cpp
+++ b/GShr/LBoxProj.cpp
@@ -73,9 +73,9 @@ int CProjListBoxBase::AddSeqItem(int nGroupCode, LPCSTR pszText, int nSeqNum,
     str += value_preserving_cast<char>(nGroupCode + 'A');
     str += nSourceCode == Invalid_v<size_t> ? '*' : '+';
 
-    char szNum[16];
+    char szNum[_MAX_ITOSTR_BASE10_COUNT];
     _itoa(nSeqNum, szNum, 10);
-    StrLeadZeros(szNum, 3);
+    StrLeadZeros(szNum, size_t(3));
     str += szNum;
 
     str += pszText;

--- a/GShr/LBoxTileBase2.cpp
+++ b/GShr/LBoxTileBase2.cpp
@@ -204,7 +204,7 @@ void CTileBaseListBox2::DrawTipMarker(CDC* pDC, CRect rctItem, BOOL bVisible, in
 
 void CTileBaseListBox2::OnGetItemDebugString(size_t nItem, CString& str)
 {
-    str.Format("[%d] ", (DWORD)OnGetItemDebugIDCode(nItem));
+    str.Format("[%p] ", OnGetItemDebugIDCode(nItem));
 }
 
 /////////////////////////////////////////////////////////////////////////////

--- a/GShr/MapStrng.h
+++ b/GShr/MapStrng.h
@@ -729,13 +729,9 @@ public:
 
     void Serialize(CArchive& ar)
     {
-        int ver = ar.IsStoring() ?
-                        NumVersion(fileGbxVerMajor, fileGbxVerMinor)
-                    :
-                        GetLoadingVersion();
         if (ar.IsStoring())
         {
-            if (ver <= NumVersion(3, 90))
+            if (CB::GetVersion(ar) <= NumVersion(3, 90))
             {
                 uint32_t dwCount = value_preserving_cast<uint32_t>(GetCount());
                 ar << dwCount;
@@ -758,7 +754,7 @@ public:
         {
             this->RemoveAll();
             size_t count;
-            if (ver <= NumVersion(3, 90))
+            if (CB::GetVersion(ar) <= NumVersion(3, 90))
             {
                 uint32_t dwCount;
                 ar >> dwCount;

--- a/GShr/MapStrng.h
+++ b/GShr/MapStrng.h
@@ -225,7 +225,7 @@ private:
 
             MarkerElement(MarkID16 m) :
                 mid(m),
-                pad(0),
+                pad(0),     // Hash() won't work properly if bits uninitialized
                 tag(MARKER)
             {
             }
@@ -557,12 +557,13 @@ private:
             PieceID32 pid;
             // allow for 100 sides for future development
             uint32_t nSide : 7;
-            uint32_t : 10;
+            uint32_t pad : 10;
             uint32_t tag : 15;
 
             PieceElement(PieceID32 p, unsigned s) :
                 pid(p),
                 nSide(s),
+                pad(0),     // Hash() won't work properly if bits uninitialized
                 tag(PIECE)
             {
                 if (s > 1)
@@ -588,7 +589,7 @@ private:
 
             MarkerElement(MarkID32 m) :
                 mid(m),
-                pad(0),
+                pad(0),     // Hash() won't work properly if bits uninitialized
                 tag(MARKER)
             {
             }

--- a/GShr/Marks.cpp
+++ b/GShr/Marks.cpp
@@ -260,16 +260,32 @@ void CMarkManager::SerializeMarkSets(CArchive& ar)
 {
     if (ar.IsStoring())
     {
-        ar << value_preserving_cast<WORD>(GetNumMarkSets());
-        for (size_t i = 0; i < GetNumMarkSets(); i++)
+        if (CB::GetVersion(ar) <= NumVersion(3, 90))
+        {
+            ar << value_preserving_cast<WORD>(GetNumMarkSets());
+        }
+        else
+        {
+            CB::WriteCount(ar, GetNumMarkSets());
+        }
+        for (size_t i = size_t(0); i < GetNumMarkSets(); i++)
             GetMarkSet(i).Serialize(ar);
     }
     else
     {
-        WORD wSize;
-        ar >> wSize;
-        m_MSetTbl.resize(value_preserving_cast<size_t>(wSize));
-        for (size_t i = 0; i < m_MSetTbl.size(); i++)
+        size_t wSize;
+        if (CB::GetVersion(ar) <= NumVersion(3, 90))
+        {
+            WORD temp;
+            ar >> temp;
+            wSize = temp;
+        }
+        else
+        {
+            wSize = CB::ReadCount(ar);
+        }
+        m_MSetTbl.resize(wSize);
+        for (size_t i = size_t(0); i < m_MSetTbl.size(); i++)
         {
             m_MSetTbl[i].Serialize(ar);
         }

--- a/GShr/Pieces.cpp
+++ b/GShr/Pieces.cpp
@@ -215,14 +215,30 @@ void CPieceManager::SerializePieceSets(CArchive& ar)
 {
     if (ar.IsStoring())
     {
-        ar << value_preserving_cast<WORD>(GetNumPieceSets());
-        for (size_t i = 0; i < GetNumPieceSets(); i++)
+        if (CB::GetVersion(ar) <= NumVersion(3, 90))
+        {
+            ar << value_preserving_cast<WORD>(GetNumPieceSets());
+        }
+        else
+        {
+            CB::WriteCount(ar, GetNumPieceSets());
+        }
+        for (size_t i = size_t(0); i < GetNumPieceSets(); i++)
             GetPieceSet(i).Serialize(ar);
     }
     else
     {
-        WORD wSize;
-        ar >> wSize;
+        size_t wSize;
+        if (CB::GetVersion(ar) <= NumVersion(3, 90))
+        {
+            WORD temp;
+            ar >> temp;
+            wSize = temp;
+        }
+        else
+        {
+            wSize = CB::ReadCount(ar);
+        }
         m_PSetTbl.resize(wSize);
         for (size_t i = 0; i < m_PSetTbl.size(); i++)
         {

--- a/GShr/Rotate.cpp
+++ b/GShr/Rotate.cpp
@@ -61,7 +61,7 @@ void Stepper::Setup(int nStart, int nEnd, int nSteps)
     m_nVal = nStart;
     m_nRem = 0;
     int nDiff = nEnd - nStart;
-    if ((m_bNeg = nDiff < 0))
+    if ((m_bNeg = nDiff < 0) != false)
         nDiff = -nDiff;
     m_step = nSteps > 0 ? div(nDiff, nSteps) : div(0,1);
 }

--- a/GShr/Rotate.cpp
+++ b/GShr/Rotate.cpp
@@ -142,8 +142,8 @@ OwnerPtr<CDib> Rotate16BitDib(CDib* pSDib, int angle, COLORREF crTrans)
     OwnerPtr<CDib> pDDib = CreateTransparentColorDIB(sizeDst, crTrans);
 
     // Find top and bottom point indexes
-    int nTopPnt;
-    int nBotPnt;
+    int nTopPnt = 0;
+    int nBotPnt = 0;
     for (int i = 0; i < numPnts; i++)
     {
         if (pntDst[i].y == 0)

--- a/GShr/StrLib.cpp
+++ b/GShr/StrLib.cpp
@@ -96,28 +96,35 @@ BOOL StrIsIdentifier(const char* sp)
     return TRUE;
 }
 
-void StrGetAAAFormat(char *szVal, int n)
+void StrGetAAAFormat(char *szVal, size_t n)
 {
     memset(szVal, 0, 8);
-    char ch = (char)(((n - 1) % 26) + 'A');
-    while (n > 0)
+    char ch = value_preserving_cast<char>(((n - size_t(1)) % size_t(26)) + size_t('A'));
+    for ( ; ; )
     {
         *szVal++ = ch;
-        n -= 26;
+        if (n > size_t(26))
+        {
+            n -= size_t(26);
+        }
+        else
+        {
+            break;
+        }
     }
 }
 
-void StrLeadZeros(char* szVal, int nWidth)
+void StrLeadZeros(char* szVal, size_t nWidth)
 {
-    char szTmp[20];
-    int i;
+    char szTmp[_MAX_I64TOSTR_BASE10_COUNT];
+    size_t i;
     ASSERT(nWidth < sizeof(szTmp));
-    for (i = 0; i < nWidth; i++)
-        szTmp[i] = '0';
-    szTmp[i] = 0;           // Terminate
+    for (i = size_t(0) ; i < nWidth ; ++i)
+        szTmp[value_preserving_cast<ptrdiff_t>(i)] = '0';
+    szTmp[value_preserving_cast<ptrdiff_t>(i)] = 0;           // Terminate
     size_t nLen = strlen(szVal);
     ASSERT(nLen < sizeof(szTmp));
-    memcpy(szTmp + nWidth - value_preserving_cast<ptrdiff_t>(nLen), szVal, nLen);
+    memcpy(szTmp + value_preserving_cast<ptrdiff_t>(nWidth - nLen), szVal, nLen);
     strcpy(szVal, szTmp);
 }
 

--- a/GShr/StrLib.cpp
+++ b/GShr/StrLib.cpp
@@ -111,11 +111,13 @@ void StrLeadZeros(char* szVal, int nWidth)
 {
     char szTmp[20];
     int i;
+    ASSERT(nWidth < sizeof(szTmp));
     for (i = 0; i < nWidth; i++)
         szTmp[i] = '0';
     szTmp[i] = 0;           // Terminate
-    int nLen = strlen(szVal);
-    memcpy(szTmp + nWidth - nLen, szVal, nLen);
+    size_t nLen = strlen(szVal);
+    ASSERT(nLen < sizeof(szTmp));
+    memcpy(szTmp + nWidth - value_preserving_cast<ptrdiff_t>(nLen), szVal, nLen);
     strcpy(szVal, szTmp);
 }
 

--- a/GShr/StrLib.h
+++ b/GShr/StrLib.h
@@ -32,8 +32,8 @@ char *StrToLong(const char *sp, long *lVal);
 char *SetFileExt(char *fname, const char *ext);
 BOOL StrIsIdentifierChar(int ch);
 BOOL StrIsIdentifier(const char* sp);
-void StrGetAAAFormat(char *szVal, int n);
-void StrLeadZeros(char* szVal, int nWidth);
+void StrGetAAAFormat(char *szVal, size_t n);
+void StrLeadZeros(char* szVal, size_t nWidth);
 void StrTruncatePath(char *pszName);
 void StrExtractFilename(char *pszFName, const char* pszFPath);
 void StrBuildFullFilename(char* pszFull, const char* pszPath,

--- a/GShr/TileMgr.cpp
+++ b/GShr/TileMgr.cpp
@@ -650,17 +650,17 @@ void CTileManager::DumpTileDatabaseInfoToFile(LPCTSTR pszFileName, BOOL bNewFile
 
     // Sort the tile sheet table by CX and CY and dump it again...
 
-    UINT *pShtTbl = new UINT[4 * m_TShtTbl.size()];
-    UINT* pTbl = pShtTbl;
-    for (size_t nSheet = 0; nSheet < m_TShtTbl.size(); nSheet++)
+    uintmax_t *pShtTbl = new uintmax_t[size_t(4) * m_TShtTbl.size()];
+    uintmax_t* pTbl = pShtTbl;
+    for (size_t nSheet = size_t(0) ; nSheet < m_TShtTbl.size() ; nSheet++)
     {
         CTileSheet& pTSheet = m_TShtTbl.at(nSheet);
         *pTbl++ = nSheet;
-        *pTbl++ = value_preserving_cast<UINT>(pTSheet.GetWidth());
-        *pTbl++ = value_preserving_cast<UINT>(pTSheet.GetHeight());
-        *pTbl++ = value_preserving_cast<UINT>(pTSheet.GetSheetHeight());
+        *pTbl++ = value_preserving_cast<uintmax_t>(pTSheet.GetWidth());
+        *pTbl++ = value_preserving_cast<uintmax_t>(pTSheet.GetHeight());
+        *pTbl++ = value_preserving_cast<uintmax_t>(pTSheet.GetSheetHeight());
     }
-    qsort(pShtTbl, m_TShtTbl.size(), sizeof(UINT) * 4, compsheets);
+    qsort(pShtTbl, m_TShtTbl.size(), sizeof(uintmax_t) * 4, compsheets);
 
     WriteFileString(hFile,
         "     Tile Sheet Table\r\n"
@@ -672,7 +672,7 @@ void CTileManager::DumpTileDatabaseInfoToFile(LPCTSTR pszFileName, BOOL bNewFile
     pTbl = pShtTbl;
     for (size_t nSheet = 0; nSheet < m_TShtTbl.size(); nSheet++)
     {
-        wsprintf(szBfr, "| %04X  | %3u | %3u | %5u |\r\n", pTbl[0], pTbl[1], pTbl[2], pTbl[3]);
+        wsprintf(szBfr, "| %04jX  | %3ju | %3ju | %5ju |\r\n", pTbl[0], pTbl[1], pTbl[2], pTbl[3]);
         pTbl += 4;
         WriteFileString(hFile, szBfr);
     }

--- a/GShr/TileMgr.cpp
+++ b/GShr/TileMgr.cpp
@@ -56,7 +56,7 @@ CTileManager::CTileManager()
     SetBackColor(RGB(255, 255, 255));
     SetLineWidth(1);
     m_fontID = CGamDoc::GetFontManager()->AddFont(TenthPointsToScreenPixels(80),
-        0, FF_SWISS, "Arial");
+        0, uint8_t(FF_SWISS), "Arial");
     // --------- //
     m_wReserved1 = 0;
     m_wReserved2 = 0;

--- a/GShr/Versions.h
+++ b/GShr/Versions.h
@@ -5,6 +5,11 @@
 // wsu20210731
 //      4.00 - 32-bit TileID/MarkID/PieceID/BoardID
 //
+// wsu20220208:  This version has been reverted.
+//                  (It is equivalent to 3.10, so we will no
+//                  longer create v 3.90 files to preserve
+//                  compatibility with released CB 3.10 unless
+//                  later features are enabled.)
 // DLL20100103
 //      3.90 - Stripped out XtremeToolkit C++ code. MORE TO COME.
 //
@@ -102,7 +107,7 @@ inline int GetSaveFileVersion()
         };
         FileFlagParser ffp;
         CbGetApp().ParseCommandLine(ffp);
-        return ffp.id32cb64 ? NumVersion(4, 0) : NumVersion(3, 90);
+        return ffp.id32cb64 ? NumVersion(4, 0) : NumVersion(3, 10);
     }();
     return retval;
 }
@@ -184,8 +189,8 @@ namespace CB { namespace Impl
         ASSERT(NumVersion(fileGmvVerMajor, fileGmvVerMinor) == NumVersion(fileGbxVerMajor, fileGbxVerMinor));
         if (GetVersion(ar) <= NumVersion(3, 90))
         {
-            // ASSERT(GetVersion(ar) < NumVersion(3, 90) --> ar.IsLoading());
-            ASSERT(GetVersion(ar) == NumVersion(3, 90) || ar.IsLoading());
+            // ASSERT(GetVersion(ar) < NumVersion(3, 10) --> ar.IsLoading());
+            ASSERT(GetVersion(ar) == NumVersion(3, 10) || ar.IsLoading());
             return sizeof(XxxxID16<T::PREFIX>::UNDERLYING_TYPE);
         }
         else

--- a/GShr/Versions.h
+++ b/GShr/Versions.h
@@ -91,18 +91,19 @@ inline int GetSaveFileVersion()
     static const int retval = [] {
         struct FileFlagParser : public CCommandLineInfo
         {
-            bool id32 = false;
+            bool id32cb64 = false;
             virtual void ParseParam(const char* pszParam, BOOL bFlag, BOOL bLast) override
             {
-                if (bFlag && strcmp(pszParam, "id32") == 0)
+                if (bFlag && strcmp(pszParam, "id32cb64") == 0)
                 {
-                    id32 = true;
+                    ASSERT(!"not ready yet");
+                    id32cb64 = true;
                 }
             }
         };
         FileFlagParser ffp;
         CbGetApp().ParseCommandLine(ffp);
-        return ffp.id32 ? NumVersion(4, 0) : NumVersion(3, 90);
+        return ffp.id32cb64 ? NumVersion(4, 0) : NumVersion(3, 90);
     }();
     return retval;
 }

--- a/GShr/Versions.h
+++ b/GShr/Versions.h
@@ -96,7 +96,6 @@ inline int GetSaveFileVersion()
             {
                 if (bFlag && strcmp(pszParam, "id32cb64") == 0)
                 {
-                    ASSERT(!"not ready yet");
                     id32cb64 = true;
                 }
             }
@@ -157,6 +156,16 @@ private:
 
 // KLUDGE:  get access to CGamDoc::GetLoadingVersion
 extern int GetLoadingVersion();
+namespace CB
+{
+    inline int GetVersion(const CArchive& ar)
+    {
+        return ar.IsStoring() ?
+                    NumVersion(fileGbxVerMajor, fileGbxVerMinor)
+                :
+                    GetLoadingVersion();
+    }
+}
 
 /* cope with varying file versions
 by getting sizeof(XxxxID<>) for file */
@@ -173,19 +182,15 @@ namespace CB { namespace Impl
         ASSERT(NumVersion(fileGsnVerMajor, fileGsnVerMinor) == NumVersion(fileGbxVerMajor, fileGbxVerMinor));
         ASSERT(NumVersion(fileGamVerMajor, fileGamVerMinor) == NumVersion(fileGbxVerMajor, fileGbxVerMinor));
         ASSERT(NumVersion(fileGmvVerMajor, fileGmvVerMinor) == NumVersion(fileGbxVerMajor, fileGbxVerMinor));
-        int ver = ar.IsStoring() ?
-                        NumVersion(fileGbxVerMajor, fileGbxVerMinor)
-                    :
-                        GetLoadingVersion();
-        if (ver <= NumVersion(3, 90))
+        if (GetVersion(ar) <= NumVersion(3, 90))
         {
-            // ASSERT(ver < NumVersion(3, 90) --> ar.IsLoading());
-            ASSERT(ver == NumVersion(3, 90) || ar.IsLoading());
+            // ASSERT(GetVersion(ar) < NumVersion(3, 90) --> ar.IsLoading());
+            ASSERT(GetVersion(ar) == NumVersion(3, 90) || ar.IsLoading());
             return sizeof(XxxxID16<T::PREFIX>::UNDERLYING_TYPE);
         }
         else
         {
-            ASSERT(ver == NumVersion(4, 0));
+            ASSERT(GetVersion(ar) == NumVersion(4, 0));
             if (sizeof(XxxxID<T::PREFIX>::UNDERLYING_TYPE) != sizeof(XxxxID32<T::PREFIX>::UNDERLYING_TYPE))
             {
                 ASSERT(!"not ready for 32bit ids");
@@ -305,9 +310,8 @@ namespace CB
         {
             AfxThrowArchiveException(CArchiveException::readOnly);
         }
-        int ver = NumVersion(fileGbxVerMajor, fileGbxVerMinor);
 
-        if (ver <= NumVersion(3, 90))
+        if (CB::GetVersion(ar) <= NumVersion(3, 90))
         {
             /* this matches the
             MFC CArchive::WriteCount()/ReadCount() format.  Note
@@ -348,8 +352,7 @@ namespace CB
             AfxThrowArchiveException(CArchiveException::readOnly);
         }
 
-        int ver = GetLoadingVersion();
-        if (ver <= NumVersion(3, 90))
+        if (CB::GetVersion(ar) <= NumVersion(3, 90))
         {
             uint16_t u16;
             ar >> u16;

--- a/GShr/WinExt.h
+++ b/GShr/WinExt.h
@@ -74,7 +74,7 @@ extern "C" {            /* Assume C declarations for C++ */
 #define     GlobalReAllocPtr(lp, cbNew, flags)       \
                 (GlobalUnlockPtr(lp), GlobalLock(GlobalReAlloc(GlobalPtrHandle(lp) , (cbNew), (flags))))
 #define     GlobalFreePtr(lp)                \
-                (GlobalUnlockPtr(lp), (BOOL)GlobalFree(GlobalPtrHandle(lp)))
+                (GlobalUnlockPtr(lp), (bool)GlobalFree(GlobalPtrHandle(lp)))
 
 #ifdef __cplusplus
 }                       /* End of extern "C" { */

--- a/GShr/WinState.cpp
+++ b/GShr/WinState.cpp
@@ -164,7 +164,7 @@ BOOL CWinStateManager::RestoreWindowState(CWnd* pWnd, CWinStateElement& pWse)
 
     TRY
     {
-        CMemFile file(pWse.m_pWinStateBfr, pWse.m_pWinStateBfr.GetSize());
+        CMemFile file(pWse.m_pWinStateBfr, value_preserving_cast<unsigned>(pWse.m_pWinStateBfr.GetSize()));
         CArchive ar(&file, CArchive::load);
         bOK = (BOOL)pWnd->SendMessage(WM_WINSTATE, (WPARAM)&ar, 1);
         ar.Close();
@@ -319,7 +319,7 @@ void CWinStateManager::CWinStateElement::Serialize(CArchive& ar)
         ar << m_wndState;
         ar << value_preserving_cast<DWORD>(m_pWinStateBfr.GetSize());
         if (m_pWinStateBfr.GetSize() > size_t(0))
-            ar.Write(m_pWinStateBfr, m_pWinStateBfr.GetSize());
+            ar.Write(m_pWinStateBfr, value_preserving_cast<unsigned>(m_pWinStateBfr.GetSize()));
     }
     else
     {
@@ -339,7 +339,7 @@ void CWinStateManager::CWinStateElement::Serialize(CArchive& ar)
             {
                 AfxThrowMemoryException();
             }
-            ar.Read(m_pWinStateBfr, m_pWinStateBfr.GetSize());
+            ar.Read(m_pWinStateBfr, value_preserving_cast<unsigned>(m_pWinStateBfr.GetSize()));
         }
     }
 }

--- a/zLib/zLib.vcxproj
+++ b/zLib/zLib.vcxproj
@@ -105,6 +105,7 @@
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
+      <DisableSpecificWarnings>4131</DisableSpecificWarnings>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -145,6 +146,7 @@
       <PrecompiledHeader />
       <WarningLevel>Level4</WarningLevel>
       <SuppressStartupBanner>true</SuppressStartupBanner>
+      <DisableSpecificWarnings>4131</DisableSpecificWarnings>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>

--- a/zLib/zLib.vcxproj
+++ b/zLib/zLib.vcxproj
@@ -5,9 +5,17 @@
       <Configuration>Debug</Configuration>
       <Platform>Win32</Platform>
     </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
     <ProjectConfiguration Include="Release|Win32">
       <Configuration>Release</Configuration>
       <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
     </ProjectConfiguration>
   </ItemGroup>
   <ItemGroup>
@@ -46,7 +54,17 @@
     <CharacterSet>MultiByte</CharacterSet>
     <PlatformToolset>v142</PlatformToolset>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <CharacterSet>MultiByte</CharacterSet>
+    <PlatformToolset>v142</PlatformToolset>
+  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <PlatformToolset>v142</PlatformToolset>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
@@ -58,7 +76,15 @@
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
     <Import Project="$(VCTargetsPath)Microsoft.CPP.UpgradeFromVC71.props" />
   </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="$(VCTargetsPath)Microsoft.CPP.UpgradeFromVC71.props" />
+  </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="$(VCTargetsPath)Microsoft.CPP.UpgradeFromVC71.props" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
     <Import Project="$(VCTargetsPath)Microsoft.CPP.UpgradeFromVC71.props" />
   </ImportGroup>
@@ -67,6 +93,7 @@
     <_ProjectFileVersion>11.0.50727.1</_ProjectFileVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" />
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
@@ -87,6 +114,27 @@
       <SuppressStartupBanner>true</SuppressStartupBanner>
     </Lib>
   </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;_AFX_SECURE_NO_WARNINGS;_ATL_SECURE_NO_WARNINGS;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level4</WarningLevel>
+      <SuppressStartupBanner>true</SuppressStartupBanner>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
+      <DisableSpecificWarnings>4131</DisableSpecificWarnings>
+    </ClCompile>
+    <ResourceCompile>
+      <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <Culture>0x0409</Culture>
+    </ResourceCompile>
+    <Lib>
+      <SuppressStartupBanner>true</SuppressStartupBanner>
+    </Lib>
+  </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
       <InlineFunctionExpansion>OnlyExplicitInline</InlineFunctionExpansion>
@@ -97,6 +145,27 @@
       <PrecompiledHeader />
       <WarningLevel>Level4</WarningLevel>
       <SuppressStartupBanner>true</SuppressStartupBanner>
+    </ClCompile>
+    <ResourceCompile>
+      <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <Culture>0x0409</Culture>
+    </ResourceCompile>
+    <Lib>
+      <SuppressStartupBanner>true</SuppressStartupBanner>
+    </Lib>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <InlineFunctionExpansion>OnlyExplicitInline</InlineFunctionExpansion>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;_AFX_SECURE_NO_WARNINGS;_ATL_SECURE_NO_WARNINGS;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <StringPooling>true</StringPooling>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level4</WarningLevel>
+      <SuppressStartupBanner>true</SuppressStartupBanner>
+      <DisableSpecificWarnings>4131</DisableSpecificWarnings>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>

--- a/zLib/zLib.vcxproj
+++ b/zLib/zLib.vcxproj
@@ -74,7 +74,7 @@
       <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;_AFX_SECURE_NO_WARNINGS;_ATL_SECURE_NO_WARNINGS;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <PrecompiledHeader />
-      <WarningLevel>Level3</WarningLevel>
+      <WarningLevel>Level4</WarningLevel>
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
@@ -95,7 +95,7 @@
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <PrecompiledHeader />
-      <WarningLevel>Level3</WarningLevel>
+      <WarningLevel>Level4</WarningLevel>
       <SuppressStartupBanner>true</SuppressStartupBanner>
     </ClCompile>
     <ResourceCompile>

--- a/zLib/zLib.vcxproj
+++ b/zLib/zLib.vcxproj
@@ -39,19 +39,16 @@
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <ProjectGuid>{5BF1B9BA-043F-469F-BE19-787FF317EDDC}</ProjectGuid>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
-    <PlatformToolset>v142</PlatformToolset>
-    <UseOfMfc>false</UseOfMfc>
     <CharacterSet>MultiByte</CharacterSet>
+    <PlatformToolset>v142</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <PlatformToolset>v142</PlatformToolset>
-    <UseOfMfc>false</UseOfMfc>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
@@ -69,35 +66,24 @@
   <PropertyGroup>
     <_ProjectFileVersion>11.0.50727.1</_ProjectFileVersion>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-    <OutDir>.\Debug\</OutDir>
-    <IntDir>.\Debug\</IntDir>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
-    <OutDir>.\Release\</OutDir>
-    <IntDir>.\Release\</IntDir>
-  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" />
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;_AFX_SECURE_NO_WARNINGS;_ATL_SECURE_NO_WARNINGS;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <PrecompiledHeader />
-      <PrecompiledHeaderOutputFile>.\Debug/zLib.pch</PrecompiledHeaderOutputFile>
-      <AssemblerListingLocation>.\Debug/</AssemblerListingLocation>
-      <ObjectFileName>.\Debug/</ObjectFileName>
-      <ProgramDataBaseFileName>.\Debug/</ProgramDataBaseFileName>
       <WarningLevel>Level3</WarningLevel>
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
+      <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <Culture>0x0409</Culture>
     </ResourceCompile>
     <Lib>
-      <OutputFile>.\Debug\zLib.lib</OutputFile>
       <SuppressStartupBanner>true</SuppressStartupBanner>
     </Lib>
   </ItemDefinitionGroup>
@@ -109,10 +95,6 @@
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <PrecompiledHeader />
-      <PrecompiledHeaderOutputFile>.\Release/zLib.pch</PrecompiledHeaderOutputFile>
-      <AssemblerListingLocation>.\Release/</AssemblerListingLocation>
-      <ObjectFileName>.\Release/</ObjectFileName>
-      <ProgramDataBaseFileName>.\Release/</ProgramDataBaseFileName>
       <WarningLevel>Level3</WarningLevel>
       <SuppressStartupBanner>true</SuppressStartupBanner>
     </ClCompile>
@@ -121,7 +103,6 @@
       <Culture>0x0409</Culture>
     </ResourceCompile>
     <Lib>
-      <OutputFile>.\Release\zLib.lib</OutputFile>
       <SuppressStartupBanner>true</SuppressStartupBanner>
     </Lib>
   </ItemDefinitionGroup>


### PR DESCRIPTION
Dale,

This pull request makes CB able to build and run as either a 32-bit or 64-bit program.   This includes file format changes that further extend the previous v4.00 (`/id32`) format to support 64-bit `size_t` values.

This is a draft pull request because I would like your assessment of the following issues:

Since there hasn't been an actual release with 32bit ids in the file format, I have left the "new" file format as still being v4.00 even though it has changed again to support 64bit `size_t`.  This is my understanding of the conclusion of previous discussions, but I want to be sure this is still the desired behavior.

The default behavior of CB, in both 32- and 64-bit, is still to use the v3.90 file format.  I changed the command line switch to enable v4.00 to `/id32cb64` to make clear that the new v4.00 files have both changes.

I have used a minor compression technique on the 32bit id values (19a041a2acb27eff9d39a620023483dee05d6cf0) as well as Invalid_v<size_t> (f5bf4668dc9755c60ed76c70536e365a79be952b).  This (typically) results in files that are actually smaller than v3,90, but does make the file format less intuitive.  The reduction in size is quite small; it might not be worth the extra complexity.

GShr/CyberBoard.h disables warnings 4701 and 4703 at line 80.  They are uninitialized variable warnings.  I fixed some uninitialized vars at 1f65b6eaaafe4d0c95a988f9828d51f23751fa85.  However, I wasn't sure what to do with the rest, which is why I disabled the warnings.  I hope you can un-disable the warnings, and figure out some good initial values for the remaining vars.

While the process now supports 64bit, and some variables are actually 64bit, not everything that might have been widened actually was.  For example, I haven't tried to support individual bitmaps >=2G.  (I don't even know whether Windows supports that.)  Please let me know if there is anything specific that you think should be widened.

Resolve #13 
