### PR TITLE
update .sln file to VS2022

### DIFF
--- a/CyberBoard.sln
+++ b/CyberBoard.sln
@@ -1,6 +1,6 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.30611.23
+# Visual Studio Version 17
+VisualStudioVersion = 17.4.33213.308
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "CBDesign", "GM\CBDsgn32.vcxproj", "{107CA415-78FA-4517-B192-D207313CD48E}"
 EndProject


### PR DESCRIPTION
I have no idea why I now finally see the `.sln` file updated for VS2022, when I didn't see it updated before, but here it is...