### PR TITLE
improve support for parallel file format changes

### DIFF
--- a/GM/Gm.cpp
+++ b/GM/Gm.cpp
@@ -1,6 +1,6 @@
 // Gm.cpp : Defines the class behaviors for the application.
 //
-// Copyright (c) 1994-2020 By Dale L. Larson, All Rights Reserved.
+// Copyright (c) 1994-2023 By Dale L. Larson & William Su, All Rights Reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining
 // a copy of this software and associated documentation files (the

--- a/GM/GmDoc.cpp
+++ b/GM/GmDoc.cpp
@@ -1,6 +1,6 @@
 // GmDoc.cpp : implementation of the CGamDoc class
 //
-// Copyright (c) 1994-2020 By Dale L. Larson, All Rights Reserved.
+// Copyright (c) 1994-2023 By Dale L. Larson & William Su, All Rights Reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining
 // a copy of this software and associated documentation files (the

--- a/GM/GmDoc.cpp
+++ b/GM/GmDoc.cpp
@@ -566,7 +566,7 @@ void CGamDoc::Serialize(CArchive& ar)
 
         // leave space for pointer to feature list at end of file
         uint64_t offsetOffsetFeatureTable = UINT64_MAX;
-        if (NumVersion(fileGbxVerMajor, fileGbxVerMinor) >= NumVersion(105, 0))
+        if (NumVersion(fileGbxVerMajor, fileGbxVerMinor) >= NumVersion(5, 0))
         {
             ar.Flush();     // ensure GetPosition() is current
             offsetOffsetFeatureTable = ar.GetFile()->GetPosition();
@@ -646,7 +646,7 @@ void CGamDoc::Serialize(CArchive& ar)
         CColorPalette::CustomColorsSerialize(ar, m_pCustomColors);
 
         // serialize done, so write features now
-        if (NumVersion(fileGbxVerMajor, fileGbxVerMinor) >= NumVersion(105, 0))
+        if (NumVersion(fileGbxVerMajor, fileGbxVerMinor) >= NumVersion(5, 0))
         {
             ar.Flush();     // ensure GetPosition() is current
             uint64_t offsetFeatureTable = ar.GetFile()->GetPosition();
@@ -676,7 +676,7 @@ void CGamDoc::Serialize(CArchive& ar)
             ar >> verMinor;
 
             Features fileFeatures;
-            if (NumVersion(verMajor, verMinor) >= NumVersion(105, 0))
+            if (NumVersion(verMajor, verMinor) >= NumVersion(5, 0))
             {
                 try
                 {

--- a/GM/GmDoc.cpp
+++ b/GM/GmDoc.cpp
@@ -595,8 +595,7 @@ void CGamDoc::Serialize(CArchive& ar)
                 c_fileFeatures.Add(ftrSizet64Bit);
             }
         }
-        else if (NumVersion(fileGbxVerMajor, fileGbxVerMinor) == NumVersion(4, 0) ||
-                NumVersion(fileGbxVerMajor, fileGbxVerMinor) == NumVersion(104, 5)) {
+        else if (NumVersion(fileGbxVerMajor, fileGbxVerMinor) == NumVersion(4, 0)) {
             c_fileFeatures = GetCBFile4Features();
         }
         else
@@ -703,14 +702,13 @@ void CGamDoc::Serialize(CArchive& ar)
                     verMajor = value_preserving_cast<BYTE>(fileGbxVerMajor + 1);
                 }
             }
-            else if (NumVersion(verMajor, verMinor) == NumVersion(4, 0) ||
-                    NumVersion(verMajor, verMinor) == NumVersion(104, 5))
+            else if (NumVersion(verMajor, verMinor) == NumVersion(4, 0))
             {
                 fileFeatures = GetCBFile4Features();
             }
             else
             {
-                ASSERT(NumVersion(fileGmvVerMajor, fileGmvVerMinor) <= NumVersion(3, 90));
+                ASSERT(NumVersion(verMajor, verMinor) <= NumVersion(3, 90));
                 fileFeatures = Features();
             }
 

--- a/GM/GmDoc.h
+++ b/GM/GmDoc.h
@@ -196,6 +196,8 @@ public:
     static CFontTbl* GetFontManager() { return &m_fontTbl; }
     // Version of file being loaded
     static int c_fileVersion;
+    // load and save can't be simultaneous, so use for both
+    static Features c_fileFeatures;
 
 // Attributes
 public:
@@ -204,6 +206,9 @@ public:
     static void SetLoadingVersion(int ver) { c_fileVersion = ver; }
     using SetLoadingVersionGuard = ::SetLoadingVersionGuard<CGamDoc>;
     static int GetLoadingVersion() { return c_fileVersion; }
+    static void SetFileFeatures(Features&& feat) noexcept { c_fileFeatures = std::move(feat); }
+    static void SetFileFeatures(const Features& feat) { SetFileFeatures(Features(feat)); }
+    static const Features& GetFileFeatures() { return c_fileFeatures; }
     // -------- //
     DWORD GetGameBoxID() { return m_dwGameID; }
     // -------- //

--- a/GM/VwPrjgb1.cpp
+++ b/GM/VwPrjgb1.cpp
@@ -150,6 +150,7 @@ void CGbxProjView::DoBoardClone()
         CMemFile file;
         CArchive arSave(&file, CArchive::store);
         arSave.m_pDocument = pDoc;
+        SetFileFeaturesGuard setFileFeaturesGuard(arSave, GetCBFeatures());
         pOrigBoard.Serialize(arSave);      // Make a copy of the board
         arSave.Close();
 

--- a/GM/VwPrjgbx.cpp
+++ b/GM/VwPrjgbx.cpp
@@ -1047,6 +1047,7 @@ void CGbxProjView::OnProjectSaveTileFile()
         }
         CArchive ar(&file, CArchive::store);
         ar.Write(FILEGTLSIGNATURE, 4);
+        // TODO:  if new format ever needed, use Features
         ar << (WORD)NumVersion(fileGtlVerMajor, fileGtlVerMinor);
         pTMgr->CopyTileImagesToArchive(ar, tidtbl);
         ar.Close();

--- a/GP/GamDoc.cpp
+++ b/GP/GamDoc.cpp
@@ -1,6 +1,6 @@
 // GamDoc.cpp
 //
-// Copyright (c) 1994-2020 By Dale L. Larson, All Rights Reserved.
+// Copyright (c) 1994-2023 By Dale L. Larson & William Su, All Rights Reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining
 // a copy of this software and associated documentation files (the

--- a/GP/GamDoc.cpp
+++ b/GP/GamDoc.cpp
@@ -80,9 +80,20 @@ int GetLoadingVersion()
     return CGamDoc::GetLoadingVersion();
 }
 
+const Features& GetFileFeatures()
+{
+    return CGamDoc::GetFileFeatures();
+}
+
+void SetFileFeatures(Features&& fs)
+{
+    CGamDoc::SetFileFeatures(std::move(fs));
+}
+
 /////////////////////////////////////////////////////////////////////////////
 
 int CGamDoc::c_fileVersion = 0;
