### PR TITLE
fix newly created Piece objects having an owner

### DIFF
--- a/GP/PPieces.cpp
+++ b/GP/PPieces.cpp
@@ -552,6 +552,7 @@ void Piece::SetUnused()
 {
     m_nSide = uint8_t(0xFF);
     m_nFacing = uint16_t(0);
+    m_dwOwnerMask = uint32_t(0);
 }
 
 

--- a/GShr/Marks.h
+++ b/GShr/Marks.h
@@ -64,7 +64,7 @@ struct MarkDef
     enum { flagPromptText = 0x8000 };
 
     // -------- //
-    void SetEmpty() { m_tid = nullTid; }
+    void SetEmpty() { m_tid = nullTid; m_flags = 0; }
     BOOL IsEmpty() { return m_tid == nullTid; }
     // ---------- //
     void Serialize(CArchive& ar);

--- a/GShr/Pieces.h
+++ b/GShr/Pieces.h
@@ -69,7 +69,7 @@ struct PieceDef
     };
 
     // -------- //
-    void SetEmpty() { m_tidFront = m_tidBack = nullTid; }
+    void SetEmpty() { m_tidFront = m_tidBack = nullTid; m_flags = 0; }
     BOOL IsEmpty() const { return m_tidFront == nullTid && m_tidBack == nullTid; }
     // ---------- //
     void Serialize(CArchive& ar);

--- a/GShr/Tile.h
+++ b/GShr/Tile.h
@@ -93,7 +93,7 @@ struct TileDef
     COLORREF    m_tileSmall;        // Color for reduced scale maps
     // ------ //
     BOOL IsEmpty() const { return m_tileFull.IsEmpty(); }
-    void SetEmpty() { m_tileFull.SetEmpty(); m_tileHalf.SetEmpty(); }
+    void SetEmpty() { m_tileFull.SetEmpty(); m_tileHalf.SetEmpty(); m_tileSmall = 0; }
 
     void Serialize(CArchive& archive);
 };


### PR DESCRIPTION
CB3.1 used GlobalAlloc(GHND) to allocate CPieceTable memory,
which guarantees that allocated memory is zero-initialized.
Therefore, newly created Piece objects had no owner even though
Piece::SetUnused() didn't initialize m_dwOwnerMask.  Now that
malloc() is allocating memory, this is no longer true.
Therefore, make all of the XxxxIDTable<> initialize functions
explicitly initialize all member variables.