### PR TITLE
more ownership / CPieceObj::m_rctExtent interaction work

### DIFF
--- a/GP/GamState.cpp
+++ b/GP/GamState.cpp
@@ -57,7 +57,13 @@ BOOL CGameState::CompareState(const CGamDoc& doc) const
     if (!doc.GetPieceTable()->Compare(*m_pPTbl))
         return FALSE;
     // Compare the play boards
-    if (!doc.GetPBoardManager()->Compare(*m_pPBMgr))
+    /* compare must be relative to the doc's piece table, not
+        game state's, because ownership might be different,
+        which can cause CPieceObj::m_rctExtent to differ */
+    // const_cast safe because we're just using temp for compare
+    OwnerPtr<CPBoardManager> temp = m_pPBMgr->Clone(const_cast<CGamDoc&>(doc));
+    temp->OnPieceTableChanged();
+    if (!doc.GetPBoardManager()->Compare(*temp))
         return FALSE;
     // Compare the trays
     if (!doc.GetTrayManager()->Compare(m_pYMgr))

--- a/GP/PBoard.cpp
+++ b/GP/PBoard.cpp
@@ -506,6 +506,13 @@ void CPlayBoard::Serialize(CArchive& ar)
     }
 }
 
+// see CPieceObj::OnPieceTableChanged()
+void CPlayBoard::OnPieceTableChanged()
+{
+    m_pPceList->OnPieceTableChanged();
+    m_pIndList->OnPieceTableChanged();
+}
+
 std::string CPlayBoard::GetCellNumberStr(CPoint pnt, TileScale eScale) const
 {
     if (!m_pGeoBoard)
@@ -829,6 +836,15 @@ void CPBoardManager::Serialize(CArchive& ar)
             push_back(new CPlayBoard(*m_pDoc));
             GetPBoard(i).Serialize(ar);
         }
+    }
+}
+
+// see CPieceObj::OnPieceTableChanged()
+void CPBoardManager::OnPieceTableChanged()
+{
+    for (size_t i = size_t(0) ; i < GetNumPBoards() ; i++)
+    {
+        GetPBoard(i).OnPieceTableChanged();
     }
 }
 

--- a/GP/PBoard.h
+++ b/GP/PBoard.h
@@ -135,6 +135,8 @@ public:
     bool Compare(const CPlayBoard& pBrd) const;
     // ------- //
     void Serialize(CArchive& ar);
+    // see CPieceObj::OnPieceTableChanged()
+    void OnPieceTableChanged();
 
     std::string GetCellNumberStr(CPoint pnt, TileScale eScale) const;
 
@@ -281,6 +283,8 @@ public:
     bool Compare(const CPBoardManager& pMgr) const;
     // ------- //
     void Serialize(CArchive& ar);
+    // see CPieceObj::OnPieceTableChanged()
+    void OnPieceTableChanged();
 
 // Implementation - methods
 protected:

--- a/GP/PPieces.cpp
+++ b/GP/PPieces.cpp
@@ -523,6 +523,11 @@ void CPieceTable::Restore(const CPieceTable& pTbl)
 {
     Clear();
     m_pPieceTbl = pTbl.m_pPieceTbl;
+    if (m_pDoc->GetPieceTable() == this)
+    {
+        CPBoardManager& brdMgr = CheckedDeref(m_pDoc->GetPBoardManager());
+        brdMgr.OnPieceTableChanged();
+    }
 }
 
 BOOL CPieceTable::Compare(const CPieceTable& pTbl) const
@@ -587,6 +592,11 @@ void CPieceTable::Serialize(CArchive& ar)
                 pYMgr->RemovePieceIDFromTraySets(static_cast<PieceID>(i));
                 OwnerPtr<CDrawObj> pObj = pPBMgr->RemoveObjectID(static_cast<ObjectID>(static_cast<PieceID>(i)));
             }
+        }
+        if (m_pDoc->GetPieceTable() == this)
+        {
+            CPBoardManager& brdMgr = CheckedDeref(m_pDoc->GetPBoardManager());
+            brdMgr.OnPieceTableChanged();
         }
     }
 }

--- a/GShr/DrawObj.h
+++ b/GShr/DrawObj.h
@@ -146,6 +146,8 @@ public:
 #endif
     // ------- //
     virtual void Serialize(CArchive& ar) /* override */;
+    // see CPieceObj::OnPieceTableChanged()
+    virtual void OnPieceTableChanged() /* override */ {}
 
 // Implementation - methods
 protected:
@@ -865,6 +867,8 @@ public:
     virtual OwnerPtr Clone(CGamDoc* pDoc) const override;
     virtual BOOL Compare(const CDrawObj& pObj) const override;
     virtual void Serialize(CArchive& ar) override;
+    // see impl
+    virtual void OnPieceTableChanged() override;
 };
 
 ///////////////////////////////////////////////////////////////////////
@@ -1023,6 +1027,8 @@ public:
 #endif
     // -------- //
     void Serialize(CArchive& ar);
+    // see CPieceObj::OnPieceTableChanged()
+    void OnPieceTableChanged();
 };
 
 #endif


### PR DESCRIPTION
The problem of CPieceObj::m_rctExtent being different for different players also shows up in playback, not just .gmv validation.  So whenever the CGamDoc's main CPieceTable Serialize() or Restore() run, force a recalculation of the CGamDoc's CDrawLists.