+Features CGamDoc::c_fileFeatures;
 
 /////////////////////////////////////////////////////////////////////////////
 // CGamDoc
@@ -1193,6 +1204,7 @@ void CGamDoc::OnEditRestoreBookMark()
     if (m_pBookMark != NULL)
     {
         SetLoadingVersion(NumVersion(fileGamVerMajor, fileGamVerMinor));
+        SetFileFeatures(GetCBFeatures());
         if (!m_pBookMark->RestoreState(*this))
         {
             // Add memory error message

--- a/GP/GamDoc.h
+++ b/GP/GamDoc.h
@@ -238,6 +238,8 @@ protected: // create from serialization only
 // Class vars and methods (used during deserialize)...
     // Version of file being loaded
     static int c_fileVersion;
+    // load and save can't be simultaneous, so use for both
+    static Features c_fileFeatures;
 
 public:
     static CFontTbl* GetFontManager()
@@ -245,6 +247,9 @@ public:
     static void SetLoadingVersion(int ver) { c_fileVersion = ver; }
     using SetLoadingVersionGuard = ::SetLoadingVersionGuard<CGamDoc>;
     static int GetLoadingVersion() { return c_fileVersion; }
+    static void SetFileFeatures(Features&& feat) noexcept { c_fileFeatures = std::move(feat); }
+    static void SetFileFeatures(const Features& feat) { SetFileFeatures(Features(feat)); }
+    static const Features& GetFileFeatures() { return c_fileFeatures; }
     // The version of the loaded file is used to determine
     // if the game histories need to be upgraded and written
     // to the file. Normally the histories are simply copied
@@ -524,7 +529,7 @@ public:
     void SerializeScenario(CArchive& ar);
     void SerializeGame(CArchive& ar);
     void SerializeMoveSet(CArchive& ar, CHistRecord*& pHist);
-    void SerializeScenarioOrGame(CArchive& ar);
+    void SerializeScenarioOrGame(CArchive& ar, uint64_t& offsetOffsetFeatureTable);
     void SerializeCurrentGameData(CFile* pFile, long lOffset, BOOL bSaving);
     long SerializeMovesToFile(CFile* pFile, long lOffset, CMoveList* pLst);
     CMoveList* DeserializeMovesFromFile(CFile* pFile, long lOffset);

--- a/GP/GamDoc3.cpp
+++ b/GP/GamDoc3.cpp
@@ -154,8 +154,7 @@ void CGamDoc::SerializeMoveSet(CArchive& ar, CHistRecord*& pHist)
                 c_fileFeatures.Add(ftrSizet64Bit);
             }
         }
-        else if (NumVersion(fileGmvVerMajor, fileGmvVerMinor) == NumVersion(4, 0) ||
-            NumVersion(fileGmvVerMajor, fileGmvVerMinor) == NumVersion(104, 5)) {
+        else if (NumVersion(fileGmvVerMajor, fileGmvVerMinor) == NumVersion(4, 0)) {
             c_fileFeatures = GetCBFile4Features();
         }
         else
@@ -222,8 +221,7 @@ void CGamDoc::SerializeMoveSet(CArchive& ar, CHistRecord*& pHist)
                 verMajor = value_preserving_cast<BYTE>(fileGbxVerMajor + 1);
             }
         }
-        else if (NumVersion(verMajor, verMinor) == NumVersion(4, 0) ||
-                NumVersion(verMajor, verMinor) == NumVersion(104, 5))
+        else if (NumVersion(verMajor, verMinor) == NumVersion(4, 0))
         {
             fileFeatures = GetCBFile4Features();
         }
@@ -735,8 +733,7 @@ void CGamDoc::SerializeScenarioOrGame(CArchive& ar, uint64_t& offsetOffsetFeatur
                 verMajor = value_preserving_cast<BYTE>(fileGbxVerMajor + 1);
             }
         }
-        else if (NumVersion(verMajor, verMinor) == NumVersion(4, 0) ||
-                NumVersion(verMajor, verMinor) == NumVersion(104, 5))
+        else if (NumVersion(verMajor, verMinor) == NumVersion(4, 0))
         {
             fileFeatures = GetCBFile4Features();
         }

--- a/GP/GamDoc3.cpp
+++ b/GP/GamDoc3.cpp
@@ -117,7 +117,7 @@ void CGamDoc::SerializeMoveSet(CArchive& ar, CHistRecord*& pHist)
 
         // leave space for pointer to feature list at end of file
         uint64_t offsetOffsetFeatureTable = UINT64_MAX;
-        if (NumVersion(fileGmvVerMajor, fileGmvVerMinor) >= NumVersion(105, 0))
+        if (NumVersion(fileGmvVerMajor, fileGmvVerMinor) >= NumVersion(5, 0))
         {
             ar.Flush();     // ensure GetPosition() is current
             offsetOffsetFeatureTable = ar.GetFile()->GetPosition();
@@ -170,7 +170,7 @@ void CGamDoc::SerializeMoveSet(CArchive& ar, CHistRecord*& pHist)
         pHist->Serialize(ar);
 
         // serialize done, so write features now
-        if (NumVersion(fileGmvVerMajor, fileGmvVerMinor) >= NumVersion(105, 0))
+        if (NumVersion(fileGmvVerMajor, fileGmvVerMinor) >= NumVersion(5, 0))
         {
             ar.Flush();     // ensure GetPosition() is current
             uint64_t offsetFeatureTable = ar.GetFile()->GetPosition();
@@ -197,7 +197,7 @@ void CGamDoc::SerializeMoveSet(CArchive& ar, CHistRecord*& pHist)
         ar >> verMinor;
 
         Features fileFeatures;
-        if (NumVersion(verMajor, verMinor) >= NumVersion(105, 0))
+        if (NumVersion(verMajor, verMinor) >= NumVersion(5, 0))
         {
             try
             {
@@ -346,7 +346,7 @@ void CGamDoc::SerializeGame(CArchive& ar)
             m_pHistTbl->Serialize(ar);
 
         // serialize done, so write features now
-        if (NumVersion(fileGsnVerMajor, fileGsnVerMinor) >= NumVersion(105, 0))
+        if (NumVersion(fileGsnVerMajor, fileGsnVerMinor) >= NumVersion(5, 0))
         {
             ar.Flush();     // ensure GetPosition() is current
             uint64_t offsetFeatureTable = ar.GetFile()->GetPosition();
@@ -556,7 +556,7 @@ void CGamDoc::SerializeScenario(CArchive& ar)
     if (ar.IsStoring())
     {
         // serialize done, so write features now
-        if (NumVersion(fileGsnVerMajor, fileGsnVerMinor) >= NumVersion(105, 0))
+        if (NumVersion(fileGsnVerMajor, fileGsnVerMinor) >= NumVersion(5, 0))
         {
             ar.Flush();     // ensure GetPosition() is current
             uint64_t offsetFeatureTable = ar.GetFile()->GetPosition();
@@ -593,7 +593,7 @@ void CGamDoc::SerializeScenarioOrGame(CArchive& ar, uint64_t& offsetOffsetFeatur
         ar << (BYTE)fileGsnVerMajor;
         ar << (BYTE)fileGsnVerMinor;
 
-        if (NumVersion(fileGsnVerMajor, fileGsnVerMinor) >= NumVersion(105, 0))
+        if (NumVersion(fileGsnVerMajor, fileGsnVerMinor) >= NumVersion(5, 0))
         {
             // leave space for pointer to feature list at end of file
             ar.Flush();     // ensure GetPosition() is current
@@ -709,7 +709,7 @@ void CGamDoc::SerializeScenarioOrGame(CArchive& ar, uint64_t& offsetOffsetFeatur
         ar >> verMinor;
 
         Features fileFeatures;
-        if (NumVersion(verMajor, verMinor) >= NumVersion(105, 0))
+        if (NumVersion(verMajor, verMinor) >= NumVersion(5, 0))
         {
             try
             {

--- a/GP/GamDoc3.cpp
+++ b/GP/GamDoc3.cpp
@@ -1,6 +1,6 @@
 // GamDoc3.cpp -- serialization support for the document.
 //
-// Copyright (c) 1994-2020 By Dale L. Larson, All Rights Reserved.
+// Copyright (c) 1994-2023 By Dale L. Larson & William Su, All Rights Reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining
 // a copy of this software and associated documentation files (the

--- a/GP/GameBox.cpp
+++ b/GP/GameBox.cpp
@@ -1,6 +1,6 @@
 // GameBox.cpp
 //
-// Copyright (c) 1994-2020 By Dale L. Larson, All Rights Reserved.
+// Copyright (c) 1994-2023 By Dale L. Larson & William Su, All Rights Reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining
 // a copy of this software and associated documentation files (the

--- a/GP/GameBox.cpp
+++ b/GP/GameBox.cpp
@@ -115,7 +115,7 @@ BOOL CGameBox::Load(CGamDoc* pDoc, LPCSTR pszPathName, CString& strErr,
         ar >> verMinor;
 
         Features fileFeatures;
-        if (NumVersion(verMajor, verMinor) >= NumVersion(105, 0))
+        if (NumVersion(verMajor, verMinor) >= NumVersion(5, 0))
         {
             try
             {

--- a/GP/GameBox.cpp
+++ b/GP/GameBox.cpp
@@ -139,8 +139,7 @@ BOOL CGameBox::Load(CGamDoc* pDoc, LPCSTR pszPathName, CString& strErr,
                 verMajor = value_preserving_cast<BYTE>(fileGbxVerMajor + 1);
             }
         }
-        else if (NumVersion(verMajor, verMinor) == NumVersion(4, 0) ||
-                NumVersion(verMajor, verMinor) == NumVersion(104, 5))
+        else if (NumVersion(verMajor, verMinor) == NumVersion(4, 0))
         {
             fileFeatures = GetCBFile4Features();
         }

--- a/GP/GeoBoard.cpp
+++ b/GP/GeoBoard.cpp
@@ -1,6 +1,6 @@
 // GeoBoard.cpp
 //
-// Copyright (c) 1994-2020 By Dale L. Larson, All Rights Reserved.
+// Copyright (c) 1994-2023 By Dale L. Larson & William Su, All Rights Reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining
 // a copy of this software and associated documentation files (the

--- a/GP/GeoBoard.h
+++ b/GP/GeoBoard.h
@@ -93,6 +93,7 @@ public:
 
     size_t  AddElement(BoardID nBoardSerialNum, Rotation90 rot);
 
+    bool NeedsGeoRotate() const;
     void Serialize(CArchive& ar);
 
     std::string GetCellNumberStr(CPoint pnt, TileScale eScale) const;

--- a/GP/MoveHist.cpp
+++ b/GP/MoveHist.cpp
@@ -48,7 +48,7 @@ void CHistoryTable::Serialize(CArchive& ar)
 {
     if (ar.IsStoring())
     {
-        if (CB::GetVersion(ar) <= NumVersion(3, 90))
+        if (!CB::GetFeatures(ar).Check(ftrSizet64Bit))
         {
             ar << value_preserving_cast<WORD>(size());
         }
@@ -63,7 +63,7 @@ void CHistoryTable::Serialize(CArchive& ar)
     {
         Clear();
         size_t wSize;
-        if (CB::GetVersion(ar) <= NumVersion(3, 90))
+        if (!CB::GetFeatures(ar).Check(ftrSizet64Bit))
         {
             WORD temp;
             ar >> temp;

--- a/GP/MoveMgr.cpp
+++ b/GP/MoveMgr.cpp
@@ -1,6 +1,6 @@
 // MoveMgr.cpp
 //
-// Copyright (c) 1994-2020 By Dale L. Larson, All Rights Reserved.
+// Copyright (c) 1994-2023 By Dale L. Larson & William Su, All Rights Reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining
 // a copy of this software and associated documentation files (the

--- a/GP/MoveMgr.cpp
+++ b/GP/MoveMgr.cpp
@@ -57,7 +57,7 @@ void CMoveRecord::Serialize(CArchive& ar)
     // by the object's constructor.
     if (ar.IsStoring())
     {
-        if (CB::GetVersion(ar) <= NumVersion(3, 90))
+        if (!CB::GetFeatures(ar).Check(ftrSizet64Bit))
         {
             ar << (m_nSeqNum == Invalid_v<size_t> ? uint16_t(0xFFFF) : value_preserving_cast<uint16_t>(m_nSeqNum));
         }
@@ -68,7 +68,7 @@ void CMoveRecord::Serialize(CArchive& ar)
     }
     else
     {
-        if (CB::GetVersion(ar) <= NumVersion(3, 90))
+        if (!CB::GetFeatures(ar).Check(ftrSizet64Bit))
         {
             uint16_t sTmp;
             ar >> sTmp; m_nSeqNum = (sTmp == uint16_t(0xFFFF) ? Invalid_v<size_t> : sTmp);
@@ -326,7 +326,7 @@ void CTrayPieceMove::Serialize(CArchive& ar)
     if (ar.IsStoring())
     {
         ar << m_pid;
-        if (CB::GetVersion(ar) <= NumVersion(3, 90))
+        if (!CB::GetFeatures(ar).Check(ftrSizet64Bit))
         {
             ar << value_preserving_cast<int16_t>(m_nTrayNum);
             ASSERT(m_nPos == Invalid_v<size_t> ||
@@ -342,7 +342,7 @@ void CTrayPieceMove::Serialize(CArchive& ar)
     else
     {
         ar >> m_pid;
-        if (CB::GetVersion(ar) <= NumVersion(3, 90))
+        if (!CB::GetFeatures(ar).Check(ftrSizet64Bit))
         {
             int16_t sTmp;
             ar >> sTmp; m_nTrayNum = value_preserving_cast<size_t>(sTmp);
@@ -449,7 +449,8 @@ void CPieceSetSide::Serialize(CArchive& ar)
     CMoveRecord::Serialize(ar);
     if (ar.IsStoring())
     {
-        if (CB::GetVersion(ar) <= NumVersion(3, 90))
+        // TODO:  handle ftrPiece100Sides w/o ftrSizet64Bit?
+        if (!CB::GetFeatures(ar).Check(ftrSizet64Bit) || !CB::GetFeatures(ar).Check(ftrPiece100Sides))
         {
             if (m_flip != CPieceTable::fNext ||
                 m_side >= size_t(2))
@@ -465,7 +466,7 @@ void CPieceSetSide::Serialize(CArchive& ar)
             ar << value_preserving_cast<uint8_t>(m_flip);
             CB::WriteCount(ar, m_side);
         }
-        if (CB::GetVersion(ar) <= NumVersion(3, 90))
+        if (!CB::GetFeatures(ar).Check(ftrPiece100Sides))
         {
             if (m_forceMoveHidden)
             {
@@ -479,7 +480,7 @@ void CPieceSetSide::Serialize(CArchive& ar)
     }
     else
     {
-        if (CB::GetVersion(ar) <= NumVersion(3, 90))
+        if (!CB::GetFeatures(ar).Check(ftrSizet64Bit) || !CB::GetFeatures(ar).Check(ftrPiece100Sides))
         {
             ar >> m_pid;
             m_flip = CPieceTable::fNext;
@@ -494,7 +495,7 @@ void CPieceSetSide::Serialize(CArchive& ar)
             m_flip = static_cast<CPieceTable::Flip>(temp);
             m_side = CB::ReadCount(ar);
         }
-        if (CB::GetVersion(ar) <= NumVersion(3, 90))
+        if (!CB::GetFeatures(ar).Check(ftrPiece100Sides))
         {
             m_forceMoveHidden = false;
         }
@@ -1578,7 +1579,7 @@ void CEventMessageRcd::Serialize(CArchive& ar)
         }
         else
         {
-            if (CB::GetVersion(ar) <= NumVersion(3, 90))
+            if (!CB::GetFeatures(ar).Check(ftrSizet64Bit))
             {
                 ar << value_preserving_cast<WORD>(m_nTray);
                 ar << value_preserving_cast<DWORD>(static_cast<PieceID::UNDERLYING_TYPE>(m_pieceID));
@@ -1605,7 +1606,7 @@ void CEventMessageRcd::Serialize(CArchive& ar)
         }
         else
         {
-            if (CB::GetVersion(ar) <= NumVersion(3, 90))
+            if (!CB::GetFeatures(ar).Check(ftrSizet64Bit))
             {
                 ar >> wTmp; m_nTray = value_preserving_cast<size_t>(wTmp);
                 ar >> dwTmp; m_pieceID = static_cast<PieceID>(dwTmp);
@@ -2320,7 +2321,7 @@ void CMoveList::Serialize(CArchive& ar, BOOL bSaveUndo)
     {
         ASSERT(m_pStateSave == NULL); // Should never save with this active!
 
-        if (CB::GetVersion(ar) <= NumVersion(3, 90))
+        if (!CB::GetFeatures(ar).Check(ftrSizet64Bit))
         {
             ar << value_preserving_cast<uint16_t>(m_nSeqNum);
         }
@@ -2329,7 +2330,7 @@ void CMoveList::Serialize(CArchive& ar, BOOL bSaveUndo)
             CB::WriteCount(ar, m_nSeqNum);
         }
         ar << (WORD)m_bCompoundMove;
-        if (CB::GetVersion(ar) <= NumVersion(3, 90))
+        if (!CB::GetFeatures(ar).Check(ftrSizet64Bit))
         {
             ar << (m_nCompoundBaseIndex != Invalid_v<size_t> ? value_preserving_cast<uint32_t>(m_nCompoundBaseIndex) : uint32_t(INT32_C(-1)));
         }
@@ -2341,7 +2342,7 @@ void CMoveList::Serialize(CArchive& ar, BOOL bSaveUndo)
         if (m_pCompoundBaseBookMark)
             m_pCompoundBaseBookMark->Serialize(ar);
 
-        if (CB::GetVersion(ar) <= NumVersion(3, 90))
+        if (!CB::GetFeatures(ar).Check(ftrSizet64Bit))
         {
             ar << value_preserving_cast<WORD>(size());
         }
@@ -2364,7 +2365,7 @@ void CMoveList::Serialize(CArchive& ar, BOOL bSaveUndo)
         size_t wCount;
         uint16_t sTmp;
 
-        if (CB::GetVersion(ar) <= NumVersion(3, 90))
+        if (!CB::GetFeatures(ar).Check(ftrSizet64Bit))
         {
             ar >> sTmp; m_nSeqNum = sTmp;
         }
@@ -2379,7 +2380,7 @@ void CMoveList::Serialize(CArchive& ar, BOOL bSaveUndo)
             WORD  wTmp;
             uint32_t dwTmp;
             ar >> wTmp; m_bCompoundMove = (BOOL)wTmp;
-            if (CB::GetVersion(ar) <= NumVersion(3, 90))
+            if (!CB::GetFeatures(ar).Check(ftrSizet64Bit))
             {
                 ar >> dwTmp; m_nCompoundBaseIndex = (dwTmp != uint32_t(INT32_C(-1)) ? value_preserving_cast<size_t>(dwTmp) : Invalid_v<size_t>);
             }
@@ -2396,7 +2397,7 @@ void CMoveList::Serialize(CArchive& ar, BOOL bSaveUndo)
             }
         }
 
-        if (CB::GetVersion(ar) <= NumVersion(3, 90))
+        if (!CB::GetFeatures(ar).Check(ftrSizet64Bit))
         {
             WORD temp;
             ar >> temp;

--- a/GP/PBoard.cpp
+++ b/GP/PBoard.cpp
@@ -302,6 +302,11 @@ bool CPlayBoard::Compare(const CPlayBoard& pBrd) const
     return m_pIndList->Compare(*pBrd.m_pIndList);
 }
 
+bool CPlayBoard::NeedsGeoRotate() const
+{
+    return m_pGeoBoard && m_pGeoBoard->NeedsGeoRotate();
+}
+
 void CPlayBoard::Serialize(CArchive& ar)
 {
     if (ar.IsStoring())
@@ -357,7 +362,7 @@ void CPlayBoard::Serialize(CArchive& ar)
         ASSERT(m_pIndList != NULL);
         m_pIndList->Serialize(ar);  // Board's indicator list
 
-        if (CB::GetVersion(ar) < NumVersion(4, 0))
+        if (!CB::GetFeatures(ar).Check(ftrPrivatePlayerBoard))
         {
             if (m_bPrivate)
             {
@@ -495,7 +500,7 @@ void CPlayBoard::Serialize(CArchive& ar)
         m_pIndList = MakeOwner<CDrawList>();
         m_pIndList->Serialize(ar);  // Board's indicator list
 
-        if (CB::GetVersion(ar) < NumVersion(4, 0))
+        if (!CB::GetFeatures(ar).Check(ftrPrivatePlayerBoard))
         {
             m_bPrivate = false;
         }
@@ -788,7 +793,7 @@ void CPBoardManager::Serialize(CArchive& ar)
         ar << m_wReserved3;
         ar << m_wReserved4;
 
-        if (CB::GetVersion(ar) <= NumVersion(3, 90))
+        if (!CB::GetFeatures(ar).Check(ftrSizet64Bit))
         {
             ar << value_preserving_cast<WORD>(GetNumPBoards());
         }
@@ -796,6 +801,37 @@ void CPBoardManager::Serialize(CArchive& ar)
         {
             CB::WriteCount(ar, GetNumPBoards());
         }
+
+        /* if any CPBoard needs Feature "private-player-board"
+            or Feature "geo-rotate-unit", all must use that new
+            feature */
+        for (const OwnerPtr<CPlayBoard>& board : *this)
+        {
+            if (board->IsPrivate())
+            {
+                if (GetCBFeatures().Check(ftrPrivatePlayerBoard))
+                {
+                    CB::AddFeature(ar, ftrPrivatePlayerBoard);
+                }
+                // else will be checked by CPBoard::Serialize
+            }
+            if (board->NeedsGeoRotate())
+            {
+                if (GetCBFeatures().Check(ftrGeoRotateUnit))
+                {
+                    CB::AddFeature(ar, ftrGeoRotateUnit);
+                }
+                // else will be checked by CGeoBoardElement::Serialize
+            }
+
+            const Features& fs = CB::GetFeatures(ar);
+            if (fs.Check(ftrPrivatePlayerBoard) &&
+                fs.Check(ftrGeoRotateUnit))
+            {
+                break;
+            }
+        }
+
         for (size_t i = size_t(0); i < GetNumPBoards(); i++)
             GetPBoard(i).Serialize(ar);
     }
@@ -814,7 +850,7 @@ void CPBoardManager::Serialize(CArchive& ar)
         ar >> m_wReserved3;
         ar >> m_wReserved4;
 
-        if (CB::GetVersion(ar) <= NumVersion(3, 90))
+        if (!CB::GetFeatures(ar).Check(ftrSizet64Bit))
         {
             WORD tmp;
             ar >> tmp;

--- a/GP/PBoard.cpp
+++ b/GP/PBoard.cpp
@@ -1,6 +1,6 @@
 // PBoard.cpp
 //
-// Copyright (c) 1994-2020 By Dale L. Larson, All Rights Reserved.
+// Copyright (c) 1994-2023 By Dale L. Larson & William Su, All Rights Reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining
 // a copy of this software and associated documentation files (the

--- a/GP/PBoard.h
+++ b/GP/PBoard.h
@@ -134,6 +134,7 @@ public:
     void Restore(CGamDoc& pDoc, const CPlayBoard& pBrd);
     bool Compare(const CPlayBoard& pBrd) const;
     // ------- //
+    bool NeedsGeoRotate() const;
     void Serialize(CArchive& ar);
 
     std::string GetCellNumberStr(CPoint pnt, TileScale eScale) const;

--- a/GP/Player.cpp
+++ b/GP/Player.cpp
@@ -64,7 +64,7 @@ void CPlayerManager::Serialize(CArchive& ar)
 {
     if (ar.IsStoring())
     {
-        if (CB::GetVersion(ar) <= NumVersion(3, 90))
+        if (!CB::GetFeatures(ar).Check(ftrSizet64Bit))
         {
             ar << value_preserving_cast<WORD>(GetSize());
         }
@@ -81,7 +81,7 @@ void CPlayerManager::Serialize(CArchive& ar)
         size_t nCount;
         WORD wTmp;
 
-        if (CB::GetVersion(ar) <= NumVersion(3, 90))
+        if (!CB::GetFeatures(ar).Check(ftrSizet64Bit))
         {
             ar >> wTmp;
             nCount = wTmp;

--- a/GP/Trays.cpp
+++ b/GP/Trays.cpp
@@ -155,7 +155,7 @@ void CTraySet::Serialize(CArchive& ar)
     {
         ar << m_strName;
         ar << static_cast<uint16_t>(m_bRandomPull);
-        if (CB::GetVersion(ar) <= NumVersion(3, 90))
+        if (!CB::GetFeatures(ar).Check(ftrPiece100Sides))
         {
             if (m_bRandomSidePull)
             {
@@ -182,7 +182,7 @@ void CTraySet::Serialize(CArchive& ar)
         {
             uint16_t  wTmp;
             ar >> wTmp; m_bRandomPull = static_cast<BOOL>(wTmp);
-            if (CB::GetVersion(ar) <= NumVersion(3, 90))
+            if (!CB::GetFeatures(ar).Check(ftrPiece100Sides))
             {
                 m_bRandomSidePull = false;
             }
@@ -362,7 +362,7 @@ void CTrayManager::SerializeTraySets(CArchive& ar)
 {
     if (ar.IsStoring())
     {
-        if (CB::GetVersion(ar) <= NumVersion(3, 90))
+        if (!CB::GetFeatures(ar).Check(ftrSizet64Bit))
         {
             ar << value_preserving_cast<WORD>(GetNumTraySets());
         }
@@ -376,7 +376,7 @@ void CTrayManager::SerializeTraySets(CArchive& ar)
     else
     {
         size_t wSize;
-        if (CB::GetVersion(ar) <= NumVersion(3, 90))
+        if (!CB::GetFeatures(ar).Check(ftrSizet64Bit))
         {
             WORD temp;
             ar >> temp;

--- a/GShr/Board.cpp
+++ b/GShr/Board.cpp
@@ -788,7 +788,7 @@ void CBoardManager::Serialize(CArchive& ar)
         ar << m_wReserved3;
         ar << m_wReserved4;
 
-        if (CB::GetVersion(ar) <= NumVersion(3, 90))
+        if (!CB::GetFeatures(ar).Check(ftrSizet64Bit))
         {
             ar << value_preserving_cast<WORD>(GetNumBoards());
         }
@@ -821,14 +821,13 @@ void CBoardManager::Serialize(CArchive& ar)
         ar >> m_wReserved3;
         ar >> m_wReserved4;
         size_t count;
-        if (CB::GetVersion(ar) <= NumVersion(3, 90))
+        if (!CB::GetFeatures(ar).Check(ftrSizet64Bit))
         {
             ar >> wTmp;
             count = wTmp;
         }
         else
         {
-            ASSERT(CB::GetVersion(ar) == NumVersion(4, 0));
             count = CB::ReadCount(ar);
         }
         reserve(count);

--- a/GShr/Board.h
+++ b/GShr/Board.h
@@ -276,6 +276,10 @@ public:
     OwnerPtr<CBoard>& operator[](size_t nIndex)
         { return at(nIndex); }
     // ------- //
+    bool Needs32BitIDs() const
+    {
+        return static_cast<BoardID::UNDERLYING_TYPE>(m_nNextSerialNumber) >= size_t(0xFFFF);
+    }
     void Serialize(CArchive& ar);
 protected:
     // Saved in file...

--- a/GShr/BrdCell.cpp
+++ b/GShr/BrdCell.cpp
@@ -522,7 +522,7 @@ void BoardCell::Serialize(CArchive& ar)
     static_assert(sizeof(temp.m_crCell) == sizeof(DWORD), "file v3.90 mixup");
     if (ar.IsStoring())
     {
-        if (CB::GetVersion(ar) <= NumVersion(3, 90))
+        if (!CB::GetFeatures(ar).Check(ftrId32Bit))
         {
             if (IsTileID())
             {
@@ -552,7 +552,7 @@ void BoardCell::Serialize(CArchive& ar)
     }
     else
     {
-        if (CB::GetVersion(ar) <= NumVersion(3, 90))
+        if (!CB::GetFeatures(ar).Check(ftrId32Bit))
         {
             DWORD dwTmp;
             ar >> dwTmp; temp.m_crCell = (COLORREF)dwTmp;
@@ -649,7 +649,7 @@ void CBoardArray::Serialize(CArchive& ar)
         ar << value_preserving_cast<int16_t>(m_nColTrkOffset);
         ar << (WORD)m_bRowTrkInvert;
         ar << (WORD)m_bColTrkInvert;
-        if (CB::GetVersion(ar) <= NumVersion(3, 90))
+        if (!CB::GetFeatures(ar).Check(ftrSizet64Bit))
         {
             ar << value_preserving_cast<WORD>(m_nRows);
             ar << value_preserving_cast<WORD>(m_nCols);
@@ -678,7 +678,7 @@ void CBoardArray::Serialize(CArchive& ar)
         ar >> iVal; m_nColTrkOffset = iVal;  // (was int cast)
         ar >> wVal; m_bRowTrkInvert = (BOOL)wVal;
         ar >> wVal; m_bColTrkInvert = (BOOL)wVal;
-        if (CB::GetVersion(ar) <= NumVersion(3, 90))
+        if (!CB::GetFeatures(ar).Check(ftrSizet64Bit))
         {
             ar >> wVal; m_nRows = wVal;
             ar >> wVal; m_nCols = wVal;

--- a/GShr/CellForm.cpp
+++ b/GShr/CellForm.cpp
@@ -1,6 +1,6 @@
 // CellForm.cpp
 //
-// Copyright (c) 1994-2020 By Dale L. Larson, All Rights Reserved.
+// Copyright (c) 1994-2023 By Dale L. Larson & William Su, All Rights Reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining
 // a copy of this software and associated documentation files (the

--- a/GShr/CyberBoard.h
+++ b/GShr/CyberBoard.h
@@ -1,6 +1,6 @@
 // CyberBoard.h
 //
-// Copyright (c) 2020 By Bill Su, All Rights Reserved.
+// Copyright (c) 2020-2023 By William Su, All Rights Reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining
 // a copy of this software and associated documentation files (the

--- a/GShr/CyberBoard.h
+++ b/GShr/CyberBoard.h
@@ -28,6 +28,7 @@
 // use explicitly sized ints for portable file format control
 #include <cinttypes>
 #include <cstdarg>
+#include <format>
 #include <limits>
 #include <memory>
 #include <string>

--- a/GShr/DrawObj.cpp
+++ b/GShr/DrawObj.cpp
@@ -1,6 +1,6 @@
 // DrawObj.cpp
 //
-// Copyright (c) 1994-2020 By Dale L. Larson, All Rights Reserved.
+// Copyright (c) 1994-2023 By Dale L. Larson & William Su, All Rights Reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining
 // a copy of this software and associated documentation files (the

--- a/GShr/DrawObj.cpp
+++ b/GShr/DrawObj.cpp
@@ -821,7 +821,7 @@ void CPolyObj::Serialize(CArchive& ar)
         ar << (DWORD)m_crFill;
         ar << (DWORD)m_crLine;
         ar << (WORD)m_nLineWidth;
-        if (CB::GetVersion(ar) <= NumVersion(3, 90))
+        if (!CB::GetFeatures(ar).Check(ftrSizet64Bit))
         {
             ar << value_preserving_cast<WORD>(m_Pnts.size());
         }
@@ -839,7 +839,7 @@ void CPolyObj::Serialize(CArchive& ar)
         ar >> dwTmp; m_crFill = (COLORREF)dwTmp;
         ar >> dwTmp; m_crLine = (COLORREF)dwTmp;
         ar >> wTmp;  m_nLineWidth = (UINT)wTmp;
-        if (CB::GetVersion(ar) <= NumVersion(3, 90))
+        if (!CB::GetFeatures(ar).Check(ftrSizet64Bit))
         {
             ar >> wTmp; m_Pnts.resize(wTmp);
         }
@@ -2318,7 +2318,7 @@ void CDrawList::Serialize(CArchive& ar)
 {
     if (ar.IsStoring())
     {
-        if (CB::GetVersion(ar) <= NumVersion(3, 90))
+        if (!CB::GetFeatures(ar).Check(ftrSizet64Bit))
         {
             ar << value_preserving_cast<WORD>(size());
         }
@@ -2345,7 +2345,7 @@ void CDrawList::Serialize(CArchive& ar)
     {
         clear();
         size_t count;
-        if (CB::GetVersion(ar) <= NumVersion(3, 90))
+        if (!CB::GetFeatures(ar).Check(ftrSizet64Bit))
         {
             WORD wCount;
             ar >> wCount;

--- a/GShr/LBoxGrfx.h
+++ b/GShr/LBoxGrfx.h
@@ -1,6 +1,6 @@
 // LBoxGrfx.h
 //
-// Copyright (c) 1994-2020 By Dale L. Larson, All Rights Reserved.
+// Copyright (c) 1994-2023 By Dale L. Larson & William Su, All Rights Reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining
 // a copy of this software and associated documentation files (the

--- a/GShr/MapStrng.cpp
+++ b/GShr/MapStrng.cpp
@@ -160,6 +160,11 @@ void GameElement64::Serialize(CArchive& ar) const
         AfxThrowArchiveException(CArchiveException::readOnly);
     }
     size_t fileIDSize = GetXxxxIDSerializeSize<decltype(u.pieceElement.pid)>(ar);
+    // piece-100-sides can't fit in GameElement32, so use GameElement64
+    if (CB::GetFeatures(ar).Check(ftrPiece100Sides))
+    {
+        fileIDSize = 4;
+    }
     switch (fileIDSize)
     {
         case 2:
@@ -186,6 +191,11 @@ void GameElement64::Serialize(CArchive& ar)
         AfxThrowArchiveException(CArchiveException::readOnly);
     }
     size_t fileIDSize = GetXxxxIDSerializeSize<decltype(u.pieceElement.pid)>(ar);
+    // piece-100-sides can't fit in GameElement32, so use GameElement64
+    if (CB::GetFeatures(ar).Check(ftrPiece100Sides))
+    {
+        fileIDSize = 4;
+    }
     switch (fileIDSize)
     {
         case 2:

--- a/GShr/MapStrng.cpp
+++ b/GShr/MapStrng.cpp
@@ -1,6 +1,6 @@
 // MapStrng.cpp
 //
-// Copyright (c) 1994-2020 By Dale L. Larson, All Rights Reserved.
+// Copyright (c) 1994-2023 By Dale L. Larson & William Su, All Rights Reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining
 // a copy of this software and associated documentation files (the

--- a/GShr/MapStrng.h
+++ b/GShr/MapStrng.h
@@ -1,6 +1,6 @@
 // MapStrng.h
 //
-// Copyright (c) 1994-2020 By Dale L. Larson, All Rights Reserved.
+// Copyright (c) 1994-2023 By Dale L. Larson & William Su, All Rights Reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining
 // a copy of this software and associated documentation files (the

--- a/GShr/MapStrng.h
+++ b/GShr/MapStrng.h
@@ -732,7 +732,7 @@ public:
     {
         if (ar.IsStoring())
         {
-            if (CB::GetVersion(ar) <= NumVersion(3, 90))
+            if (!CB::GetFeatures(ar).Check(ftrSizet64Bit))
             {
                 uint32_t dwCount = value_preserving_cast<uint32_t>(this->GetCount());
                 ar << dwCount;
@@ -755,7 +755,7 @@ public:
         {
             this->RemoveAll();
             size_t count;
-            if (CB::GetVersion(ar) <= NumVersion(3, 90))
+            if (!CB::GetFeatures(ar).Check(ftrSizet64Bit))
             {
                 uint32_t dwCount;
                 ar >> dwCount;

--- a/GShr/Marks.cpp
+++ b/GShr/Marks.cpp
@@ -259,7 +259,7 @@ void CMarkManager::SerializeMarkSets(CArchive& ar)
 {
     if (ar.IsStoring())
     {
-        if (CB::GetVersion(ar) <= NumVersion(3, 90))
+        if (!CB::GetFeatures(ar).Check(ftrSizet64Bit))
         {
             ar << value_preserving_cast<WORD>(GetNumMarkSets());
         }
@@ -273,7 +273,7 @@ void CMarkManager::SerializeMarkSets(CArchive& ar)
     else
     {
         size_t wSize;
-        if (CB::GetVersion(ar) <= NumVersion(3, 90))
+        if (!CB::GetFeatures(ar).Check(ftrSizet64Bit))
         {
             WORD temp;
             ar >> temp;

--- a/GShr/Marks.h
+++ b/GShr/Marks.h
@@ -174,6 +174,10 @@ public:
     void DeleteMarkSet(size_t nMSet, CGameElementStringMap* pMapString = NULL);
     void Clear();
     // ---------- //
+    bool Needs32BitIDs() const
+    {
+        return m_pMarkTbl.GetSize() >= size_t(0xFFFF);
+    }
     void Serialize(CArchive& ar);
     void SerializeMarkSets(CArchive& ar);
 

--- a/GShr/Pieces.cpp
+++ b/GShr/Pieces.cpp
@@ -268,6 +268,18 @@ void CPieceManager::RemovePieceIDFromPieceSets(PieceID pid)
     ASSERT(FALSE);
 }
 
+bool CPieceManager::Needs100SidePieces() const
+{
+    for (size_t i = size_t(0) ; i < m_pPieceTbl.GetSize() ; ++i)
+    {
+        if (m_pPieceTbl[static_cast<PieceID>(i)].GetSides() > size_t(2))
+        {
+            return true;
+        }
+    }
+    return false;
+}
+
 void CPieceManager::Serialize(CArchive& ar)
 {
     typedef XxxxIDTable<PieceID, PieceDef_v310,
@@ -277,11 +289,19 @@ void CPieceManager::Serialize(CArchive& ar)
 
     if (ar.IsStoring())
     {
+        if (Needs100SidePieces())
+        {
+            if (!GetCBFeatures().Check(ftrPiece100Sides))
+            {
+                AfxThrowArchiveException(CArchiveException::badSchema);
+            }
+            CB::AddFeature(ar, ftrPiece100Sides);
+        }
         ar << m_wReserved1;
         ar << m_wReserved2;
         ar << m_wReserved3;
         ar << m_wReserved4;
-        if (CB::GetVersion(ar) <= NumVersion(3, 90))
+        if (!CB::GetFeatures(ar).Check(ftrPiece100Sides))
         {
             PieceIDTable_v310 temp;
             temp.ResizeTable(m_pPieceTbl.GetSize(), &PieceDef_v310::SetEmpty);
@@ -304,7 +324,7 @@ void CPieceManager::Serialize(CArchive& ar)
         ar >> m_wReserved2;
         ar >> m_wReserved3;
         ar >> m_wReserved4;
-        if (CB::GetVersion(ar) <= NumVersion(3, 90))
+        if (!CB::GetFeatures(ar).Check(ftrPiece100Sides))
         {
             PieceIDTable_v310 temp;
             ar >> temp;
@@ -327,7 +347,7 @@ void CPieceManager::SerializePieceSets(CArchive& ar)
 {
     if (ar.IsStoring())
     {
-        if (CB::GetVersion(ar) <= NumVersion(3, 90))
+        if (!CB::GetFeatures(ar).Check(ftrSizet64Bit))
         {
             ar << value_preserving_cast<WORD>(GetNumPieceSets());
         }
@@ -341,7 +361,7 @@ void CPieceManager::SerializePieceSets(CArchive& ar)
     else
     {
         size_t wSize;
-        if (CB::GetVersion(ar) <= NumVersion(3, 90))
+        if (!CB::GetFeatures(ar).Check(ftrSizet64Bit))
         {
             WORD temp;
             ar >> temp;
@@ -415,7 +435,7 @@ void PieceDef::Serialize(CArchive& ar)
 {
     if (ar.IsStoring())
     {
-        if (CB::GetVersion(ar) <= NumVersion(3, 90))
+        if (!CB::GetFeatures(ar).Check(ftrPiece100Sides))
         {
             ASSERT(!"dead code");
             PieceDef_v310 temp(*this);
@@ -429,7 +449,7 @@ void PieceDef::Serialize(CArchive& ar)
     }
     else
     {
-        if (CB::GetVersion(ar) <= NumVersion(3, 90))
+        if (!CB::GetFeatures(ar).Check(ftrPiece100Sides))
         {
             ASSERT(!"dead code");
             PieceDef_v310 temp;

--- a/GShr/Pieces.cpp
+++ b/GShr/Pieces.cpp
@@ -1,6 +1,6 @@
 // Pieces.cpp
 //
-// Copyright (c) 1994-2020 By Dale L. Larson, All Rights Reserved.
+// Copyright (c) 1994-2023 By Dale L. Larson & William Su, All Rights Reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining
 // a copy of this software and associated documentation files (the

--- a/GShr/Pieces.h
+++ b/GShr/Pieces.h
@@ -1,6 +1,6 @@
 // Pieces.h
 //
-// Copyright (c) 1994-2020 By Dale L. Larson, All Rights Reserved.
+// Copyright (c) 1994-2023 By Dale L. Larson & William Su, All Rights Reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining
 // a copy of this software and associated documentation files (the

--- a/GShr/Pieces.h
+++ b/GShr/Pieces.h
@@ -174,6 +174,13 @@ public:
     void DeletePieceSet(size_t nPSet, CGameElementStringMap* mapStrings = NULL);
     void Clear();
     // ---------- //
+    bool Needs32BitIDs() const
+    {
+        return m_pPieceTbl.GetSize() >= size_t(0xFFFF);
+    }
+private:
+    bool Needs100SidePieces() const;
+public:
     void Serialize(CArchive& ar);
     void SerializePieceSets(CArchive& ar);
 // Implementation

--- a/GShr/Tile.h
+++ b/GShr/Tile.h
@@ -1,6 +1,6 @@
 // Tile.h
 //
-// Copyright (c) 1994-2020 By Dale L. Larson, All Rights Reserved.
+// Copyright (c) 1994-2023 By Dale L. Larson & William Su, All Rights Reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining
 // a copy of this software and associated documentation files (the

--- a/GShr/Tile.h
+++ b/GShr/Tile.h
@@ -267,6 +267,10 @@ public:
     void CreateTilesFromTileImageArchive(CArchive& ar, size_t nTSet,
             std::vector<TileID>* pTidTbl  = NULL, size_t nPos = Invalid_v<size_t>);
     // ---------- //
+    bool Needs32BitIDs() const
+    {
+        return m_pTileTbl.GetSize() >= size_t(0xFFFF);
+    }
     void Serialize(CArchive& archive);
     void SerializeTileSets(CArchive& ar);
     void SerializeTileSheets(CArchive& ar);

--- a/GShr/TileMgr.cpp
+++ b/GShr/TileMgr.cpp
@@ -1,6 +1,6 @@
 // TileMgr.cpp
 //
-// Copyright (c) 1994-2020 By Dale L. Larson, All Rights Reserved.
+// Copyright (c) 1994-2023 By Dale L. Larson & William Su, All Rights Reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining
 // a copy of this software and associated documentation files (the

--- a/GShr/TileMgr.cpp
+++ b/GShr/TileMgr.cpp
@@ -469,7 +469,7 @@ void CTileManager::SerializeTileSets(CArchive& ar)
 {
     if (ar.IsStoring())
     {
-        if (CB::GetVersion(ar) <= NumVersion(3, 90))
+        if (!CB::GetFeatures(ar).Check(ftrSizet64Bit))
         {
             ar << value_preserving_cast<WORD>(GetNumTileSets());
         }
@@ -483,7 +483,7 @@ void CTileManager::SerializeTileSets(CArchive& ar)
     else
     {
         size_t wSize;
-        if (CB::GetVersion(ar) <= NumVersion(3, 90))
+        if (!CB::GetFeatures(ar).Check(ftrSizet64Bit))
         {
             WORD temp;
             ar >> temp;
@@ -505,7 +505,7 @@ void CTileManager::SerializeTileSheets(CArchive& ar)
 {
     if (ar.IsStoring())
     {
-        if (CB::GetVersion(ar) <= NumVersion(3, 90))
+        if (!CB::GetFeatures(ar).Check(ftrSizet64Bit))
         {
             ar << value_preserving_cast<WORD>(m_TShtTbl.size());
         }
@@ -519,7 +519,7 @@ void CTileManager::SerializeTileSheets(CArchive& ar)
     else
     {
         size_t wSize;
-        if (CB::GetVersion(ar) <= NumVersion(3, 90))
+        if (!CB::GetFeatures(ar).Check(ftrSizet64Bit))
         {
             WORD temp;
             ar >> temp;
@@ -841,7 +841,7 @@ void TileLoc::Serialize(CArchive& ar)
 {
     if (ar.IsStoring())
     {
-        if (CB::GetVersion(ar) <= NumVersion(3, 90))
+        if (!CB::GetFeatures(ar).Check(ftrSizet64Bit))
         {
             ar << (m_nSheet == noSheet ? noSheet16 : value_preserving_cast<uint16_t>(m_nSheet));
         }
@@ -859,7 +859,7 @@ void TileLoc::Serialize(CArchive& ar)
             ar >> chTmp;
             m_nSheet = (chTmp == 0xFF) ? noSheet : value_preserving_cast<size_t>(chTmp);
         }
-        else if (CB::GetVersion(ar) <= NumVersion(3, 90))   // V3.90
+        else if (!CB::GetFeatures(ar).Check(ftrSizet64Bit))   // V3.90
         {
             uint16_t wTmp;
             ar >> wTmp;

--- a/GShr/Versions.h
+++ b/GShr/Versions.h
@@ -105,7 +105,7 @@ inline int GetSaveFileVersion()
     static const int retval = [] {
         struct FileFlagParser : public CCommandLineInfo
         {
-            int version = NumVersion(105, 0);
+            int version = NumVersion(5, 0);
             virtual void ParseParam(const char* pszParam, BOOL bFlag, BOOL bLast) override
             {
                 static const std::regex re(R"(filever:([[:digit:]]+)\.([[:digit:]]+))");

--- a/GShr/Versions.h
+++ b/GShr/Versions.h
@@ -1,6 +1,6 @@
 // versions.h - program version numbers.
 //
-// Copyright (c) 1994-2010 By Dale L. Larson, All Rights Reserved.
+// Copyright (c) 1994-2023 By Dale L. Larson & William Su, All Rights Reserved.
 //
 #ifndef __VERSIONS_H__
 #define __VERSIONS_H__

--- a/GShr/WinState.cpp
+++ b/GShr/WinState.cpp
@@ -229,7 +229,7 @@ void CWinStateManager::Serialize(CArchive& ar)
             ar << (DWORD)0;
             return;
         }
-        if (CB::GetVersion(ar) <= NumVersion(3, 90))
+        if (!CB::GetFeatures(ar).Check(ftrSizet64Bit))
         {
             ar << value_preserving_cast<DWORD>(m_pList->size());
         }
@@ -247,7 +247,7 @@ void CWinStateManager::Serialize(CArchive& ar)
     {
         m_pList = nullptr;
         size_t dwCount;
-        if (CB::GetVersion(ar) <= NumVersion(3, 90))
+        if (!CB::GetFeatures(ar).Check(ftrSizet64Bit))
         {
             DWORD temp;
             ar >> temp;
@@ -340,7 +340,7 @@ void CWinStateManager::CWinStateElement::Serialize(CArchive& ar)
         ar << m_wUserCode1;
         ar << m_boardID;
         ar << m_wndState;
-        if (CB::GetVersion(ar) <= NumVersion(3, 90))
+        if (!CB::GetFeatures(ar).Check(ftrSizet64Bit))
         {
             ar << value_preserving_cast<DWORD>(m_pWinStateBfr.GetSize());
         }
@@ -360,7 +360,7 @@ void CWinStateManager::CWinStateElement::Serialize(CArchive& ar)
         ar >> m_boardID;
         ar >> m_wndState;
         size_t size;
-        if (CB::GetVersion(ar) <= NumVersion(3, 90))
+        if (!CB::GetFeatures(ar).Check(ftrSizet64Bit))
         {
             DWORD dwSize;
             ar >> dwSize;


### PR DESCRIPTION
Note:  This might be a wild idea, so I have set it as a draft, and I have set the file version number to 105.0.

Using a file version number makes it difficult for developers to make file format changes in parallel.  For example, in previous work, it was common for test files to have the same version number, but different formats.  This makes it difficult to keep a stock of test files.

Therefore, modify the file format to allow files to more clearly describe their format.

