### PR TITLE
convert Board Editor from MFC to wxWidgets

### DIFF
--- a/GM/CBDesign.fbp
+++ b/GM/CBDesign.fbp
@@ -18635,6 +18635,452 @@
       <property name="window_name"></property>
       <property name="window_style"></property>
       <object class="wxMenu" expanded="false">
+        <property name="label">0=BV_EDIT</property>
+        <property name="name">MENU_BV_DRAWING</property>
+        <property name="permission">protected</property>
+        <object class="wxMenuItem" expanded="false">
+          <property name="bitmap"></property>
+          <property name="checked">0</property>
+          <property name="enabled">1</property>
+          <property name="help">Undo the last action&#x0A;Undo</property>
+          <property name="id">wxID_ANY</property>
+          <property name="kind">wxITEM_NORMAL</property>
+          <property name="label">Undo</property>
+          <property name="name">wxID_UNDO</property>
+          <property name="permission">none</property>
+          <property name="shortcut"></property>
+          <property name="unchecked_bitmap"></property>
+        </object>
+        <object class="separator" expanded="false">
+          <property name="name">m_separator6</property>
+          <property name="permission">none</property>
+        </object>
+        <object class="wxMenuItem" expanded="false">
+          <property name="bitmap"></property>
+          <property name="checked">0</property>
+          <property name="enabled">1</property>
+          <property name="help">Copy the selection and put it on the Clipboard&#x0A;Copy</property>
+          <property name="id">wxID_ANY</property>
+          <property name="kind">wxITEM_NORMAL</property>
+          <property name="label">Copy</property>
+          <property name="name">wxID_COPY</property>
+          <property name="permission">none</property>
+          <property name="shortcut"></property>
+          <property name="unchecked_bitmap"></property>
+        </object>
+        <object class="wxMenuItem" expanded="false">
+          <property name="bitmap"></property>
+          <property name="checked">0</property>
+          <property name="enabled">1</property>
+          <property name="help">Insert Clipboard contents&#x0A;Paste</property>
+          <property name="id">wxID_ANY</property>
+          <property name="kind">wxITEM_NORMAL</property>
+          <property name="label">Paste</property>
+          <property name="name">wxID_PASTE</property>
+          <property name="permission">none</property>
+          <property name="shortcut"></property>
+          <property name="unchecked_bitmap"></property>
+        </object>
+        <object class="wxMenuItem" expanded="false">
+          <property name="bitmap"></property>
+          <property name="checked">0</property>
+          <property name="enabled">1</property>
+          <property name="help">Erase the current selection&#x0A;Delete (Del)</property>
+          <property name="id">wxID_ANY</property>
+          <property name="kind">wxITEM_NORMAL</property>
+          <property name="label">Delete</property>
+          <property name="name">wxID_CLEAR</property>
+          <property name="permission">none</property>
+          <property name="shortcut"></property>
+          <property name="unchecked_bitmap"></property>
+        </object>
+        <object class="separator" expanded="false">
+          <property name="name">m_separator7</property>
+          <property name="permission">none</property>
+        </object>
+        <object class="submenu" expanded="false">
+          <property name="bitmap"></property>
+          <property name="label">Board Drawing Tools</property>
+          <property name="name">m_menu3</property>
+          <property name="permission">protected</property>
+          <object class="wxMenuItem" expanded="false">
+            <property name="bitmap"></property>
+            <property name="checked">0</property>
+            <property name="enabled">1</property>
+            <property name="help">Selects objects&#x0A;Select Objects</property>
+            <property name="id">wxID_ANY</property>
+            <property name="kind">wxITEM_CHECK</property>
+            <property name="label">Selector</property>
+            <property name="name">ID_TOOL_ARROW</property>
+            <property name="permission">none</property>
+            <property name="shortcut"></property>
+            <property name="unchecked_bitmap"></property>
+          </object>
+          <object class="wxMenuItem" expanded="false">
+            <property name="bitmap"></property>
+            <property name="checked">0</property>
+            <property name="enabled">1</property>
+            <property name="help">Extract a color from the screen&#x0A;Pickup Color</property>
+            <property name="id">wxID_ANY</property>
+            <property name="kind">wxITEM_CHECK</property>
+            <property name="label">Pickup Color</property>
+            <property name="name">ID_TOOL_DROPPER</property>
+            <property name="permission">none</property>
+            <property name="shortcut"></property>
+            <property name="unchecked_bitmap"></property>
+          </object>
+          <object class="wxMenuItem" expanded="false">
+            <property name="bitmap"></property>
+            <property name="checked">0</property>
+            <property name="enabled">1</property>
+            <property name="help">Places tiles on the board&#x0A;Tile</property>
+            <property name="id">wxID_ANY</property>
+            <property name="kind">wxITEM_CHECK</property>
+            <property name="label">Draw Tile</property>
+            <property name="name">ID_TOOL_TILE</property>
+            <property name="permission">none</property>
+            <property name="shortcut"></property>
+            <property name="unchecked_bitmap"></property>
+          </object>
+          <object class="wxMenuItem" expanded="false">
+            <property name="bitmap"></property>
+            <property name="checked">0</property>
+            <property name="enabled">1</property>
+            <property name="help">Places text on the board&#x0A;Text</property>
+            <property name="id">wxID_ANY</property>
+            <property name="kind">wxITEM_CHECK</property>
+            <property name="label">Draw Text</property>
+            <property name="name">ID_TOOL_TEXT</property>
+            <property name="permission">none</property>
+            <property name="shortcut"></property>
+            <property name="unchecked_bitmap"></property>
+          </object>
+          <object class="wxMenuItem" expanded="false">
+            <property name="bitmap"></property>
+            <property name="checked">0</property>
+            <property name="enabled">1</property>
+            <property name="help">Draw a line on the board&#x0A;Line</property>
+            <property name="id">wxID_ANY</property>
+            <property name="kind">wxITEM_CHECK</property>
+            <property name="label">Draw Line</property>
+            <property name="name">ID_TOOL_LINE</property>
+            <property name="permission">none</property>
+            <property name="shortcut"></property>
+            <property name="unchecked_bitmap"></property>
+          </object>
+          <object class="wxMenuItem" expanded="false">
+            <property name="bitmap"></property>
+            <property name="checked">0</property>
+            <property name="enabled">1</property>
+            <property name="help">Draw a rectangle on the board&#x0A;Rectangle</property>
+            <property name="id">wxID_ANY</property>
+            <property name="kind">wxITEM_CHECK</property>
+            <property name="label">Draw Rectangle</property>
+            <property name="name">ID_TOOL_RECT</property>
+            <property name="permission">none</property>
+            <property name="shortcut"></property>
+            <property name="unchecked_bitmap"></property>
+          </object>
+          <object class="wxMenuItem" expanded="false">
+            <property name="bitmap"></property>
+            <property name="checked">0</property>
+            <property name="enabled">1</property>
+            <property name="help">Draw a polygon or polyline on board&#x0A;Polygon or Polyline</property>
+            <property name="id">wxID_ANY</property>
+            <property name="kind">wxITEM_CHECK</property>
+            <property name="label">Draw Polygon</property>
+            <property name="name">ID_TOOL_POLYGON</property>
+            <property name="permission">none</property>
+            <property name="shortcut"></property>
+            <property name="unchecked_bitmap"></property>
+          </object>
+          <object class="wxMenuItem" expanded="false">
+            <property name="bitmap"></property>
+            <property name="checked">0</property>
+            <property name="enabled">1</property>
+            <property name="help">Draw an oval on the board&#x0A;Oval</property>
+            <property name="id">wxID_ANY</property>
+            <property name="kind">wxITEM_CHECK</property>
+            <property name="label">Draw Oval</property>
+            <property name="name">ID_TOOL_OVAL</property>
+            <property name="permission">none</property>
+            <property name="shortcut"></property>
+            <property name="unchecked_bitmap"></property>
+          </object>
+          <object class="wxMenuItem" expanded="false">
+            <property name="bitmap"></property>
+            <property name="checked">0</property>
+            <property name="enabled">1</property>
+            <property name="help">Fills board cell with a single color&#x0A;Color Cell</property>
+            <property name="id">wxID_ANY</property>
+            <property name="kind">wxITEM_CHECK</property>
+            <property name="label">Color Cell</property>
+            <property name="name">ID_TOOL_FILL</property>
+            <property name="permission">none</property>
+            <property name="shortcut"></property>
+            <property name="unchecked_bitmap"></property>
+          </object>
+          <object class="wxMenuItem" expanded="false">
+            <property name="bitmap"></property>
+            <property name="checked">0</property>
+            <property name="enabled">1</property>
+            <property name="help">Erases contents of board cell&#x0A;Erase Cell</property>
+            <property name="id">wxID_ANY</property>
+            <property name="kind">wxITEM_CHECK</property>
+            <property name="label">Erase Cell</property>
+            <property name="name">ID_TOOL_ERASER</property>
+            <property name="permission">none</property>
+            <property name="shortcut"></property>
+            <property name="unchecked_bitmap"></property>
+          </object>
+        </object>
+        <object class="wxMenuItem" expanded="false">
+          <property name="bitmap"></property>
+          <property name="checked">0</property>
+          <property name="enabled">1</property>
+          <property name="help">Toggle automatic selection of Select tool after drawing.</property>
+          <property name="id">wxID_ANY</property>
+          <property name="kind">wxITEM_CHECK</property>
+          <property name="label">Drawing Tools Are Sticky</property>
+          <property name="name">ID_STICKY_DRAWTOOLS</property>
+          <property name="permission">none</property>
+          <property name="shortcut"></property>
+          <property name="unchecked_bitmap"></property>
+        </object>
+        <object class="wxMenuItem" expanded="false">
+          <property name="bitmap"></property>
+          <property name="checked">0</property>
+          <property name="enabled">1</property>
+          <property name="help">Set default drawing font.</property>
+          <property name="id">wxID_ANY</property>
+          <property name="kind">wxITEM_NORMAL</property>
+          <property name="label">Font...</property>
+          <property name="name">ID_DWG_FONT</property>
+          <property name="permission">none</property>
+          <property name="shortcut"></property>
+          <property name="unchecked_bitmap"></property>
+        </object>
+        <object class="separator" expanded="false">
+          <property name="name">m_separator8</property>
+          <property name="permission">none</property>
+        </object>
+        <object class="wxMenuItem" expanded="false">
+          <property name="bitmap"></property>
+          <property name="checked">0</property>
+          <property name="enabled">1</property>
+          <property name="help">Brings the selected drawing objects to the front of the drawing&#x0A;Move Object to Front</property>
+          <property name="id">wxID_ANY</property>
+          <property name="kind">wxITEM_NORMAL</property>
+          <property name="label">Bring Objects to Front</property>
+          <property name="name">ID_DWG_TOFRONT</property>
+          <property name="permission">none</property>
+          <property name="shortcut"></property>
+          <property name="unchecked_bitmap"></property>
+        </object>
+        <object class="wxMenuItem" expanded="false">
+          <property name="bitmap"></property>
+          <property name="checked">0</property>
+          <property name="enabled">1</property>
+          <property name="help">Sends the selected drawing objects to the back of the drawing&#x0A;Move Object to Back</property>
+          <property name="id">wxID_ANY</property>
+          <property name="kind">wxITEM_NORMAL</property>
+          <property name="label">Send Objects to Back</property>
+          <property name="name">ID_DWG_TOBACK</property>
+          <property name="permission">none</property>
+          <property name="shortcut"></property>
+          <property name="unchecked_bitmap"></property>
+        </object>
+        <object class="wxMenuItem" expanded="false">
+          <property name="bitmap"></property>
+          <property name="checked">0</property>
+          <property name="enabled">1</property>
+          <property name="help">Draw selected objects above the grid lines&#x0A;Draw Above Grid</property>
+          <property name="id">wxID_ANY</property>
+          <property name="kind">wxITEM_CHECK</property>
+          <property name="label">Draw Objects Above Grid</property>
+          <property name="name">ID_DWG_DRAWABOVEGRID</property>
+          <property name="permission">none</property>
+          <property name="shortcut"></property>
+          <property name="unchecked_bitmap"></property>
+        </object>
+        <object class="separator" expanded="false">
+          <property name="name">m_separator9</property>
+          <property name="permission">none</property>
+        </object>
+        <object class="wxMenuItem" expanded="false">
+          <property name="bitmap"></property>
+          <property name="checked">0</property>
+          <property name="enabled">1</property>
+          <property name="help">Enable or disables the board editor snap grid&#x0A;Board Snap Grid</property>
+          <property name="id">wxID_ANY</property>
+          <property name="kind">wxITEM_CHECK</property>
+          <property name="label">Snap Grid</property>
+          <property name="name">ID_TOOLS_BRDSNAPGRID</property>
+          <property name="permission">none</property>
+          <property name="shortcut"></property>
+          <property name="unchecked_bitmap"></property>
+        </object>
+        <object class="wxMenuItem" expanded="false">
+          <property name="bitmap"></property>
+          <property name="checked">0</property>
+          <property name="enabled">1</property>
+          <property name="help">Select which scales the objects are visible</property>
+          <property name="id">wxID_ANY</property>
+          <property name="kind">wxITEM_NORMAL</property>
+          <property name="label">Set Scale Related Visibility...</property>
+          <property name="name">ID_TOOL_SETVISIBLESCALE</property>
+          <property name="permission">none</property>
+          <property name="shortcut"></property>
+          <property name="unchecked_bitmap"></property>
+        </object>
+        <object class="wxMenuItem" expanded="false">
+          <property name="bitmap"></property>
+          <property name="checked">0</property>
+          <property name="enabled">1</property>
+          <property name="help">Turn off scaled visibility for drawn objects</property>
+          <property name="id">wxID_ANY</property>
+          <property name="kind">wxITEM_CHECK</property>
+          <property name="label">Suspend Scale Related Visibility</property>
+          <property name="name">ID_TOOL_SUSPENDSCALEVISIBILITY</property>
+          <property name="permission">none</property>
+          <property name="shortcut"></property>
+          <property name="unchecked_bitmap"></property>
+        </object>
+        <object class="separator" expanded="false">
+          <property name="name">m_separator10</property>
+          <property name="permission">none</property>
+        </object>
+        <object class="wxMenuItem" expanded="false">
+          <property name="bitmap"></property>
+          <property name="checked">0</property>
+          <property name="enabled">1</property>
+          <property name="help">Edit the board&apos;s base drawing layer&#x0A;Base Drawing Layer</property>
+          <property name="id">wxID_ANY</property>
+          <property name="kind">wxITEM_CHECK</property>
+          <property name="label">Edit Base Board Layer</property>
+          <property name="name">ID_EDIT_LAYER_BASE</property>
+          <property name="permission">none</property>
+          <property name="shortcut"></property>
+          <property name="unchecked_bitmap"></property>
+        </object>
+        <object class="wxMenuItem" expanded="false">
+          <property name="bitmap"></property>
+          <property name="checked">0</property>
+          <property name="enabled">1</property>
+          <property name="help">Edit the board&apos;s cell layer&#x0A;Board Cell Layer</property>
+          <property name="id">wxID_ANY</property>
+          <property name="kind">wxITEM_CHECK</property>
+          <property name="label">Edit Cell Board Layer</property>
+          <property name="name">ID_EDIT_LAYER_TILE</property>
+          <property name="permission">none</property>
+          <property name="shortcut"></property>
+          <property name="unchecked_bitmap"></property>
+        </object>
+        <object class="wxMenuItem" expanded="false">
+          <property name="bitmap"></property>
+          <property name="checked">0</property>
+          <property name="enabled">1</property>
+          <property name="help">Edit the board&apos;s top drawing layer&#x0A;Top Drawing Layer</property>
+          <property name="id">wxID_ANY</property>
+          <property name="kind">wxITEM_CHECK</property>
+          <property name="label">Edit Top Board Layer</property>
+          <property name="name">ID_EDIT_LAYER_TOP</property>
+          <property name="permission">none</property>
+          <property name="shortcut"></property>
+          <property name="unchecked_bitmap"></property>
+        </object>
+        <object class="separator" expanded="false">
+          <property name="name">m_separator11</property>
+          <property name="permission">none</property>
+        </object>
+        <object class="wxMenuItem" expanded="false">
+          <property name="bitmap"></property>
+          <property name="checked">0</property>
+          <property name="enabled">1</property>
+          <property name="help">Show full scale board view</property>
+          <property name="id">wxID_ANY</property>
+          <property name="kind">wxITEM_CHECK</property>
+          <property name="label">View Full Scale Board</property>
+          <property name="name">ID_VIEW_FULLSCALE</property>
+          <property name="permission">none</property>
+          <property name="shortcut"></property>
+          <property name="unchecked_bitmap"></property>
+        </object>
+        <object class="wxMenuItem" expanded="false">
+          <property name="bitmap"></property>
+          <property name="checked">0</property>
+          <property name="enabled">1</property>
+          <property name="help">Show half scale board view</property>
+          <property name="id">wxID_ANY</property>
+          <property name="kind">wxITEM_CHECK</property>
+          <property name="label">View Half Scale Board</property>
+          <property name="name">ID_VIEW_HALFSCALE</property>
+          <property name="permission">none</property>
+          <property name="shortcut"></property>
+          <property name="unchecked_bitmap"></property>
+        </object>
+        <object class="wxMenuItem" expanded="false">
+          <property name="bitmap"></property>
+          <property name="checked">0</property>
+          <property name="enabled">1</property>
+          <property name="help">Show small scale board view</property>
+          <property name="id">wxID_ANY</property>
+          <property name="kind">wxITEM_CHECK</property>
+          <property name="label">View Small Scale Board</property>
+          <property name="name">ID_VIEW_SMALLSCALE</property>
+          <property name="permission">none</property>
+          <property name="shortcut"></property>
+          <property name="unchecked_bitmap"></property>
+        </object>
+        <object class="separator" expanded="false">
+          <property name="name">m_separator12</property>
+          <property name="permission">none</property>
+        </object>
+        <object class="wxMenuItem" expanded="false">
+          <property name="bitmap"></property>
+          <property name="checked">0</property>
+          <property name="enabled">1</property>
+          <property name="help">Hides or shows cell layer border lines&#x0A;Cell Border Lines</property>
+          <property name="id">wxID_ANY</property>
+          <property name="kind">wxITEM_CHECK</property>
+          <property name="label">View Cell Border Lines</property>
+          <property name="name">ID_VIEW_GRIDLINES</property>
+          <property name="permission">none</property>
+          <property name="shortcut"></property>
+          <property name="unchecked_bitmap"></property>
+        </object>
+        <object class="separator" expanded="false">
+          <property name="name">m_separator13</property>
+          <property name="permission">none</property>
+        </object>
+        <object class="wxMenuItem" expanded="false">
+          <property name="bitmap"></property>
+          <property name="checked">0</property>
+          <property name="enabled">1</property>
+          <property name="help">Change the board properties</property>
+          <property name="id">wxID_ANY</property>
+          <property name="kind">wxITEM_NORMAL</property>
+          <property name="label">Board Properties...</property>
+          <property name="name">ID_TOOLS_BRDPROPS</property>
+          <property name="permission">none</property>
+          <property name="shortcut"></property>
+          <property name="unchecked_bitmap"></property>
+        </object>
+        <object class="wxMenuItem" expanded="false">
+          <property name="bitmap"></property>
+          <property name="checked">0</property>
+          <property name="enabled">1</property>
+          <property name="help"></property>
+          <property name="id">wxID_ANY</property>
+          <property name="kind">wxITEM_NORMAL</property>
+          <property name="label">Paste Bitmap From File...</property>
+          <property name="name">ID_EDIT_PASTEBITMAPFROMFILE</property>
+          <property name="permission">none</property>
+          <property name="shortcut"></property>
+          <property name="unchecked_bitmap"></property>
+        </object>
+      </object>
+      <object class="wxMenu" expanded="false">
         <property name="label">1=IV_BITEDIT</property>
         <property name="name">MENU_IV_BITEDIT</property>
         <property name="permission">protected</property>

--- a/GM/CBDesign.xrc
+++ b/GM/CBDesign.xrc
@@ -3478,6 +3478,196 @@
     </object>
   </object>
   <object class="wxMenuBar" name="IDR_MENU_DESIGN_POPUPS">
+    <object class="wxMenu" name="MENU_BV_DRAWING">
+      <label>0=BV__EDIT</label>
+      <object class="wxMenuItem" name="wxID_UNDO">
+        <label>Undo</label>
+        <accel></accel>
+        <help>Undo the last action\nUndo</help>
+      </object>
+      <object class="separator"/>
+      <object class="wxMenuItem" name="wxID_COPY">
+        <label>Copy</label>
+        <accel></accel>
+        <help>Copy the selection and put it on the Clipboard\nCopy</help>
+      </object>
+      <object class="wxMenuItem" name="wxID_PASTE">
+        <label>Paste</label>
+        <accel></accel>
+        <help>Insert Clipboard contents\nPaste</help>
+      </object>
+      <object class="wxMenuItem" name="wxID_CLEAR">
+        <label>Delete</label>
+        <accel></accel>
+        <help>Erase the current selection\nDelete (Del)</help>
+      </object>
+      <object class="separator"/>
+      <object class="wxMenu" name="m_menu3">
+        <label>Board Drawing Tools</label>
+        <object class="wxMenuItem" name="ID_TOOL_ARROW">
+          <label>Selector</label>
+          <accel></accel>
+          <help>Selects objects\nSelect Objects</help>
+          <checkable>1</checkable>
+        </object>
+        <object class="wxMenuItem" name="ID_TOOL_DROPPER">
+          <label>Pickup Color</label>
+          <accel></accel>
+          <help>Extract a color from the screen\nPickup Color</help>
+          <checkable>1</checkable>
+        </object>
+        <object class="wxMenuItem" name="ID_TOOL_TILE">
+          <label>Draw Tile</label>
+          <accel></accel>
+          <help>Places tiles on the board\nTile</help>
+          <checkable>1</checkable>
+        </object>
+        <object class="wxMenuItem" name="ID_TOOL_TEXT">
+          <label>Draw Text</label>
+          <accel></accel>
+          <help>Places text on the board\nText</help>
+          <checkable>1</checkable>
+        </object>
+        <object class="wxMenuItem" name="ID_TOOL_LINE">
+          <label>Draw Line</label>
+          <accel></accel>
+          <help>Draw a line on the board\nLine</help>
+          <checkable>1</checkable>
+        </object>
+        <object class="wxMenuItem" name="ID_TOOL_RECT">
+          <label>Draw Rectangle</label>
+          <accel></accel>
+          <help>Draw a rectangle on the board\nRectangle</help>
+          <checkable>1</checkable>
+        </object>
+        <object class="wxMenuItem" name="ID_TOOL_POLYGON">
+          <label>Draw Polygon</label>
+          <accel></accel>
+          <help>Draw a polygon or polyline on board\nPolygon or Polyline</help>
+          <checkable>1</checkable>
+        </object>
+        <object class="wxMenuItem" name="ID_TOOL_OVAL">
+          <label>Draw Oval</label>
+          <accel></accel>
+          <help>Draw an oval on the board\nOval</help>
+          <checkable>1</checkable>
+        </object>
+        <object class="wxMenuItem" name="ID_TOOL_FILL">
+          <label>Color Cell</label>
+          <accel></accel>
+          <help>Fills board cell with a single color\nColor Cell</help>
+          <checkable>1</checkable>
+        </object>
+        <object class="wxMenuItem" name="ID_TOOL_ERASER">
+          <label>Erase Cell</label>
+          <accel></accel>
+          <help>Erases contents of board cell\nErase Cell</help>
+          <checkable>1</checkable>
+        </object>
+      </object>
+      <object class="wxMenuItem" name="ID_STICKY_DRAWTOOLS">
+        <label>Drawing Tools Are Sticky</label>
+        <accel></accel>
+        <help>Toggle automatic selection of Select tool after drawing.</help>
+        <checkable>1</checkable>
+      </object>
+      <object class="wxMenuItem" name="ID_DWG_FONT">
+        <label>Font...</label>
+        <accel></accel>
+        <help>Set default drawing font.</help>
+      </object>
+      <object class="separator"/>
+      <object class="wxMenuItem" name="ID_DWG_TOFRONT">
+        <label>Bring Objects to Front</label>
+        <accel></accel>
+        <help>Brings the selected drawing objects to the front of the drawing\nMove Object to Front</help>
+      </object>
+      <object class="wxMenuItem" name="ID_DWG_TOBACK">
+        <label>Send Objects to Back</label>
+        <accel></accel>
+        <help>Sends the selected drawing objects to the back of the drawing\nMove Object to Back</help>
+      </object>
+      <object class="wxMenuItem" name="ID_DWG_DRAWABOVEGRID">
+        <label>Draw Objects Above Grid</label>
+        <accel></accel>
+        <help>Draw selected objects above the grid lines\nDraw Above Grid</help>
+        <checkable>1</checkable>
+      </object>
+      <object class="separator"/>
+      <object class="wxMenuItem" name="ID_TOOLS_BRDSNAPGRID">
+        <label>Snap Grid</label>
+        <accel></accel>
+        <help>Enable or disables the board editor snap grid\nBoard Snap Grid</help>
+        <checkable>1</checkable>
+      </object>
+      <object class="wxMenuItem" name="ID_TOOL_SETVISIBLESCALE">
+        <label>Set Scale Related Visibility...</label>
+        <accel></accel>
+        <help>Select which scales the objects are visible</help>
+      </object>
+      <object class="wxMenuItem" name="ID_TOOL_SUSPENDSCALEVISIBILITY">
+        <label>Suspend Scale Related Visibility</label>
+        <accel></accel>
+        <help>Turn off scaled visibility for drawn objects</help>
+        <checkable>1</checkable>
+      </object>
+      <object class="separator"/>
+      <object class="wxMenuItem" name="ID_EDIT_LAYER_BASE">
+        <label>Edit Base Board Layer</label>
+        <accel></accel>
+        <help>Edit the board&apos;s base drawing layer\nBase Drawing Layer</help>
+        <checkable>1</checkable>
+      </object>
+      <object class="wxMenuItem" name="ID_EDIT_LAYER_TILE">
+        <label>Edit Cell Board Layer</label>
+        <accel></accel>
+        <help>Edit the board&apos;s cell layer\nBoard Cell Layer</help>
+        <checkable>1</checkable>
+      </object>
+      <object class="wxMenuItem" name="ID_EDIT_LAYER_TOP">
+        <label>Edit Top Board Layer</label>
+        <accel></accel>
+        <help>Edit the board&apos;s top drawing layer\nTop Drawing Layer</help>
+        <checkable>1</checkable>
+      </object>
+      <object class="separator"/>
+      <object class="wxMenuItem" name="ID_VIEW_FULLSCALE">
+        <label>View Full Scale Board</label>
+        <accel></accel>
+        <help>Show full scale board view</help>
+        <checkable>1</checkable>
+      </object>
+      <object class="wxMenuItem" name="ID_VIEW_HALFSCALE">
+        <label>View Half Scale Board</label>
+        <accel></accel>
+        <help>Show half scale board view</help>
+        <checkable>1</checkable>
+      </object>
+      <object class="wxMenuItem" name="ID_VIEW_SMALLSCALE">
+        <label>View Small Scale Board</label>
+        <accel></accel>
+        <help>Show small scale board view</help>
+        <checkable>1</checkable>
+      </object>
+      <object class="separator"/>
+      <object class="wxMenuItem" name="ID_VIEW_GRIDLINES">
+        <label>View Cell Border Lines</label>
+        <accel></accel>
+        <help>Hides or shows cell layer border lines\nCell Border Lines</help>
+        <checkable>1</checkable>
+      </object>
+      <object class="separator"/>
+      <object class="wxMenuItem" name="ID_TOOLS_BRDPROPS">
+        <label>Board Properties...</label>
+        <accel></accel>
+        <help>Change the board properties</help>
+      </object>
+      <object class="wxMenuItem" name="ID_EDIT_PASTEBITMAPFROMFILE">
+        <label>Paste Bitmap From File...</label>
+        <accel></accel>
+        <help></help>
+      </object>
+    </object>
     <object class="wxMenu" name="MENU_IV_BITEDIT">
       <label>1=IV__BITEDIT</label>
       <object class="wxMenuItem" name="wxID_UNDO">

--- a/GM/FrmMain.cpp
+++ b/GM/FrmMain.cpp
@@ -92,11 +92,15 @@ static UINT toolbars[] =
 ///////////////////////////////////////////////////////////////////////
 // These are used to qualify palette visiblility...
 
-static const CRuntimeClass *tblColor[] = { RUNTIME_CLASS(CBrdEditView),
+static const CRuntimeClass *tblColor[] = {
+    RUNTIME_CLASS(CBrdEditView), RUNTIME_CLASS(CBrdEditViewContainer),
     RUNTIME_CLASS(CBitEditViewContainer),
     RUNTIME_CLASS(CTileSelViewContainer), NULL };
 
-static const CRuntimeClass *tblBrd[] = { RUNTIME_CLASS(CBrdEditView), NULL };
+static const CRuntimeClass *tblBrd[] = {
+    RUNTIME_CLASS(CBrdEditView), RUNTIME_CLASS(CBrdEditViewContainer),
+    NULL
+};
 
 ///////////////////////////////////////////////////////////////////////
 // CMainFrame construction/destruction

--- a/GM/FrmMain.cpp
+++ b/GM/FrmMain.cpp
@@ -93,12 +93,12 @@ static UINT toolbars[] =
 // These are used to qualify palette visiblility...
 
 static const CRuntimeClass *tblColor[] = {
-    RUNTIME_CLASS(CBrdEditView), RUNTIME_CLASS(CBrdEditViewContainer),
+    RUNTIME_CLASS(CBrdEditViewContainer),
     RUNTIME_CLASS(CBitEditViewContainer),
     RUNTIME_CLASS(CTileSelViewContainer), NULL };
 
 static const CRuntimeClass *tblBrd[] = {
-    RUNTIME_CLASS(CBrdEditView), RUNTIME_CLASS(CBrdEditViewContainer),
+    RUNTIME_CLASS(CBrdEditViewContainer),
     NULL
 };
 

--- a/GM/Gm.cpp
+++ b/GM/Gm.cpp
@@ -405,7 +405,7 @@ BOOL CGmApp::InitInstance()
 
     m_pMapViewTmpl = new CMultiDocTemplate(IDR_BOARDVIEW,
         RUNTIME_CLASS(CGamDoc), RUNTIME_CLASS(CViewFrame),
-        RUNTIME_CLASS(CBrdEditView));
+        RUNTIME_CLASS(CBrdEditViewContainer));
 
     m_pTileEditTmpl = new CMultiDocTemplate(IDR_BITEDITOR,
         RUNTIME_CLASS(CGamDoc), RUNTIME_CLASS(CBitEditFrame),

--- a/GM/GmDoc.cpp
+++ b/GM/GmDoc.cpp
@@ -158,7 +158,7 @@ void CGamDoc::OnCloseDocument()
 /////////////////////////////////////////////////////////////////////////////
 
 static const CRuntimeClass *tblBrd[] = {
-    RUNTIME_CLASS(CBrdEditView), RUNTIME_CLASS(CBrdEditViewContainer),
+    RUNTIME_CLASS(CBrdEditViewContainer),
     NULL
 };
 
@@ -394,10 +394,10 @@ CView* CGamDoc::FindBoardEditorView(const CBoard& pBoard)
     POSITION pos = GetFirstViewPosition();
     while (pos != NULL)
     {
-        CBrdEditView* pView = (CBrdEditView*)GetNextView(pos);
-        if (pView->IsKindOf(RUNTIME_CLASS(CBrdEditView)))
+        CBrdEditViewContainer* pView = (CBrdEditViewContainer*)GetNextView(pos);
+        if (pView->IsKindOf(RUNTIME_CLASS(CBrdEditViewContainer)))
         {
-            if (&pView->GetBoard() == &pBoard)
+            if (&pView->GetChild().GetBoard() == &pBoard)
                 return pView;
         }
     }

--- a/GM/GmDoc.cpp
+++ b/GM/GmDoc.cpp
@@ -397,7 +397,7 @@ CView* CGamDoc::FindBoardEditorView(const CBoard& pBoard)
         CBrdEditView* pView = (CBrdEditView*)GetNextView(pos);
         if (pView->IsKindOf(RUNTIME_CLASS(CBrdEditView)))
         {
-            if (pView->GetBoard() == &pBoard)
+            if (&pView->GetBoard() == &pBoard)
                 return pView;
         }
     }

--- a/GM/GmDoc.cpp
+++ b/GM/GmDoc.cpp
@@ -157,7 +157,10 @@ void CGamDoc::OnCloseDocument()
 
 /////////////////////////////////////////////////////////////////////////////
 
-static const CRuntimeClass *tblBrd[] = { RUNTIME_CLASS(CBrdEditView), NULL };
+static const CRuntimeClass *tblBrd[] = {
+    RUNTIME_CLASS(CBrdEditView), RUNTIME_CLASS(CBrdEditViewContainer),
+    NULL
+};
 
 void CGamDoc::OnIdle(BOOL bActive)
 {

--- a/GM/PalColor.cpp
+++ b/GM/PalColor.cpp
@@ -155,6 +155,7 @@ wxBEGIN_EVENT_TABLE(CColorPalette, wxPanel)
     EVT_LEFT_UP(OnLButtonUp)
     EVT_RIGHT_UP(OnRButtonUp)
     EVT_LEFT_DCLICK(OnLButtonDblClk)
+    EVT_MOUSE_CAPTURE_LOST(OnMouseCaptureLost)
     EVT_COMMAND(wxID_ANY, WM_PALETTE_HIDE_WX, OnPaletteHide)
 wxEND_EVENT_TABLE()
 
@@ -1011,6 +1012,13 @@ void CColorPalette::OnRButtonUp(wxMouseEvent& event)
     }
 
     event.Skip();
+}
+
+void CColorPalette::OnMouseCaptureLost(wxMouseCaptureLostEvent& /*event*/)
+{
+    m_bTrackHue = FALSE;
+    m_bTrackSV = FALSE;
+    m_bIgnoreRButtonUp = FALSE;
 }
 
 /////////////////////////////////////////////////////////////////////////////

--- a/GM/PalColor.h
+++ b/GM/PalColor.h
@@ -249,6 +249,7 @@ protected:
     void OnLButtonUp(wxMouseEvent& event);
     void OnRButtonUp(wxMouseEvent& event);
     void OnLButtonDblClk(wxMouseEvent& event);
+    void OnMouseCaptureLost(wxMouseCaptureLostEvent& event);
     void OnPaletteHide(wxCommandEvent& event);
 
     wxDECLARE_EVENT_TABLE();

--- a/GM/SelObjs.cpp
+++ b/GM/SelObjs.cpp
@@ -636,7 +636,7 @@ void CSelList::Open()
     if (pSel.m_pObj->GetType() != CDrawObj::drawText)
         return;
     CText& pDObj = static_cast<CText&>(*pSel.m_pObj);
-    m_pView->DoEditTextDrawingObject(&pDObj);
+    m_pView->DoEditTextDrawingObject(pDObj);
     pSel.InvalidateHandles();
     pSel.m_rect = pDObj.GetEnclosingRect();
     pSel.InvalidateHandles();

--- a/GM/SelObjs.cpp
+++ b/GM/SelObjs.cpp
@@ -30,6 +30,7 @@
 #include    "SelObjs.h"
 #include    "VwEdtbrd.h"
 #include    "ClipBrd.h"
+#include    "CDib.h"
 
 #ifdef _DEBUG
 #undef THIS_FILE
@@ -88,14 +89,17 @@ void CSelection::InvalidateHandles()
     int n = GetHandleCount();
     for (int i = 0; i < n; i++)
     {
+#if 0
         CRect rct = GetHandleRect(i);
         m_pView->InvalidateWorkspaceRect(&rct, FALSE);
+#endif
     }
 }
 
 // Returns handle rectangle in logical coords.
 CRect CSelection::GetHandleRect(int nHandleID) const
 {
+#if 0
     // Get the center of the handle in logical coords
     CPoint point = GetHandleLoc(nHandleID);
 
@@ -108,13 +112,18 @@ CRect CSelection::GetHandleRect(int nHandleID) const
     m_pView->ClientToWorkspace(rect);
 
     return rect;
+#else
+return CRect();
+#endif
 }
 
 void CSelection::Invalidate()
 {
+#if 0
     CRect rct = m_rect;
     rct = m_pObj->GetEnclosingRect();
     m_pView->InvalidateWorkspaceRect(&rct, FALSE);
+#endif
 }
 
 //=---------------------------------------------------=//
@@ -221,11 +230,13 @@ void CSelRect::UpdateObject(BOOL bInvalidate,
     {
         CRect rctA = pObj.GetEnclosingRect();
         CRect rctB = pObj.GetRect();
+#if 0
         m_pView->WorkspaceToClient(rctB);
         rctB.InflateRect(handleHalfWidth, handleHalfWidth);
         m_pView->ClientToWorkspace(rctB);
         rctA |= rctB;               // Make sure we erase the handles
         m_pView->InvalidateWorkspaceRect(&rctA);
+#endif
     }
     if (bUpdateObjectExtent)
     {
@@ -241,8 +252,10 @@ void CSelRect::UpdateObject(BOOL bInvalidate,
     }
     if (bInvalidate)
     {
+#if 0
         CRect rct = pObj.GetEnclosingRect();
         m_pView->InvalidateWorkspaceRect(&rct);
+#endif
     }
 }
 
@@ -338,11 +351,13 @@ void CSelLine::UpdateObject(BOOL bInvalidate,
         CRect rctB;
         pObj.GetLine(rctB.left, rctB.top, rctB.right, rctB.bottom);
         rctB.NormalizeRect();
+#if 0
         m_pView->WorkspaceToClient(rctB);
         rctB.InflateRect(handleHalfWidth, handleHalfWidth);
         m_pView->ClientToWorkspace(rctB);
         rctA |= rctB;       // Make sure we erase the handles
         m_pView->InvalidateWorkspaceRect(&rctA, FALSE);
+#endif
     }
     pObj.SetLine(m_rect.left, m_rect.top, m_rect.right, m_rect.bottom);
     if (bUpdateObjectExtent)
@@ -358,8 +373,10 @@ void CSelLine::UpdateObject(BOOL bInvalidate,
     }
     if (bInvalidate)
     {
+#if 0
         CRect rct = pObj.GetEnclosingRect();
         m_pView->InvalidateWorkspaceRect(&rct);
+#endif
     }
 }
 
@@ -435,11 +452,13 @@ void CSelPoly::UpdateObject(BOOL bInvalidate,
     {
         CRect rctA = pObj.GetEnclosingRect();
         CRect rctB = pObj.GetRect();
+#if 0
         m_pView->WorkspaceToClient(rctB);
         rctB.InflateRect(handleHalfWidth, handleHalfWidth);
         m_pView->ClientToWorkspace(rctB);
         rctA |= rctB;               // Make sure we erase the handles
         m_pView->InvalidateWorkspaceRect(&rctA);
+#endif
     }
     if (bUpdateObjectExtent)
     {
@@ -454,8 +473,10 @@ void CSelPoly::UpdateObject(BOOL bInvalidate,
     }
     if (bInvalidate)
     {
+#if 0
         CRect rct = pObj.GetEnclosingRect();
         m_pView->InvalidateWorkspaceRect(&rct);
+#endif
     }
 }
 
@@ -492,11 +513,13 @@ void CSelGeneric::UpdateObject(BOOL bInvalidate,
     CDrawObj& pObj = static_cast<CRectObj&>(*m_pObj);
     if (bInvalidate)
     {
+#if 0
         CRect rct = pObj.GetRect();
         m_pView->WorkspaceToClient(rct);
         rct.InflateRect(handleHalfWidth, handleHalfWidth);
         m_pView->ClientToWorkspace(rct);
         m_pView->InvalidateWorkspaceRect(&rct);
+#endif
     }
     if (bUpdateObjectExtent)
     {
@@ -512,8 +535,10 @@ void CSelGeneric::UpdateObject(BOOL bInvalidate,
     }
     if (bInvalidate)
     {
+#if 0
         CRect rct = pObj.GetEnclosingRect();
         m_pView->InvalidateWorkspaceRect(&rct);
+#endif
     }
 }
 
@@ -624,7 +649,7 @@ void CSelList::CopyToClipboard()
     CSelection& pSel = *front();
     ASSERT(pSel.m_pObj->GetType() == CDrawObj::drawBitmap);
     CBitmapImage& pDObj = static_cast<CBitmapImage&>(*pSel.m_pObj);
-    SetClipboardBitmap(m_pView.get(), pDObj.m_bitmap);
+    SetClipboardBitmap(CB::Convert(pDObj.m_bitmap));
 }
 
 void CSelList::Open()
@@ -636,10 +661,12 @@ void CSelList::Open()
     if (pSel.m_pObj->GetType() != CDrawObj::drawText)
         return;
     CText& pDObj = static_cast<CText&>(*pSel.m_pObj);
+#if 0
     m_pView->DoEditTextDrawingObject(pDObj);
     pSel.InvalidateHandles();
     pSel.m_rect = pDObj.GetEnclosingRect();
     pSel.InvalidateHandles();
+#endif
 }
 
 // Assumes RECTs are normalized!!
@@ -706,7 +733,7 @@ void CSelList::InvalidateListHandles(BOOL bUpdate)
         bFoundOne = TRUE;
     }
     if (bFoundOne && bUpdate)
-        m_pView->UpdateWindow();
+        m_pView->Update();
 }
 
 void CSelList::InvalidateList(BOOL bUpdate)
@@ -720,7 +747,7 @@ void CSelList::InvalidateList(BOOL bUpdate)
         bFoundOne = TRUE;
     }
     if (bFoundOne && bUpdate)
-        m_pView->UpdateWindow();
+        m_pView->Update();
 }
 
 void CSelList::PurgeList(BOOL bInvalidate)

--- a/GM/SelObjs.cpp
+++ b/GM/SelObjs.cpp
@@ -1,6 +1,6 @@
 // SelObjs.cpp
 //
-// Copyright (c) 1994-2020 By Dale L. Larson, All Rights Reserved.
+// Copyright (c) 1994-2024 By Dale L. Larson & William Su, All Rights Reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining
 // a copy of this software and associated documentation files (the
@@ -61,6 +61,17 @@ void CSelection::DrawTracker(CDC& pDC, TrackMode eMode) const
         DrawHandles(pDC);
     else if (eMode == trkMoving || eMode == trkSizing)
         DrawTrackingImage(pDC, eMode);
+}
+
+void CSelection::DrawTracker(wxDC& pDC, TrackMode eMode) const
+{
+    wxASSERT(!"TODO:");
+#if 0
+    if (eMode == trkSelected)
+        DrawHandles(pDC);
+    else if (eMode == trkMoving || eMode == trkSizing)
+        DrawTrackingImage(pDC, eMode);
+#endif
 }
 
 void CSelection::DrawHandles(CDC& pDC) const
@@ -710,7 +721,25 @@ void CSelList::OnDraw(CDC& pDC)
         DrawTracker(pDC);
 }
 
+void CSelList::OnDraw(wxDC& pDC)
+{
+    if (m_eTrkMode == trkSelected)
+        DrawTracker(pDC);
+}
+
 void CSelList::DrawTracker(CDC& pDC, TrackMode eTrkMode)
+{
+    if (eTrkMode != trkCurrent)
+        m_eTrkMode = eTrkMode;
+
+    for (iterator pos = begin() ; pos != end() ; ++pos)
+    {
+        CSelection& pSel = **pos;
+        pSel.DrawTracker(pDC, m_eTrkMode);
+    }
+}
+
+void CSelList::DrawTracker(wxDC& pDC, TrackMode eTrkMode)
 {
     if (eTrkMode != trkCurrent)
         m_eTrkMode = eTrkMode;

--- a/GM/SelObjs.cpp
+++ b/GM/SelObjs.cpp
@@ -48,7 +48,7 @@ const int handleHalfWidth = 3;
 /////////////////////////////////////////////////////////////////////
 // Class level variables
 
-const wxPen CSelection::c_penDot(*wxWHITE, 1, wxPENSTYLE_DOT);
+const wxPen CSelection::c_penDot(*wxLIGHT_GREY, 1, wxPENSTYLE_SHORT_DASH);
 
 /////////////////////////////////////////////////////////////////////
 
@@ -121,7 +121,6 @@ void CSelection::Invalidate()
 // Static methods...
 
 CSelection::DCSetupTrackingDraw::DCSetupTrackingDraw(wxDC& pDC) :
-    setLogFunc(pDC, wxXOR),
     setPen(pDC, c_penDot),
     setBrush(pDC, *wxTRANSPARENT_BRUSH)
 {
@@ -183,7 +182,6 @@ wxPoint CSelRect::GetHandleLoc(int nHandleID) const
 
 void CSelRect::MoveHandle(int nHandle, wxPoint point)
 {
-    wxASSERT(!"TODO:  needs testing");
     // SetLeft() and SetTop() also change right and bottom
     switch (nHandle)
     {

--- a/GM/SelObjs.h
+++ b/GM/SelObjs.h
@@ -1,7 +1,7 @@
 // SelObjs.h -- contains class definitions for selection proxies. Used
 //  in concert with the selection tool.
 //
-// Copyright (c) 1994-2020 By Dale L. Larson, All Rights Reserved.
+// Copyright (c) 1994-2024 By Dale L. Larson & William Su, All Rights Reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining
 // a copy of this software and associated documentation files (the
@@ -82,7 +82,6 @@ public:
     virtual void MoveHandle(int m_nHandle, CPoint point) /* override */ {}
     virtual void Offset(CPoint ptDelta) /* override */ { m_rect += ptDelta; }
     // ------- //
-    virtual void DrawTracker(CDC& pDC, TrackMode eMode) const /* override */;
     virtual void DrawTracker(wxDC& pDC, TrackMode eMode) const /* override */;
     virtual void InvalidateHandles() /* override */;
     virtual void Invalidate() /* override */;
@@ -93,10 +92,10 @@ public:
 
 // Miscellaneous Implementer's Overrides
 protected:
-    virtual CRect GetHandleRect(int nHandleID) const /* override */;
-    virtual CPoint GetHandleLoc(int nHandleID) const /* override */ = 0;
+    virtual wxRect GetHandleRect(int nHandleID) const /* override */;
+    virtual wxPoint GetHandleLoc(int nHandleID) const /* override */ = 0;
     virtual int GetHandleCount() const /* override */ = 0;
-    virtual void DrawHandles(CDC& pDC) const /* override */;
+    virtual void DrawHandles(wxDC& pDC) const /* override */;
     virtual void DrawTrackingImage(CDC& pDC, TrackMode eMode) const /* override */ = 0;
 
 // Implementation
@@ -129,7 +128,7 @@ public:
 
 protected:
     virtual void DrawTrackingImage(CDC& pDC, TrackMode eMode) const override;
-    virtual CPoint GetHandleLoc(int nHandleID) const override;
+    virtual wxPoint GetHandleLoc(int nHandleID) const override;
     virtual int GetHandleCount() const override { return 8; }
     virtual void UpdateObject(BOOL bInvalidate = TRUE,
         BOOL bUpdateObjectExtent = TRUE) override;
@@ -170,7 +169,7 @@ public:
 
 protected:
     virtual void DrawTrackingImage(CDC& pDC, TrackMode eMode) const override;
-    virtual CPoint GetHandleLoc(int nHandleID) const override;
+    virtual wxPoint GetHandleLoc(int nHandleID) const override;
     virtual int GetHandleCount() const override { return 2; }
     virtual void UpdateObject(BOOL bInvalidate = TRUE,
         BOOL bUpdateObjectExtent = TRUE) override;
@@ -200,7 +199,7 @@ public:
 
 protected:
     virtual void DrawTrackingImage(CDC& pDC, TrackMode eMode) const override;
-    virtual CPoint GetHandleLoc(int nHandleID) const override;
+    virtual wxPoint GetHandleLoc(int nHandleID) const override;
     virtual int GetHandleCount() const override
         { return value_preserving_cast<int>(static_cast<const CPolyObj&>(*m_pObj).m_Pnts.size()); }
     virtual void UpdateObject(BOOL bInvalidate = TRUE,
@@ -227,7 +226,7 @@ public:
 
 protected:
     virtual void DrawTrackingImage(CDC& pDC, TrackMode eMode) const override;
-    virtual CPoint GetHandleLoc(int nHandleID) const override;
+    virtual wxPoint GetHandleLoc(int nHandleID) const override;
     virtual int GetHandleCount() const override { return 4; }
     virtual void UpdateObject(BOOL bInvalidate = TRUE,
         BOOL bUpdateObjectExtent = TRUE) override;
@@ -294,9 +293,7 @@ public:
     void ClearDObjFlagInAllSelectedObjects(DWORD dwFlag);
 
     // -------- //
-    void OnDraw(CDC& pDC);  // Called by view OnDraw()
     void OnDraw(wxDC& pDC);  // Called by view OnDraw()
-    void DrawTracker(CDC& pDC, TrackMode eTrkMode = trkCurrent);
     void DrawTracker(wxDC& pDC, TrackMode eTrkMode = trkCurrent);
     // -------- //
     void UpdateObjects(BOOL bInvalidate = TRUE,

--- a/GM/SelObjs.h
+++ b/GM/SelObjs.h
@@ -83,6 +83,7 @@ public:
     virtual void Offset(CPoint ptDelta) /* override */ { m_rect += ptDelta; }
     // ------- //
     virtual void DrawTracker(CDC& pDC, TrackMode eMode) const /* override */;
+    virtual void DrawTracker(wxDC& pDC, TrackMode eMode) const /* override */;
     virtual void InvalidateHandles() /* override */;
     virtual void Invalidate() /* override */;
     virtual void UpdateObject(BOOL bInvalidate = TRUE,
@@ -294,7 +295,9 @@ public:
 
     // -------- //
     void OnDraw(CDC& pDC);  // Called by view OnDraw()
+    void OnDraw(wxDC& pDC);  // Called by view OnDraw()
     void DrawTracker(CDC& pDC, TrackMode eTrkMode = trkCurrent);
+    void DrawTracker(wxDC& pDC, TrackMode eTrkMode = trkCurrent);
     // -------- //
     void UpdateObjects(BOOL bInvalidate = TRUE,
         BOOL bUpdateObjectExtent = TRUE );

--- a/GM/SelObjs.h
+++ b/GM/SelObjs.h
@@ -107,7 +107,6 @@ protected:
     public:
         DCSetupTrackingDraw(wxDC& pDC);
     private:
-        CB::DCLogicalFunctionChanger setLogFunc;
         wxDCPenChanger setPen;
         wxDCBrushChanger setBrush;
     };

--- a/GM/ToolImag.cpp
+++ b/GM/ToolImag.cpp
@@ -109,6 +109,10 @@ void CImageTool::OnLButtonUp(CBitEditView& pView, int /*nMods*/, wxPoint /*point
     pView.ReleaseMouse();
 }
 
+void CImageTool::OnMouseCaptureLost(CBitEditView& pView)
+{
+}
+
 ////////////////////////////////////////////////////////////////////////
 // CBitSelectTool
 
@@ -235,6 +239,19 @@ void CBitSelectTool::OnLButtonUp(CBitEditView& pView, int nMods,
     CImageTool::OnLButtonUp(pView, nMods, point);
 }
 
+void CBitSelectTool::OnMouseCaptureLost(CBitEditView& pView)
+{
+    pView.InvalidateFocusBorder();
+    if (!m_bMoveMode)
+    {
+        pView.SetViewImageFromMasterImage();   // Restore original
+        pView.InvalidateViewImage(false);
+    }
+
+    pView.SetSelectToolControl(FALSE);
+    CImageTool::OnMouseCaptureLost(pView);
+}
+
 wxCursor CBitSelectTool::OnSetCursor(CBitEditView& pView, wxPoint point)
 {
     // If the point is in the selected rect, show the move image cursor.
@@ -281,6 +298,14 @@ void CBitPencilTool::OnLButtonUp(CBitEditView& pView, int nMods,
     CImageTool::OnLButtonUp(pView, nMods, point);
 }
 
+void CBitPencilTool::OnMouseCaptureLost(CBitEditView& pView)
+{
+    pView.InvalidateFocusBorder();
+    pView.SetViewImageFromMasterImage();   // Restore original
+    pView.InvalidateViewImage(false);
+    CImageTool::OnMouseCaptureLost(pView);
+}
+
 wxCursor CBitPencilTool::OnSetCursor(CBitEditView& pView, wxPoint point)
 {
     if (!pView.IsPtInImage(point))
@@ -318,6 +343,13 @@ void CBitLineTool::OnLButtonUp(CBitEditView& pView, int nMods,
         return;
     pView.SetMasterImageFromViewImage();
     CImageTool::OnLButtonUp(pView, nMods, point);
+}
+
+void CBitLineTool::OnMouseCaptureLost(CBitEditView& pView)
+{
+    pView.SetViewImageFromMasterImage();   // Restore original
+    pView.InvalidateViewImage(false);
+    CImageTool::OnMouseCaptureLost(pView);
 }
 
 wxCursor CBitLineTool::OnSetCursor(CBitEditView& pView, wxPoint point)
@@ -364,6 +396,12 @@ void CBitDropperTool::OnLButtonUp(CBitEditView& pView, int nMods,
     pView.RestoreLastTool();           // For convenience.
 }
 
+void CBitDropperTool::OnMouseCaptureLost(CBitEditView& pView)
+{
+    pView.RestoreLastTool();           // For convenience.
+    CImageTool::OnMouseCaptureLost(pView);
+}
+
 wxCursor CBitDropperTool::OnSetCursor(CBitEditView& pView, wxPoint point)
 {
     return g_res.hcrDropperWx;
@@ -404,6 +442,13 @@ void CBitRectTool::OnLButtonUp(CBitEditView& pView, int nMods,
         return;
     pView.SetMasterImageFromViewImage();
     CImageTool::OnLButtonUp(pView, nMods, point);
+}
+
+void CBitRectTool::OnMouseCaptureLost(CBitEditView& pView)
+{
+    pView.SetViewImageFromMasterImage();   // Restore original
+    pView.InvalidateViewImage(false);
+    CImageTool::OnMouseCaptureLost(pView);
 }
 
 wxCursor CBitRectTool::OnSetCursor(CBitEditView& pView, wxPoint point)
@@ -449,6 +494,13 @@ void CBitOvalTool::OnLButtonUp(CBitEditView& pView, int nMods,
         return;
     pView.SetMasterImageFromViewImage();
     CImageTool::OnLButtonUp(pView, nMods, point);
+}
+
+void CBitOvalTool::OnMouseCaptureLost(CBitEditView& pView)
+{
+    pView.SetViewImageFromMasterImage();   // Restore original
+    pView.InvalidateViewImage(false);
+    CImageTool::OnMouseCaptureLost(pView);
 }
 
 wxCursor CBitOvalTool::OnSetCursor(CBitEditView& pView, wxPoint point)

--- a/GM/ToolImag.cpp
+++ b/GM/ToolImag.cpp
@@ -370,7 +370,7 @@ void CBitDropperTool::OnLButtonDown(CBitEditView& pView, int nMods,
     pView.GetImagePixelLoc(point);
     wxColour crPxl = GetPixel(pView.GetCurrentViewBitmap(),
                                 point.x, point.y);
-    if ((nMods & (wxMOD_CMD | wxMOD_SHIFT)) == 0)
+    if ((nMods & (wxMOD_CONTROL | wxMOD_SHIFT)) == 0)
         pView.SetForeColor(crPxl);
     else if (nMods & wxMOD_SHIFT)
         pView.SetBackColor(crPxl);
@@ -387,7 +387,7 @@ void CBitDropperTool::OnLButtonUp(CBitEditView& pView, int nMods,
     wxColour crPxl = GetPixel(pView.GetCurrentViewBitmap(),
                                 point.x, point.y);
 
-    if ((nMods & (wxMOD_CMD | wxMOD_SHIFT)) == 0)
+    if ((nMods & (wxMOD_CONTROL | wxMOD_SHIFT)) == 0)
         pView.SetForeColor(crPxl);
     else if (nMods & wxMOD_SHIFT)
         pView.SetBackColor(crPxl);

--- a/GM/ToolImag.h
+++ b/GM/ToolImag.h
@@ -50,6 +50,7 @@ public:
     virtual void OnLButtonDown(CBitEditView& pView, int nMods, wxPoint point) /* override */;
     virtual void OnLButtonUp(CBitEditView& pView, int nMods, wxPoint point) /* override */;
     virtual void OnMouseMove(CBitEditView& pView, int nMods, wxPoint point) /* override */;
+    virtual void OnMouseCaptureLost(CBitEditView& pView) /* override */;
     virtual wxCursor OnSetCursor(CBitEditView& /*pView*/, wxPoint /*point*/) /* override */
         { return wxNullCursor; }
 
@@ -81,6 +82,7 @@ public:
     void OnLButtonDown(CBitEditView& pView, int nMods, wxPoint point) override;
     void OnLButtonUp(CBitEditView& pView, int nMods, wxPoint point) override;
     void OnMouseMove(CBitEditView& pView, int nMods, wxPoint point) override;
+    void OnMouseCaptureLost(CBitEditView& pView) override;
     wxCursor OnSetCursor(CBitEditView& pView, wxPoint point) override;
 
 // Implementation
@@ -106,6 +108,7 @@ public:
     void OnLButtonDown(CBitEditView& pView, int nMods, wxPoint point) override;
     void OnLButtonUp(CBitEditView& pView, int nMods, wxPoint point) override;
     void OnMouseMove(CBitEditView& pView, int nMods, wxPoint point) override;
+    void OnMouseCaptureLost(CBitEditView& pView) override;
     wxCursor OnSetCursor(CBitEditView& pView, wxPoint point) override;
 
 // Implementation
@@ -129,6 +132,7 @@ public:
     void OnLButtonDown(CBitEditView& pView, int nMods, wxPoint point) override;
     void OnLButtonUp(CBitEditView& pView, int nMods, wxPoint point) override;
     void OnMouseMove(CBitEditView& pView, int nMods, wxPoint point) override;
+    void OnMouseCaptureLost(CBitEditView& pView) override;
     wxCursor OnSetCursor(CBitEditView& pView, wxPoint point) override;
 
 // Implementation
@@ -221,6 +225,7 @@ public:
     void OnLButtonDown(CBitEditView& pView, int nMods, wxPoint point) override;
     void OnLButtonUp(CBitEditView& pView, int nMods, wxPoint point) override;
     void OnMouseMove(CBitEditView& pView, int nMods, wxPoint point) override;
+    void OnMouseCaptureLost(CBitEditView& pView) override;
     wxCursor OnSetCursor(CBitEditView& pView, wxPoint point) override;
 
 // Implementation
@@ -244,6 +249,7 @@ public:
     void OnLButtonDown(CBitEditView& pView, int nMods, wxPoint point) override;
     void OnLButtonUp(CBitEditView& pView, int nMods, wxPoint point) override;
     void OnMouseMove(CBitEditView& pView, int nMods, wxPoint point) override;
+    void OnMouseCaptureLost(CBitEditView& pView) override;
     wxCursor OnSetCursor(CBitEditView& pView, wxPoint point) override;
 
 // Implementation
@@ -267,6 +273,7 @@ public:
     void OnLButtonDown(CBitEditView& pView, int nMods, wxPoint point) override;
     void OnLButtonUp(CBitEditView& pView, int nMods, wxPoint point) override;
 //  void OnMouseMove(CBitEditView& pView, int nMods, wxPoint point) override {}
+    void OnMouseCaptureLost(CBitEditView& pView) override;
     wxCursor OnSetCursor(CBitEditView& pView, wxPoint point) override;
 
 // Implementation

--- a/GM/ToolObjs.cpp
+++ b/GM/ToolObjs.cpp
@@ -118,7 +118,7 @@ void CSelectTool::OnLButtonDown(CBrdEditView& pView, UINT nFlags,
     CSelList& pSLst = pView.GetSelectList();
     // If a a handle is clicked on, immediately start tracking the
     // resize.
-    if ((m_nHandleID = pSLst.HitTestHandles(point)) >= 0)
+    if ((m_nHandleID = pSLst.HitTestHandles(CB::Convert(point))) >= 0)
     {
         StartSizingOperation(pView, nFlags, point);
         return;
@@ -575,12 +575,12 @@ void CSelectTool::MoveSelections(CSelList& pSLst, CPoint point)
     if (m_eSelMode == smodeMove)
     {
         CPoint ptDelta = (CPoint)(point - c_ptLast);
-        pSLst.Offset(ptDelta);
+        pSLst.Offset(CB::Convert(ptDelta));
         if (!m_rectMultiBorder.IsRectNull())
             m_rectMultiBorder += ptDelta;
     }
     else
-        pSLst.MoveHandle(m_nHandleID, point);
+        pSLst.MoveHandle(m_nHandleID, CB::Convert(point));
 }
 
 BOOL CSelectTool::AdjustPoint(const CBrdEditView& pView, CPoint& point) const

--- a/GM/ToolObjs.cpp
+++ b/GM/ToolObjs.cpp
@@ -422,30 +422,6 @@ void CSelectTool::MoveSelections(CSelList& pSLst, wxPoint point)
         pSLst.MoveHandle(m_nHandleID, point);
 }
 
-BOOL CSelectTool::AdjustPoint(const CBrdEditView& pView, wxPoint& point) const
-{
-    wxASSERT(!"TODO:");
-#if 0
-    pView.AdjustPoint(point);
-    if (point == c_ptLast)
-        return FALSE;
-    if (m_eSelMode == smodeMove)
-    {
-        CRect rct = pView.GetSelectList().GetEnclosingRect();
-        CPoint pnt = pView.GetWorkspaceDim();
-        if (rct.left + point.x - c_ptLast.x < 0)        // Clamp
-            point.x = c_ptLast.x - rct.left;
-        if (rct.top + point.y - c_ptLast.y < 0)         // Clamp
-            point.y = c_ptLast.y - rct.top;
-        if (rct.right + point.x - c_ptLast.x > pnt.x)   // Clamp
-            point.x = pnt.x - (rct.right - c_ptLast.x);
-        if (rct.bottom + point.y - c_ptLast.y > pnt.y)  // Clamp
-            point.y = pnt.y - (rct.bottom - c_ptLast.y);
-    }
-#endif
-    return TRUE;
-}
-
 void CSelectTool::StartDragTimer(CBrdEditView& pView)
 {
     wxASSERT(!pView.GetTimer().IsRunning());

--- a/GM/ToolObjs.cpp
+++ b/GM/ToolObjs.cpp
@@ -984,13 +984,13 @@ BOOL CCellPaintTool::OnSetCursor(CBrdEditView* pView, UINT nHitTest)
 void CPaintTool::OnLButtonDown(CBrdEditView* pView, UINT nFlags,
     CPoint point)
 {
-    if (pView->m_pBoard->GetMaxDrawLayer() == LAYER_BASE)
+    if (pView->GetBoard()->GetMaxDrawLayer() == LAYER_BASE)
         pView->SetBoardBackColor(pView->GetForeColor(), TRUE);
 }
 
 BOOL CPaintTool::OnSetCursor(CBrdEditView* pView, UINT nHitTest)
 {
-    if (pView->m_pBoard->GetMaxDrawLayer() != LAYER_BASE)
+    if (pView->GetBoard()->GetMaxDrawLayer() != LAYER_BASE)
         return FALSE;
     if (nHitTest != HTCLIENT)
         return FALSE;
@@ -1005,7 +1005,7 @@ void CTileTool::OnLButtonDown(CBrdEditView* pView, UINT nFlags,
     CPoint point)
 {
     TileID tid = pView->GetDocument()->GetTilePalWnd()->GetCurrentTileID();
-    if (pView->m_pBoard->GetMaxDrawLayer() == LAYER_GRID)
+    if (pView->GetBoard()->GetMaxDrawLayer() == LAYER_GRID)
         pView->SetCellTile(tid, point, TRUE);
     else
     {
@@ -1018,7 +1018,7 @@ void CTileTool::OnLButtonDown(CBrdEditView* pView, UINT nFlags,
 void CTileTool::OnMouseMove(CBrdEditView* pView, UINT nFlags, CPoint point)
 {
     if ((nFlags & MK_LBUTTON) != 0 &&
-        pView->m_pBoard->GetMaxDrawLayer() == LAYER_GRID)
+        pView->GetBoard()->GetMaxDrawLayer() == LAYER_GRID)
     {
         TileID tid = pView->GetDocument()->GetTilePalWnd()->GetCurrentTileID();
         pView->SetCellTile(tid, point, TRUE);

--- a/GM/ToolObjs.cpp
+++ b/GM/ToolObjs.cpp
@@ -89,7 +89,7 @@ CTool& CTool::GetTool(ToolType eToolType)
 
 void CTool::OnLButtonDown(CBrdEditView& pView, UINT nFlags, CPoint point)
 {
-    pView.SetCapture();
+    pView.CaptureMouse();
 
     c_ptDown = point;
     c_ptLast = point;
@@ -97,16 +97,16 @@ void CTool::OnLButtonDown(CBrdEditView& pView, UINT nFlags, CPoint point)
 
 void CTool::OnMouseMove(CBrdEditView& pView, UINT nFlags, CPoint point)
 {
-    if (CWnd::GetCapture() == &pView)
+    if (pView.HasCapture())
         c_ptLast = point;
 //    SetCursor(AfxGetApp()->LoadStandardCursor(IDC_ARROW));
 }
 
 void CTool::OnLButtonUp(CBrdEditView& pView, UINT, CPoint point)
 {
-    if (CWnd::GetCapture() != &pView)
+    if (!pView.HasCapture())
         return;
-    ReleaseCapture();
+    pView.ReleaseMouse();
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -123,6 +123,8 @@ void CSelectTool::OnLButtonDown(CBrdEditView& pView, UINT nFlags,
         StartSizingOperation(pView, nFlags, point);
         return;
     }
+    wxASSERT(!"TODO:");
+#if 0
     CDrawObj* pObj = pView.ObjectHitTest(point);
     if (pObj == NULL)
     {
@@ -179,15 +181,18 @@ void CSelectTool::OnLButtonDown(CBrdEditView& pView, UINT nFlags,
         m_rectMultiBorder.InflateRect(2, 2);
     }
     StartDragTimer(pView);
+#endif
 }
 
 void CSelectTool::OnMouseMove(CBrdEditView& pView, UINT nFlags, CPoint point)
 {
     CSelList& pSLst = pView.GetSelectList();
 
-    if (CWnd::GetCapture() != &pView)
+    if (!pView.HasCapture())
         return;
 
+    wxASSERT(!"TODO:");
+#if 0
     if (m_eSelMode != smodeNormal)
     {
         // Autoscroll initiate possibility processing (sounds like a
@@ -292,11 +297,14 @@ void CSelectTool::OnMouseMove(CBrdEditView& pView, UINT nFlags, CPoint point)
             pSLst.DrawTracker(dc, eTrkMode); // Erase previous tracker
     }
     c_ptLast = point;               // Save new 'last' position
+#endif
 }
 
 void CSelectTool::OnLButtonUp(CBrdEditView& pView, UINT nFlags, CPoint point)
 {
-    if (CWnd::GetCapture() == &pView)
+    wxASSERT(!"TODO:");
+#if 0
+    if (pView.HasCapture())
     {
         if (m_eSelMode == smodeNet)
         {
@@ -334,13 +342,16 @@ void CSelectTool::OnLButtonUp(CBrdEditView& pView, UINT nFlags, CPoint point)
     m_eSelMode = smodeNormal;
     KillDragTimer(pView);           // Make sure timers are released
     KillScrollTimer(pView);
+#endif
     m_rectMultiBorder.SetRectEmpty();// Make sure trigger rect is empty
     CTool::OnLButtonUp(pView, nFlags, point);
 }
 
 void CSelectTool::OnTimer(CBrdEditView& pView, uintptr_t nIDEvent)
 {
-    if (CWnd::GetCapture() != &pView)
+    wxASSERT(!"TODO:");
+#if 0
+    if (!pView.HasCapture())
     {
         m_eSelMode = smodeNormal;
         KillDragTimer(pView);
@@ -386,6 +397,7 @@ void CSelectTool::OnTimer(CBrdEditView& pView, uintptr_t nIDEvent)
         if (!ProcessAutoScroll(pView))
             KillScrollTimer(pView);
     }
+#endif
 }
 
 void CSelectTool::OnLButtonDblClk(CBrdEditView& pView, UINT nFlags,
@@ -400,6 +412,8 @@ void CSelectTool::OnLButtonDblClk(CBrdEditView& pView, UINT nFlags,
 
 BOOL CSelectTool::OnSetCursor(const CBrdEditView& pView, UINT nHitTest) const
 {
+    wxASSERT(!"TODO:");
+#if 0
     // Process only within the client area
     if (nHitTest != HTCLIENT)
         return FALSE;
@@ -425,6 +439,7 @@ BOOL CSelectTool::OnSetCursor(const CBrdEditView& pView, UINT nHitTest) const
             return TRUE;
         }
     }
+#endif
     return FALSE;       // Show default cursor
 }
 
@@ -435,10 +450,13 @@ void CSelectTool::StartSizingOperation(CBrdEditView& pView, UINT nFlags,
     if (nHandleID != -1)
         m_nHandleID = nHandleID;
     m_eSelMode = smodeSizing;
+    wxASSERT(!"TODO:");
+#if 0
     CTool::OnLButtonDown(pView, nFlags, point);
     CClientDC dc(&pView);
     pView.OnPrepareScaledDC(dc);
     pSLst.DrawTracker(dc, trkSizing);
+#endif
 }
 
 void CSelectTool::DrawSelectionRect(CDC& pDC, const CRect& pRct) const
@@ -467,6 +485,8 @@ void CSelectTool::DrawNetRect(CDC& pDC, CBrdEditView& /*pView*/) const
 
 BOOL CSelectTool::ProcessAutoScroll(CBrdEditView& pView)
 {
+    wxASSERT(!"TODO:");
+#if 0
     CPoint point;
     CRect  rectClient;
     CRect  rect;
@@ -546,6 +566,7 @@ BOOL CSelectTool::ProcessAutoScroll(CBrdEditView& pView)
             return TRUE;
         }
     }
+#endif
     return FALSE;
 }
 
@@ -564,6 +585,8 @@ void CSelectTool::MoveSelections(CSelList& pSLst, CPoint point)
 
 BOOL CSelectTool::AdjustPoint(const CBrdEditView& pView, CPoint& point) const
 {
+    wxASSERT(!"TODO:");
+#if 0
     pView.AdjustPoint(point);
     if (point == c_ptLast)
         return FALSE;
@@ -580,36 +603,49 @@ BOOL CSelectTool::AdjustPoint(const CBrdEditView& pView, CPoint& point) const
         if (rct.bottom + point.y - c_ptLast.y > pnt.y)  // Clamp
             point.y = pnt.y - (rct.bottom - c_ptLast.y);
     }
+#endif
     return TRUE;
 }
 
 void CSelectTool::StartDragTimer(CBrdEditView& pView)
 {
+    wxASSERT(!"TODO:");
+#if 0
     m_nTimerID = pView.SetTimer(timerIDSelectDelay,
         timerSelDelay, NULL);
+#endif
 }
 
 void CSelectTool::KillDragTimer(CBrdEditView& pView)
 {
+    wxASSERT(!"TODO:");
+#if 0
     if (m_nTimerID != uintptr_t(0))
     {
         pView.KillTimer(m_nTimerID);
         m_nTimerID = uintptr_t(0);
     }
+#endif
 }
 
 void CSelectTool::StartScrollTimer(CBrdEditView& pView)
 {
+    wxASSERT(!"TODO:");
+#if 0
     m_nTimerID = pView.SetTimer(timerIDAutoScroll, timerAutoScroll, NULL);
+#endif
 }
 
 void CSelectTool::KillScrollTimer(CBrdEditView& pView)
 {
+    wxASSERT(!"TODO:");
+#if 0
     if (m_nTimerID != uintptr_t(0))
     {
         pView.KillTimer(m_nTimerID);
         m_nTimerID = uintptr_t(0);
     }
+#endif
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -617,6 +653,8 @@ void CSelectTool::KillScrollTimer(CBrdEditView& pView)
 
 void CShapeTool::OnLButtonDown(CBrdEditView& pView, UINT nFlags, CPoint point)
 {
+    wxASSERT(!"TODO:");
+#if 0
     CSelList& pSLst = pView.GetSelectList();
     pSLst.PurgeList(TRUE);         // Clear current select list
     int nDragHandle;
@@ -624,14 +662,17 @@ void CShapeTool::OnLButtonDown(CBrdEditView& pView, UINT nFlags, CPoint point)
     m_pObj = CreateDrawObj(pView, point, nDragHandle);
     pSLst.AddObject(*m_pObj, TRUE);
     s_selectTool.StartSizingOperation(pView, nFlags, point, nDragHandle);
+#endif
 }
 
 void CShapeTool::OnLButtonUp(CBrdEditView& pView, UINT nFlags, CPoint point)
 {
-    if (CWnd::GetCapture() != &pView)
+    if (!pView.HasCapture())
         return;
     s_selectTool.OnLButtonUp(pView, nFlags, point);
     pView.GetSelectList().PurgeList(TRUE); // Clear current select list
+    wxASSERT(!"TODO:");
+#if 0
     if (!IsEmptyObject())
         pView.AddDrawObject(std::move(m_pObj));
     else
@@ -639,11 +680,12 @@ void CShapeTool::OnLButtonUp(CBrdEditView& pView, UINT nFlags, CPoint point)
         m_pObj = nullptr;
     }
     pView.ResetToDefaultTool();
+#endif
 }
 
 void CShapeTool::OnMouseMove(CBrdEditView& pView, UINT nFlags, CPoint point)
 {
-    if (CWnd::GetCapture() == &pView)
+    if (pView.HasCapture())
         s_selectTool.OnMouseMove(pView, nFlags, point);
 }
 
@@ -668,8 +710,8 @@ CDrawObj::OwnerPtr CRectTool::CreateDrawObj(const CBrdEditView& pView, CPoint po
 {
     CRectObj::OwnerPtr pObj = new CRectObj;
     pObj->SetRect(CRect(point, CSize(0,0)));
-    pObj->SetForeColor(pView.GetForeColor());
-    pObj->SetBackColor(pView.GetBackColor());
+    pObj->SetForeColor(CB::Convert(pView.GetForeColor()));
+    pObj->SetBackColor(CB::Convert(pView.GetBackColor()));
     pObj->SetLineWidth(pView.GetLineWidth());
     nHandle = hitBottomRight;
     return pObj;
@@ -678,7 +720,7 @@ CDrawObj::OwnerPtr CRectTool::CreateDrawObj(const CBrdEditView& pView, CPoint po
 BOOL CRectTool::IsEmptyObject() const
 {
     wxASSERT(m_pObj && dynamic_cast<const CRectObj*>(&*m_pObj));
-    return ((const CRectObj&)*m_pObj).GetRect().IsRectEmpty();
+    return static_cast<const CRectObj&>(*m_pObj).GetRect().IsRectEmpty();
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -689,8 +731,8 @@ CDrawObj::OwnerPtr CEllipseTool::CreateDrawObj(const CBrdEditView& pView, CPoint
 {
     CEllipse::OwnerPtr pObj = new CEllipse;
     pObj->SetRect(CRect(point, CSize(0,0)));
-    pObj->SetForeColor(pView.GetForeColor());
-    pObj->SetBackColor(pView.GetBackColor());
+    pObj->SetForeColor(CB::Convert(pView.GetForeColor()));
+    pObj->SetBackColor(CB::Convert(pView.GetBackColor()));
     pObj->SetLineWidth(pView.GetLineWidth());
     nHandle = hitBottomRight;
     return pObj;
@@ -699,7 +741,7 @@ CDrawObj::OwnerPtr CEllipseTool::CreateDrawObj(const CBrdEditView& pView, CPoint
 BOOL CEllipseTool::IsEmptyObject() const
 {
     wxASSERT(m_pObj && dynamic_cast<const CEllipse*>(&*m_pObj));
-    return ((const CEllipse&)*m_pObj).GetRect().IsRectEmpty();
+    return static_cast<const CEllipse&>(*m_pObj).GetRect().IsRectEmpty();
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -710,7 +752,7 @@ CDrawObj::OwnerPtr CLineTool::CreateDrawObj(const CBrdEditView& pView, CPoint po
 {
     OwnerPtr<CLine> pObj = new CLine;
     pObj->SetLine(point.x, point.y, point.x, point.y);
-    pObj->SetForeColor(pView.GetForeColor());
+    pObj->SetForeColor(CB::Convert(pView.GetForeColor()));
     pObj->SetLineWidth(pView.GetLineWidth());
     nHandle = hitPtB;
     return pObj;
@@ -719,7 +761,7 @@ CDrawObj::OwnerPtr CLineTool::CreateDrawObj(const CBrdEditView& pView, CPoint po
 BOOL CLineTool::IsEmptyObject() const
 {
     wxASSERT(m_pObj && dynamic_cast<const CLine*>(&*m_pObj));
-    CRect rct = ((const CLine&)*m_pObj).GetRect();
+    CRect rct = static_cast<const CLine&>(*m_pObj).GetRect();
     return rct.Width() < 3 && rct.Height() < 3;
 }
 
@@ -728,6 +770,8 @@ BOOL CLineTool::IsEmptyObject() const
 
 void CPolyTool::OnLButtonDown(CBrdEditView& pView, UINT nFlags, CPoint point)
 {
+    wxASSERT(!"TODO:");
+#if 0
     CRect rctClient;
     pView.GetClientRect(&rctClient);
     CPoint pntClient(point);
@@ -768,7 +812,7 @@ void CPolyTool::OnLButtonDown(CBrdEditView& pView, UINT nFlags, CPoint point)
             if (pnt == point)
             {
                 FinalizePolygon(pView);
-                ReleaseCapture();
+                pView->ReleaseMouse();
                 return;
             }
             m_pObj->AddPoint(point);
@@ -780,10 +824,13 @@ void CPolyTool::OnLButtonDown(CBrdEditView& pView, UINT nFlags, CPoint point)
             m_pObj->Draw(dc, pView.GetCurrentScale());
 //      }
     }
+#endif
 }
 
 void CPolyTool::OnLButtonDblClk(CBrdEditView& pView, UINT nFlags, CPoint point)
 {
+    wxASSERT(!"TODO:");
+#if 0
     CRect rctClient;
     pView.GetClientRect(&rctClient);
     CPoint pntClient(point);
@@ -797,15 +844,18 @@ void CPolyTool::OnLButtonDblClk(CBrdEditView& pView, UINT nFlags, CPoint point)
         DrawRubberLine(dc);                // Turn off rubber band
         FinalizePolygon(pView);
     }
-    ReleaseCapture();
+#endif
+    pView.ReleaseMouse();
 }
 
 void CPolyTool::OnMouseMove(CBrdEditView& pView, UINT nFlags, CPoint point)
 {
-    if (CWnd::GetCapture() != &pView)
+    if (!pView.HasCapture())
         return;
     if (m_pObj == NULL)
-        ReleaseCapture();
+        pView.ReleaseMouse();
+    wxASSERT(!"TODO:");
+#if 0
     CClientDC dc(&pView);
     pView.OnPrepareScaledDC(dc);
     DrawRubberLine(dc);
@@ -820,7 +870,7 @@ void CPolyTool::OnMouseMove(CBrdEditView& pView, UINT nFlags, CPoint point)
         if (pnt == point)
         {
             FinalizePolygon(pView);
-            ReleaseCapture();
+            pView->ReleaseMouse();
             return;
         }
         m_pObj->AddPoint(point);
@@ -832,6 +882,7 @@ void CPolyTool::OnMouseMove(CBrdEditView& pView, UINT nFlags, CPoint point)
     else
         c_ptLast = point;
     DrawRubberLine(dc);
+#endif
 }
 
 BOOL CPolyTool::OnSetCursor(const CBrdEditView& pView, UINT nHitTest) const
@@ -861,16 +912,21 @@ void CPolyTool::RemoveRubberBand(CBrdEditView& pView)
 {
     if (m_pObj != NULL)
     {
+        wxASSERT(!"TODO:");
+#if 0
         CClientDC dc(&pView);
         pView.OnPrepareScaledDC(dc);
         DrawRubberLine(dc);
-        ReleaseCapture();
+#endif
+        pView.ReleaseMouse();
     }
 }
 
 void CPolyTool::FinalizePolygon(CBrdEditView& pView,
     BOOL bForceDestroy /* = FALSE */)
 {
+    wxASSERT(!"TODO:");
+#if 0
     pView.ResetToDefaultTool();
     if (m_pObj == NULL)
         return;         // Nothing to do.
@@ -891,6 +947,7 @@ void CPolyTool::FinalizePolygon(CBrdEditView& pView,
         pView.InvalidateWorkspaceRect(&rct);
         pView.DeleteDrawObject(m_pObj);
     }
+#endif
     m_pObj = NULL;
 }
 
@@ -900,8 +957,11 @@ void CPolyTool::FinalizePolygon(CBrdEditView& pView,
 void CTextTool::OnLButtonDown(CBrdEditView& pView, UINT nFlags,
     CPoint point)
 {
+    wxASSERT(!"TODO:");
+#if 0
     pView.DoCreateTextDrawingObject(point);
     pView.ResetToDefaultTool();
+#endif
 }
 
 BOOL CTextTool::OnSetCursor(const CBrdEditView& pView, UINT nHitTest) const
@@ -918,6 +978,8 @@ BOOL CTextTool::OnSetCursor(const CBrdEditView& pView, UINT nHitTest) const
 void CColorPickupTool::OnLButtonDown(CBrdEditView& pView, UINT nFlags,
     CPoint point)
 {
+    wxASSERT(!"TODO:");
+#if 0
     pView.WorkspaceToClient(point);
     CWindowDC dc(&pView);
     COLORREF crPxl = dc.GetPixel(point);
@@ -926,12 +988,15 @@ void CColorPickupTool::OnLButtonDown(CBrdEditView& pView, UINT nFlags,
     else if (nFlags & MK_SHIFT)
         pView.SetBackColor(crPxl);
     pView.SetCapture();
+#endif
 }
 
 void CColorPickupTool::OnLButtonUp(CBrdEditView& pView, UINT nFlags, CPoint point)
 {
-    if (CWnd::GetCapture() != &pView)
+    if (!pView.HasCapture())
         return;
+    wxASSERT(!"TODO:");
+#if 0
     pView.WorkspaceToClient(point);
 
     CWindowDC dc(&pView);
@@ -943,7 +1008,8 @@ void CColorPickupTool::OnLButtonUp(CBrdEditView& pView, UINT nFlags, CPoint poin
         pView.SetBackColor(crPxl);
 
     pView.RestoreLastTool();               // For convenience
-    ReleaseCapture();
+#endif
+    pView.ReleaseMouse();
 }
 
 BOOL CColorPickupTool::OnSetCursor(const CBrdEditView& pView, UINT nHitTest) const
@@ -960,13 +1026,19 @@ BOOL CColorPickupTool::OnSetCursor(const CBrdEditView& pView, UINT nHitTest) con
 void CCellPaintTool::OnLButtonDown(CBrdEditView& pView, UINT nFlags,
     CPoint point)
 {
-    pView.SetCellColor(pView.GetForeColor(), point, TRUE);
+    wxASSERT(!"TODO:");
+#if 0
+    pView.SetCellColor(pView->GetForeColor(), point, TRUE);
+#endif
 }
 
 void CCellPaintTool::OnMouseMove(CBrdEditView& pView, UINT nFlags, CPoint point)
 {
+    wxASSERT(!"TODO:");
+#if 0
     if (nFlags & MK_LBUTTON)
-        pView.SetCellColor(pView.GetForeColor(), point, TRUE);
+        pView.SetCellColor(pView->GetForeColor(), point, TRUE);
+#endif
 }
 
 BOOL CCellPaintTool::OnSetCursor(const CBrdEditView& pView, UINT nHitTest) const
@@ -983,8 +1055,11 @@ BOOL CCellPaintTool::OnSetCursor(const CBrdEditView& pView, UINT nHitTest) const
 void CPaintTool::OnLButtonDown(CBrdEditView& pView, UINT nFlags,
     CPoint point)
 {
+    wxASSERT(!"TODO:");
+#if 0
     if (pView.GetBoard().GetMaxDrawLayer() == LAYER_BASE)
         pView.SetBoardBackColor(pView.GetForeColor(), TRUE);
+#endif
 }
 
 BOOL CPaintTool::OnSetCursor(const CBrdEditView& pView, UINT nHitTest) const
@@ -1004,6 +1079,8 @@ void CTileTool::OnLButtonDown(CBrdEditView& pView, UINT nFlags,
     CPoint point)
 {
     TileID tid = pView.GetDocument().GetTilePalWnd()->GetCurrentTileID();
+    wxASSERT(!"TODO:");
+#if 0
     if (pView.GetBoard().GetMaxDrawLayer() == LAYER_GRID)
         pView.SetCellTile(tid, point, TRUE);
     else
@@ -1011,16 +1088,20 @@ void CTileTool::OnLButtonDown(CBrdEditView& pView, UINT nFlags,
         CDrawList& pDwg = CheckedDeref(pView.GetDrawList(TRUE));
         pView.SetDrawingTile(pDwg, tid, point, TRUE);
     }
+#endif
 }
 
 void CTileTool::OnMouseMove(CBrdEditView& pView, UINT nFlags, CPoint point)
 {
+    wxASSERT(!"TODO:");
+#if 0
     if ((nFlags & MK_LBUTTON) != 0 &&
         pView.GetBoard().GetMaxDrawLayer() == LAYER_GRID)
     {
         TileID tid = pView.GetDocument().GetTilePalWnd()->GetCurrentTileID();
         pView.SetCellTile(tid, point, TRUE);
     }
+#endif
 }
 
 BOOL CTileTool::OnSetCursor(const CBrdEditView& pView, UINT nHitTest) const
@@ -1037,17 +1118,23 @@ BOOL CTileTool::OnSetCursor(const CBrdEditView& pView, UINT nHitTest) const
 void CCellEraserTool::OnLButtonDown(CBrdEditView& pView, UINT nFlags,
     CPoint point)
 {
+    wxASSERT(!"TODO:");
+#if 0
         pView.SetCellColor(noColor, point, TRUE);
 //      pView->SetCellTile(nullTid, point, TRUE);
+#endif
 }
 
 void CCellEraserTool::OnMouseMove(CBrdEditView& pView, UINT nFlags, CPoint point)
 {
+    wxASSERT(!"TODO:");
+#if 0
     if (nFlags & MK_LBUTTON)
     {
         pView.SetCellColor(noColor, point, TRUE);
 //      pView->SetCellTile(nullTid, point, TRUE);
     }
+#endif
 }
 
 BOOL CCellEraserTool::OnSetCursor(const CBrdEditView& pView, UINT nHitTest) const

--- a/GM/ToolObjs.h
+++ b/GM/ToolObjs.h
@@ -1,6 +1,6 @@
 // ToolObjs.h
 //
-// Copyright (c) 1994-2020 By Dale L. Larson, All Rights Reserved.
+// Copyright (c) 1994-2024 By Dale L. Larson & William Su, All Rights Reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining
 // a copy of this software and associated documentation files (the
@@ -56,13 +56,13 @@ public:
 public:
     static CTool& GetTool(ToolType eType);
     // ----------- //
-    virtual void OnLButtonDown(CBrdEditView& pView, UINT nFlags, CPoint point) /* override */;
-    virtual void OnLButtonDblClk(CBrdEditView& pView, UINT nFlags, CPoint point) /* override */ {}
-    virtual void OnLButtonUp(CBrdEditView& pView, UINT nFlags, CPoint point) /* override */;
-    virtual void OnMouseMove(CBrdEditView& pView, UINT nFlags, CPoint point) /* override */;
+    virtual void OnLButtonDown(CBrdEditView& pView, int nMods, wxPoint point) /* override */;
+    virtual void OnLButtonDblClk(CBrdEditView& pView, int nMods, wxPoint point) /* override */ {}
+    virtual void OnLButtonUp(CBrdEditView& pView, int nMods, wxPoint point) /* override */;
+    virtual void OnMouseMove(CBrdEditView& pView, int nMods, int nButs, wxPoint point) /* override */;
     virtual void OnTimer(CBrdEditView& pView, uintptr_t nIDEvent) /* override */ {}
-    virtual BOOL OnSetCursor(const CBrdEditView& pView, UINT nHitTest) const /* override */
-        { return FALSE; }
+    virtual wxCursor OnSetCursor(const CBrdEditView& pView, wxPoint point) const /* override */
+        { return wxNullCursor; }
 
 // Implementation
 private:
@@ -70,8 +70,8 @@ private:
     static std::vector<CTool*> c_toolLib;
 protected:
     // Drag related vars....
-    static CPoint c_ptDown;         // Document coords.
-    static CPoint c_ptLast;
+    static wxPoint c_ptDown;         // Document coords.
+    static wxPoint c_ptLast;
 };
 
 ////////////////////////////////////////////////////////////////////////
@@ -93,30 +93,30 @@ public:
 
 // Operations
 public:
-    void OnLButtonDown(CBrdEditView& pView, UINT nFlags, CPoint point) override;
-    void OnLButtonDblClk(CBrdEditView& pView, UINT nFlags, CPoint point) override;
-    void OnLButtonUp(CBrdEditView& pView, UINT nFlags, CPoint point) override;
-    void OnMouseMove(CBrdEditView& pView, UINT nFlags, CPoint point) override;
+    void OnLButtonDown(CBrdEditView& pView, int nMods, wxPoint point) override;
+    void OnLButtonDblClk(CBrdEditView& pView, int nMods, wxPoint point) override;
+    void OnLButtonUp(CBrdEditView& pView, int nMods, wxPoint point) override;
+    void OnMouseMove(CBrdEditView& pView, int nMods, int nButs, wxPoint point) override;
     void OnTimer(CBrdEditView& pView, uintptr_t nIDEvent) override;
-    BOOL OnSetCursor(const CBrdEditView& pView, UINT nHitTest) const override;
+    wxCursor OnSetCursor(const CBrdEditView& pView, wxPoint point) const override;
 
 // Implementation
 public:
     uintptr_t m_nTimerID;
-    CRect   m_rectMultiBorder;
+    wxRect  m_rectMultiBorder;
     // ------- //
     BOOL ProcessAutoScroll(CBrdEditView& pView);
-    void DrawSelectionRect(CDC& pDC, const CRect& pRct) const;
-    void DrawNetRect(CDC& pDC, CBrdEditView& pView) const;
-    BOOL AdjustPoint(const CBrdEditView& pView, CPoint& point) const;
-    void MoveSelections(CSelList& pSLst, CPoint point);
+    void DrawSelectionRect(wxDC& pDC, const wxRect& pRct) const;
+    void DrawNetRect(wxDC& pDC, CBrdEditView& pView) const;
+    BOOL AdjustPoint(const CBrdEditView& pView, wxPoint& point) const;
+    void MoveSelections(CSelList& pSLst, wxPoint point);
     void StartDragTimer(CBrdEditView& pView);
     void KillDragTimer(CBrdEditView& pView);
     void StartScrollTimer(CBrdEditView& pView);
     void KillScrollTimer(CBrdEditView& pView);
     // ------- //
-    void StartSizingOperation(CBrdEditView& pView, UINT nFlags,
-        CPoint point, int nHandleID = -1);
+    void StartSizingOperation(CBrdEditView& pView, int nMods,
+        wxPoint point, int nHandleID = -1);
 };
 
 ////////////////////////////////////////////////////////////////////////
@@ -130,16 +130,16 @@ public:
 
 // Operations
 public:
-    void OnLButtonDown(CBrdEditView& pView, UINT nFlags, CPoint point) override;
-    void OnLButtonDblClk(CBrdEditView& pView, UINT nFlags, CPoint point) override {}
-    void OnLButtonUp(CBrdEditView& pView, UINT nFlags, CPoint point) override;
-    void OnMouseMove(CBrdEditView& pView, UINT nFlags, CPoint point) override;
+    void OnLButtonDown(CBrdEditView& pView, int nMods, wxPoint point) override;
+    void OnLButtonDblClk(CBrdEditView& pView, int nMods, wxPoint point) override {}
+    void OnLButtonUp(CBrdEditView& pView, int nMods, wxPoint point) override;
+    void OnMouseMove(CBrdEditView& pView, int nMods, int nButs, wxPoint point) override;
     void OnTimer(CBrdEditView& pView, uintptr_t nIDEvent) override;
-    BOOL OnSetCursor(const CBrdEditView& pView, UINT nHitTest) const override;
+    wxCursor OnSetCursor(const CBrdEditView& pView, wxPoint point) const override;
 
 // Implementation
 public:
-    virtual CDrawObj::OwnerPtr CreateDrawObj(const CBrdEditView& pView, CPoint point,
+    virtual CDrawObj::OwnerPtr CreateDrawObj(const CBrdEditView& pView, wxPoint point,
         int& nHandle) const /* override */ = 0;
     virtual BOOL IsEmptyObject() const /* override */ = 0;
     // --------- //
@@ -159,7 +159,7 @@ public:
 
 // Implementation
 public:
-    CDrawObj::OwnerPtr CreateDrawObj(const CBrdEditView& pView, CPoint point,
+    CDrawObj::OwnerPtr CreateDrawObj(const CBrdEditView& pView, wxPoint point,
         int& nHandle) const override;
     BOOL IsEmptyObject() const override;
 };
@@ -175,7 +175,7 @@ public:
 
 // Implementation
 public:
-    CDrawObj::OwnerPtr CreateDrawObj(const CBrdEditView& pView, CPoint point,
+    CDrawObj::OwnerPtr CreateDrawObj(const CBrdEditView& pView, wxPoint point,
         int& nHandle) const override;
     BOOL IsEmptyObject() const override;
 };
@@ -191,7 +191,7 @@ public:
 
 // Implementation
 public:
-    CDrawObj::OwnerPtr CreateDrawObj(const CBrdEditView& pView, CPoint point,
+    CDrawObj::OwnerPtr CreateDrawObj(const CBrdEditView& pView, wxPoint point,
         int& nHandle) const override;
     BOOL IsEmptyObject() const override;
 };
@@ -207,12 +207,12 @@ public:
 
 // Operations
 public:
-    void OnLButtonDown(CBrdEditView& pView, UINT nFlags, CPoint point) override;
-    void OnLButtonDblClk(CBrdEditView& pView, UINT nFlags, CPoint point) override;
-    void OnLButtonUp(CBrdEditView& pView, UINT nFlags, CPoint point) override {}
-    void OnMouseMove(CBrdEditView& pView, UINT nFlags, CPoint point) override;
+    void OnLButtonDown(CBrdEditView& pView, int nMods, wxPoint point) override;
+    void OnLButtonDblClk(CBrdEditView& pView, int nMods, wxPoint point) override;
+    void OnLButtonUp(CBrdEditView& pView, int nMods, wxPoint point) override {}
+    void OnMouseMove(CBrdEditView& pView, int nMods, int nButs, wxPoint point) override;
     void OnTimer(CBrdEditView& pView, uintptr_t nIDEvent) override {}
-    BOOL OnSetCursor(const CBrdEditView& pView, UINT nHitTest) const override;
+    wxCursor OnSetCursor(const CBrdEditView& pView, wxPoint point) const override;
 
     // --------- //
     void RemoveRubberBand(CBrdEditView& pView);
@@ -220,7 +220,7 @@ public:
 
 // Implementation
 public:
-    void DrawRubberLine(CDC& pDC);
+    void DrawRubberLine(wxDC& pDC);
     // --------- //
     /* NOTE:  CShapeTool owns m_pObj, but CPolyTool passes
         ownership of m_pObj to CBrdEditView immediately */
@@ -238,12 +238,12 @@ public:
 
 // Operations
 public:
-    void OnLButtonDown(CBrdEditView& pView, UINT nFlags, CPoint point) override;
-    void OnLButtonDblClk(CBrdEditView& pView, UINT nFlags, CPoint point) override {}
-    void OnLButtonUp(CBrdEditView& pView, UINT nFlags, CPoint point) override {}
-    void OnMouseMove(CBrdEditView& pView, UINT nFlags, CPoint point) override {}
+    void OnLButtonDown(CBrdEditView& pView, int nMods, wxPoint point) override;
+    void OnLButtonDblClk(CBrdEditView& pView, int nMods, wxPoint point) override {}
+    void OnLButtonUp(CBrdEditView& pView, int nMods, wxPoint point) override {}
+    void OnMouseMove(CBrdEditView& pView, int nMods, int nButs, wxPoint point) override {}
     void OnTimer(CBrdEditView& pView, uintptr_t nIDEvent) override {}
-    BOOL OnSetCursor(const CBrdEditView& pView, UINT nHitTest) const override;
+    wxCursor OnSetCursor(const CBrdEditView& pView, wxPoint point) const override;
 
 // Implementation
 public:
@@ -260,12 +260,12 @@ public:
 
 // Operations
 public:
-    void OnLButtonDown(CBrdEditView& pView, UINT nFlags, CPoint point) override;
-    void OnLButtonDblClk(CBrdEditView& pView, UINT nFlags, CPoint point) override {}
-    void OnLButtonUp(CBrdEditView& pView, UINT nFlags, CPoint point) override;
-    void OnMouseMove(CBrdEditView& pView, UINT nFlags, CPoint point) override {}
+    void OnLButtonDown(CBrdEditView& pView, int nMods, wxPoint point) override;
+    void OnLButtonDblClk(CBrdEditView& pView, int nMods, wxPoint point) override {}
+    void OnLButtonUp(CBrdEditView& pView, int nMods, wxPoint point) override;
+    void OnMouseMove(CBrdEditView& pView, int nMods, int nButs, wxPoint point) override {}
     void OnTimer(CBrdEditView& pView, uintptr_t nIDEvent) override {}
-    BOOL OnSetCursor(const CBrdEditView& pView, UINT nHitTest) const override;
+    wxCursor OnSetCursor(const CBrdEditView& pView, wxPoint point) const override;
 
 // Implementation
 public:
@@ -282,12 +282,12 @@ public:
 
 // Operations
 public:
-    void OnLButtonDown(CBrdEditView& pView, UINT nFlags, CPoint point) override;
-    void OnLButtonDblClk(CBrdEditView& pView, UINT nFlags, CPoint point) override {}
-    void OnLButtonUp(CBrdEditView& pView, UINT nFlags, CPoint point) override {}
-    void OnMouseMove(CBrdEditView& pView, UINT nFlags, CPoint point) override;
+    void OnLButtonDown(CBrdEditView& pView, int nMods, wxPoint point) override;
+    void OnLButtonDblClk(CBrdEditView& pView, int nMods, wxPoint point) override {}
+    void OnLButtonUp(CBrdEditView& pView, int nMods, wxPoint point) override {}
+    void OnMouseMove(CBrdEditView& pView, int nMods, int nButs, wxPoint point) override;
     void OnTimer(CBrdEditView& pView, uintptr_t nIDEvent) override {}
-    BOOL OnSetCursor(const CBrdEditView& pView, UINT nHitTest) const override;
+    wxCursor OnSetCursor(const CBrdEditView& pView, wxPoint point) const override;
 
 // Implementation
 public:
@@ -304,12 +304,12 @@ public:
 
 // Operations
 public:
-    void OnLButtonDown(CBrdEditView& pView, UINT nFlags, CPoint point) override;
-    void OnLButtonDblClk(CBrdEditView& pView, UINT nFlags, CPoint point) override {}
-    void OnLButtonUp(CBrdEditView& pView, UINT nFlags, CPoint point) override {}
-    void OnMouseMove(CBrdEditView& pView, UINT nFlags, CPoint point) override;
+    void OnLButtonDown(CBrdEditView& pView, int nMods, wxPoint point) override;
+    void OnLButtonDblClk(CBrdEditView& pView, int nMods, wxPoint point) override {}
+    void OnLButtonUp(CBrdEditView& pView, int nMods, wxPoint point) override {}
+    void OnMouseMove(CBrdEditView& pView, int nMods, int nButs, wxPoint point) override;
     void OnTimer(CBrdEditView& pView, uintptr_t nIDEvent) override {}
-    BOOL OnSetCursor(const CBrdEditView& pView, UINT nHitTest) const override;
+    wxCursor OnSetCursor(const CBrdEditView& pView, wxPoint point) const override;
 
 // Implementation
 public:
@@ -326,12 +326,12 @@ public:
 
 // Operations
 public:
-    void OnLButtonDown(CBrdEditView& pView, UINT nFlags, CPoint point) override;
-    void OnLButtonDblClk(CBrdEditView& pView, UINT nFlags, CPoint point) override {}
-    void OnLButtonUp(CBrdEditView& pView, UINT nFlags, CPoint point) override {}
-    void OnMouseMove(CBrdEditView& pView, UINT nFlags, CPoint point) override {}
+    void OnLButtonDown(CBrdEditView& pView, int nMods, wxPoint point) override;
+    void OnLButtonDblClk(CBrdEditView& pView, int nMods, wxPoint point) override {}
+    void OnLButtonUp(CBrdEditView& pView, int nMods, wxPoint point) override {}
+    void OnMouseMove(CBrdEditView& pView, int nMods, int nButs, wxPoint point) override {}
     void OnTimer(CBrdEditView& pView, uintptr_t nIDEvent) override {}
-    BOOL OnSetCursor(const CBrdEditView& pView, UINT nHitTest) const override;
+    wxCursor OnSetCursor(const CBrdEditView& pView, wxPoint point) const override;
 
 // Implementation
 public:
@@ -348,12 +348,12 @@ public:
 
 // Operations
 public:
-    void OnLButtonDown(CBrdEditView& pView, UINT nFlags, CPoint point) override;
-    void OnLButtonDblClk(CBrdEditView& pView, UINT nFlags, CPoint point) override {}
-    void OnLButtonUp(CBrdEditView& pView, UINT nFlags, CPoint point) override {}
-    void OnMouseMove(CBrdEditView& pView, UINT nFlags, CPoint point) override;
+    void OnLButtonDown(CBrdEditView& pView, int nMods, wxPoint point) override;
+    void OnLButtonDblClk(CBrdEditView& pView, int nMods, wxPoint point) override {}
+    void OnLButtonUp(CBrdEditView& pView, int nMods, wxPoint point) override {}
+    void OnMouseMove(CBrdEditView& pView, int nMods, int nButs, wxPoint point) override;
     void OnTimer(CBrdEditView& pView, uintptr_t nIDEvent) override {}
-    BOOL OnSetCursor(const CBrdEditView& pView, UINT nHitTest) const override;
+    wxCursor OnSetCursor(const CBrdEditView& pView, wxPoint point) const override;
 
 // Implementation
 public:

--- a/GM/ToolObjs.h
+++ b/GM/ToolObjs.h
@@ -60,6 +60,7 @@ public:
     virtual void OnLButtonDblClk(CBrdEditView& pView, int nMods, wxPoint point) /* override */ {}
     virtual void OnLButtonUp(CBrdEditView& pView, int nMods, wxPoint point) /* override */;
     virtual void OnMouseMove(CBrdEditView& pView, int nMods, int nButs, wxPoint point) /* override */;
+    virtual void OnMouseCaptureLost(CBrdEditView& pView) /* override */;
     virtual void OnTimer(CBrdEditView& pView, uintptr_t nIDEvent) /* override */ {}
     virtual wxCursor OnSetCursor(const CBrdEditView& pView, wxPoint point) const /* override */
         { return wxNullCursor; }
@@ -97,6 +98,7 @@ public:
     void OnLButtonDblClk(CBrdEditView& pView, int nMods, wxPoint point) override;
     void OnLButtonUp(CBrdEditView& pView, int nMods, wxPoint point) override;
     void OnMouseMove(CBrdEditView& pView, int nMods, int nButs, wxPoint point) override;
+    void OnMouseCaptureLost(CBrdEditView& pView) override;
     void OnTimer(CBrdEditView& pView, uintptr_t nIDEvent) override;
     wxCursor OnSetCursor(const CBrdEditView& pView, wxPoint point) const override;
 
@@ -134,6 +136,7 @@ public:
     void OnLButtonDblClk(CBrdEditView& pView, int nMods, wxPoint point) override {}
     void OnLButtonUp(CBrdEditView& pView, int nMods, wxPoint point) override;
     void OnMouseMove(CBrdEditView& pView, int nMods, int nButs, wxPoint point) override;
+    void OnMouseCaptureLost(CBrdEditView& pView) override;
     void OnTimer(CBrdEditView& pView, uintptr_t nIDEvent) override;
     wxCursor OnSetCursor(const CBrdEditView& pView, wxPoint point) const override;
 
@@ -211,6 +214,7 @@ public:
     void OnLButtonDblClk(CBrdEditView& pView, int nMods, wxPoint point) override;
     void OnLButtonUp(CBrdEditView& pView, int nMods, wxPoint point) override {}
     void OnMouseMove(CBrdEditView& pView, int nMods, int nButs, wxPoint point) override;
+    void OnMouseCaptureLost(CBrdEditView& pView) override;
     void OnTimer(CBrdEditView& pView, uintptr_t nIDEvent) override {}
     wxCursor OnSetCursor(const CBrdEditView& pView, wxPoint point) const override;
 
@@ -264,6 +268,7 @@ public:
     void OnLButtonDblClk(CBrdEditView& pView, int nMods, wxPoint point) override {}
     void OnLButtonUp(CBrdEditView& pView, int nMods, wxPoint point) override;
     void OnMouseMove(CBrdEditView& pView, int nMods, int nButs, wxPoint point) override {}
+    void OnMouseCaptureLost(CBrdEditView& pView) override;
     void OnTimer(CBrdEditView& pView, uintptr_t nIDEvent) override {}
     wxCursor OnSetCursor(const CBrdEditView& pView, wxPoint point) const override;
 

--- a/GM/ToolObjs.h
+++ b/GM/ToolObjs.h
@@ -31,10 +31,7 @@
 
 class CBrdEditView;
 
-const UINT timerIDSelectDelay = 666;    // Select timer ID
-const UINT timerIDAutoScroll  = 999;    // Autoscroll timer ID
 const int  timerSelDelay      = 150;    // Delay until select
-const int  timerAutoScroll    = 150;    // Interval of autoscrolls
 
 enum ToolType { ttypeUnknown, ttypeSelect, ttypeText, ttypeRect,
     ttypeEllipse, ttypeLine, ttypeTile, ttypeColorPick, ttypeCellPaint,
@@ -61,7 +58,7 @@ public:
     virtual void OnLButtonUp(CBrdEditView& pView, int nMods, wxPoint point) /* override */;
     virtual void OnMouseMove(CBrdEditView& pView, int nMods, int nButs, wxPoint point) /* override */;
     virtual void OnMouseCaptureLost(CBrdEditView& pView) /* override */;
-    virtual void OnTimer(CBrdEditView& pView, uintptr_t nIDEvent) /* override */ {}
+    virtual void OnTimer(CBrdEditView& pView) /* override */ {}
     virtual wxCursor OnSetCursor(const CBrdEditView& pView, wxPoint point) const /* override */
         { return wxNullCursor; }
 
@@ -82,7 +79,7 @@ class CSelectTool : public CTool
 {
 // Constructors
 public:
-    CSelectTool() : CTool(ttypeSelect) { m_nTimerID = uintptr_t(0); }
+    CSelectTool() : CTool(ttypeSelect) {}
 
 // Attributes
 public:
@@ -99,23 +96,19 @@ public:
     void OnLButtonUp(CBrdEditView& pView, int nMods, wxPoint point) override;
     void OnMouseMove(CBrdEditView& pView, int nMods, int nButs, wxPoint point) override;
     void OnMouseCaptureLost(CBrdEditView& pView) override;
-    void OnTimer(CBrdEditView& pView, uintptr_t nIDEvent) override;
+    void OnTimer(CBrdEditView& pView) override;
     wxCursor OnSetCursor(const CBrdEditView& pView, wxPoint point) const override;
 
 // Implementation
 public:
-    uintptr_t m_nTimerID;
     wxRect  m_rectMultiBorder;
     // ------- //
-    BOOL ProcessAutoScroll(CBrdEditView& pView);
     void DrawSelectionRect(wxDC& pDC, const wxRect& pRct) const;
     void DrawNetRect(wxDC& pDC, CBrdEditView& pView) const;
     BOOL AdjustPoint(const CBrdEditView& pView, wxPoint& point) const;
     void MoveSelections(CSelList& pSLst, wxPoint point);
     void StartDragTimer(CBrdEditView& pView);
     void KillDragTimer(CBrdEditView& pView);
-    void StartScrollTimer(CBrdEditView& pView);
-    void KillScrollTimer(CBrdEditView& pView);
     // ------- //
     void StartSizingOperation(CBrdEditView& pView, int nMods,
         wxPoint point, int nHandleID = -1);
@@ -137,7 +130,7 @@ public:
     void OnLButtonUp(CBrdEditView& pView, int nMods, wxPoint point) override;
     void OnMouseMove(CBrdEditView& pView, int nMods, int nButs, wxPoint point) override;
     void OnMouseCaptureLost(CBrdEditView& pView) override;
-    void OnTimer(CBrdEditView& pView, uintptr_t nIDEvent) override;
+    void OnTimer(CBrdEditView& pView) override;
     wxCursor OnSetCursor(const CBrdEditView& pView, wxPoint point) const override;
 
 // Implementation
@@ -215,7 +208,7 @@ public:
     void OnLButtonUp(CBrdEditView& pView, int nMods, wxPoint point) override {}
     void OnMouseMove(CBrdEditView& pView, int nMods, int nButs, wxPoint point) override;
     void OnMouseCaptureLost(CBrdEditView& pView) override;
-    void OnTimer(CBrdEditView& pView, uintptr_t nIDEvent) override {}
+    void OnTimer(CBrdEditView& pView) override {}
     wxCursor OnSetCursor(const CBrdEditView& pView, wxPoint point) const override;
 
     // --------- //
@@ -246,7 +239,7 @@ public:
     void OnLButtonDblClk(CBrdEditView& pView, int nMods, wxPoint point) override {}
     void OnLButtonUp(CBrdEditView& pView, int nMods, wxPoint point) override {}
     void OnMouseMove(CBrdEditView& pView, int nMods, int nButs, wxPoint point) override {}
-    void OnTimer(CBrdEditView& pView, uintptr_t nIDEvent) override {}
+    void OnTimer(CBrdEditView& pView) override {}
     wxCursor OnSetCursor(const CBrdEditView& pView, wxPoint point) const override;
 
 // Implementation
@@ -269,7 +262,7 @@ public:
     void OnLButtonUp(CBrdEditView& pView, int nMods, wxPoint point) override;
     void OnMouseMove(CBrdEditView& pView, int nMods, int nButs, wxPoint point) override {}
     void OnMouseCaptureLost(CBrdEditView& pView) override;
-    void OnTimer(CBrdEditView& pView, uintptr_t nIDEvent) override {}
+    void OnTimer(CBrdEditView& pView) override {}
     wxCursor OnSetCursor(const CBrdEditView& pView, wxPoint point) const override;
 
 // Implementation
@@ -291,7 +284,7 @@ public:
     void OnLButtonDblClk(CBrdEditView& pView, int nMods, wxPoint point) override {}
     void OnLButtonUp(CBrdEditView& pView, int nMods, wxPoint point) override {}
     void OnMouseMove(CBrdEditView& pView, int nMods, int nButs, wxPoint point) override;
-    void OnTimer(CBrdEditView& pView, uintptr_t nIDEvent) override {}
+    void OnTimer(CBrdEditView& pView) override {}
     wxCursor OnSetCursor(const CBrdEditView& pView, wxPoint point) const override;
 
 // Implementation
@@ -313,7 +306,7 @@ public:
     void OnLButtonDblClk(CBrdEditView& pView, int nMods, wxPoint point) override {}
     void OnLButtonUp(CBrdEditView& pView, int nMods, wxPoint point) override {}
     void OnMouseMove(CBrdEditView& pView, int nMods, int nButs, wxPoint point) override;
-    void OnTimer(CBrdEditView& pView, uintptr_t nIDEvent) override {}
+    void OnTimer(CBrdEditView& pView) override {}
     wxCursor OnSetCursor(const CBrdEditView& pView, wxPoint point) const override;
 
 // Implementation
@@ -335,7 +328,7 @@ public:
     void OnLButtonDblClk(CBrdEditView& pView, int nMods, wxPoint point) override {}
     void OnLButtonUp(CBrdEditView& pView, int nMods, wxPoint point) override {}
     void OnMouseMove(CBrdEditView& pView, int nMods, int nButs, wxPoint point) override {}
-    void OnTimer(CBrdEditView& pView, uintptr_t nIDEvent) override {}
+    void OnTimer(CBrdEditView& pView) override {}
     wxCursor OnSetCursor(const CBrdEditView& pView, wxPoint point) const override;
 
 // Implementation
@@ -357,7 +350,7 @@ public:
     void OnLButtonDblClk(CBrdEditView& pView, int nMods, wxPoint point) override {}
     void OnLButtonUp(CBrdEditView& pView, int nMods, wxPoint point) override {}
     void OnMouseMove(CBrdEditView& pView, int nMods, int nButs, wxPoint point) override;
-    void OnTimer(CBrdEditView& pView, uintptr_t nIDEvent) override {}
+    void OnTimer(CBrdEditView& pView) override {}
     wxCursor OnSetCursor(const CBrdEditView& pView, wxPoint point) const override;
 
 // Implementation

--- a/GM/ToolObjs.h
+++ b/GM/ToolObjs.h
@@ -56,12 +56,12 @@ public:
 public:
     static CTool& GetTool(ToolType eType);
     // ----------- //
-    virtual void OnLButtonDown(CBrdEditView* pView, UINT nFlags, CPoint point);
-    virtual void OnLButtonDblClk(CBrdEditView* pView, UINT nFlags, CPoint point) {}
-    virtual void OnLButtonUp(CBrdEditView* pView, UINT nFlags, CPoint point);
-    virtual void OnMouseMove(CBrdEditView* pView, UINT nFlags, CPoint point);
-    virtual void OnTimer(CBrdEditView* pView, uintptr_t nIDEvent) /*override*/ {}
-    virtual BOOL OnSetCursor(CBrdEditView* pView, UINT nHitTest)
+    virtual void OnLButtonDown(CBrdEditView& pView, UINT nFlags, CPoint point) /* override */;
+    virtual void OnLButtonDblClk(CBrdEditView& pView, UINT nFlags, CPoint point) /* override */ {}
+    virtual void OnLButtonUp(CBrdEditView& pView, UINT nFlags, CPoint point) /* override */;
+    virtual void OnMouseMove(CBrdEditView& pView, UINT nFlags, CPoint point) /* override */;
+    virtual void OnTimer(CBrdEditView& pView, uintptr_t nIDEvent) /* override */ {}
+    virtual BOOL OnSetCursor(const CBrdEditView& pView, UINT nHitTest) const /* override */
         { return FALSE; }
 
 // Implementation
@@ -93,29 +93,29 @@ public:
 
 // Operations
 public:
-    virtual void OnLButtonDown(CBrdEditView* pView, UINT nFlags, CPoint point);
-    virtual void OnLButtonDblClk(CBrdEditView* pView, UINT nFlags, CPoint point);
-    virtual void OnLButtonUp(CBrdEditView* pView, UINT nFlags, CPoint point);
-    virtual void OnMouseMove(CBrdEditView* pView, UINT nFlags, CPoint point);
-    virtual void OnTimer(CBrdEditView* pView, uintptr_t nIDEvent) override;
-    virtual BOOL OnSetCursor(CBrdEditView* pView, UINT nHitTest);
+    void OnLButtonDown(CBrdEditView& pView, UINT nFlags, CPoint point) override;
+    void OnLButtonDblClk(CBrdEditView& pView, UINT nFlags, CPoint point) override;
+    void OnLButtonUp(CBrdEditView& pView, UINT nFlags, CPoint point) override;
+    void OnMouseMove(CBrdEditView& pView, UINT nFlags, CPoint point) override;
+    void OnTimer(CBrdEditView& pView, uintptr_t nIDEvent) override;
+    BOOL OnSetCursor(const CBrdEditView& pView, UINT nHitTest) const override;
 
 // Implementation
 public:
     uintptr_t m_nTimerID;
     CRect   m_rectMultiBorder;
     // ------- //
-    BOOL ProcessAutoScroll(CBrdEditView* pView);
-    void DrawSelectionRect(CDC* pDC, CRect* pRct);
-    void DrawNetRect(CDC* pDC, CBrdEditView* pView);
-    BOOL AdjustPoint(CBrdEditView* pView, CPoint& point);
-    void MoveSelections(CSelList *pSLst, CPoint point);
-    void StartDragTimer(CBrdEditView* pView);
-    void KillDragTimer(CBrdEditView* pView);
-    void StartScrollTimer(CBrdEditView* pView);
-    void KillScrollTimer(CBrdEditView* pView);
+    BOOL ProcessAutoScroll(CBrdEditView& pView);
+    void DrawSelectionRect(CDC& pDC, const CRect& pRct) const;
+    void DrawNetRect(CDC& pDC, CBrdEditView& pView) const;
+    BOOL AdjustPoint(const CBrdEditView& pView, CPoint& point) const;
+    void MoveSelections(CSelList& pSLst, CPoint point);
+    void StartDragTimer(CBrdEditView& pView);
+    void KillDragTimer(CBrdEditView& pView);
+    void StartScrollTimer(CBrdEditView& pView);
+    void KillScrollTimer(CBrdEditView& pView);
     // ------- //
-    void StartSizingOperation(CBrdEditView* pView, UINT nFlags,
+    void StartSizingOperation(CBrdEditView& pView, UINT nFlags,
         CPoint point, int nHandleID = -1);
 };
 
@@ -130,20 +130,22 @@ public:
 
 // Operations
 public:
-    virtual void OnLButtonDown(CBrdEditView* pView, UINT nFlags, CPoint point);
-    virtual void OnLButtonDblClk(CBrdEditView* pView, UINT nFlags, CPoint point) {}
-    virtual void OnLButtonUp(CBrdEditView* pView, UINT nFlags, CPoint point);
-    virtual void OnMouseMove(CBrdEditView* pView, UINT nFlags, CPoint point);
-    virtual void OnTimer(CBrdEditView* pView, uintptr_t nIDEvent) override;
-    virtual BOOL OnSetCursor(CBrdEditView* pView, UINT nHitTest);
+    void OnLButtonDown(CBrdEditView& pView, UINT nFlags, CPoint point) override;
+    void OnLButtonDblClk(CBrdEditView& pView, UINT nFlags, CPoint point) override {}
+    void OnLButtonUp(CBrdEditView& pView, UINT nFlags, CPoint point) override;
+    void OnMouseMove(CBrdEditView& pView, UINT nFlags, CPoint point) override;
+    void OnTimer(CBrdEditView& pView, uintptr_t nIDEvent) override;
+    BOOL OnSetCursor(const CBrdEditView& pView, UINT nHitTest) const override;
 
 // Implementation
 public:
-    virtual CDrawObj* CreateDrawObj(CBrdEditView* pView, CPoint point,
-        int& nHandle) = 0;
-    virtual BOOL IsEmptyObject() = 0;
+    virtual CDrawObj::OwnerPtr CreateDrawObj(const CBrdEditView& pView, CPoint point,
+        int& nHandle) const /* override */ = 0;
+    virtual BOOL IsEmptyObject() const /* override */ = 0;
     // --------- //
-    CDrawObj*   m_pObj;
+    /* NOTE:  CShapeTool owns m_pObj, but CPolyTool passes
+        ownership of m_pObj to CBrdEditView immediately */
+    OwnerOrNullPtr<CDrawObj> m_pObj;
 };
 
 ////////////////////////////////////////////////////////////////////////
@@ -157,9 +159,9 @@ public:
 
 // Implementation
 public:
-    virtual CDrawObj* CreateDrawObj(CBrdEditView* pView, CPoint point,
-        int& nHandle);
-    virtual BOOL IsEmptyObject();
+    CDrawObj::OwnerPtr CreateDrawObj(const CBrdEditView& pView, CPoint point,
+        int& nHandle) const override;
+    BOOL IsEmptyObject() const override;
 };
 
 ////////////////////////////////////////////////////////////////////////
@@ -173,9 +175,9 @@ public:
 
 // Implementation
 public:
-    virtual CDrawObj* CreateDrawObj(CBrdEditView* pView, CPoint point,
-        int& nHandle);
-    virtual BOOL IsEmptyObject();
+    CDrawObj::OwnerPtr CreateDrawObj(const CBrdEditView& pView, CPoint point,
+        int& nHandle) const override;
+    BOOL IsEmptyObject() const override;
 };
 
 ////////////////////////////////////////////////////////////////////////
@@ -189,9 +191,9 @@ public:
 
 // Implementation
 public:
-    virtual CDrawObj* CreateDrawObj(CBrdEditView* pView, CPoint point,
-        int& nHandle);
-    virtual BOOL IsEmptyObject();
+    CDrawObj::OwnerPtr CreateDrawObj(const CBrdEditView& pView, CPoint point,
+        int& nHandle) const override;
+    BOOL IsEmptyObject() const override;
 };
 
 ////////////////////////////////////////////////////////////////////////
@@ -205,21 +207,23 @@ public:
 
 // Operations
 public:
-    virtual void OnLButtonDown(CBrdEditView* pView, UINT nFlags, CPoint point);
-    virtual void OnLButtonDblClk(CBrdEditView* pView, UINT nFlags, CPoint point);
-    virtual void OnLButtonUp(CBrdEditView* pView, UINT nFlags, CPoint point) {}
-    virtual void OnMouseMove(CBrdEditView* pView, UINT nFlags, CPoint point);
-    virtual void OnTimer(CBrdEditView* pView, uintptr_t nIDEvent) override {}
-    virtual BOOL OnSetCursor(CBrdEditView* pView, UINT nHitTest);
+    void OnLButtonDown(CBrdEditView& pView, UINT nFlags, CPoint point) override;
+    void OnLButtonDblClk(CBrdEditView& pView, UINT nFlags, CPoint point) override;
+    void OnLButtonUp(CBrdEditView& pView, UINT nFlags, CPoint point) override {}
+    void OnMouseMove(CBrdEditView& pView, UINT nFlags, CPoint point) override;
+    void OnTimer(CBrdEditView& pView, uintptr_t nIDEvent) override {}
+    BOOL OnSetCursor(const CBrdEditView& pView, UINT nHitTest) const override;
 
     // --------- //
-    void RemoveRubberBand(CBrdEditView* pView);
-    void FinalizePolygon(CBrdEditView* pView, BOOL bForceDestroy = FALSE);
+    void RemoveRubberBand(CBrdEditView& pView);
+    void FinalizePolygon(CBrdEditView& pView, BOOL bForceDestroy = FALSE);
 
 // Implementation
 public:
-    void DrawRubberLine(CDC* pDC);
+    void DrawRubberLine(CDC& pDC);
     // --------- //
+    /* NOTE:  CShapeTool owns m_pObj, but CPolyTool passes
+        ownership of m_pObj to CBrdEditView immediately */
     CPolyObj*   m_pObj;
 };
 
@@ -234,12 +238,12 @@ public:
 
 // Operations
 public:
-    virtual void OnLButtonDown(CBrdEditView* pView, UINT nFlags, CPoint point);
-    virtual void OnLButtonDblClk(CBrdEditView* pView, UINT nFlags, CPoint point) {}
-    virtual void OnLButtonUp(CBrdEditView* pView, UINT nFlags, CPoint point) {}
-    virtual void OnMouseMove(CBrdEditView* pView, UINT nFlags, CPoint point) {}
-    virtual void OnTimer(CBrdEditView* pView, uintptr_t nIDEvent) override {}
-    virtual BOOL OnSetCursor(CBrdEditView* pView, UINT nHitTest);
+    void OnLButtonDown(CBrdEditView& pView, UINT nFlags, CPoint point) override;
+    void OnLButtonDblClk(CBrdEditView& pView, UINT nFlags, CPoint point) override {}
+    void OnLButtonUp(CBrdEditView& pView, UINT nFlags, CPoint point) override {}
+    void OnMouseMove(CBrdEditView& pView, UINT nFlags, CPoint point) override {}
+    void OnTimer(CBrdEditView& pView, uintptr_t nIDEvent) override {}
+    BOOL OnSetCursor(const CBrdEditView& pView, UINT nHitTest) const override;
 
 // Implementation
 public:
@@ -256,12 +260,12 @@ public:
 
 // Operations
 public:
-    virtual void OnLButtonDown(CBrdEditView* pView, UINT nFlags, CPoint point);
-    virtual void OnLButtonDblClk(CBrdEditView* pView, UINT nFlags, CPoint point) {}
-    virtual void OnLButtonUp(CBrdEditView* pView, UINT nFlags, CPoint point);
-    virtual void OnMouseMove(CBrdEditView* pView, UINT nFlags, CPoint point) {}
-    virtual void OnTimer(CBrdEditView* pView, uintptr_t nIDEvent) override {}
-    virtual BOOL OnSetCursor(CBrdEditView* pView, UINT nHitTest);
+    void OnLButtonDown(CBrdEditView& pView, UINT nFlags, CPoint point) override;
+    void OnLButtonDblClk(CBrdEditView& pView, UINT nFlags, CPoint point) override {}
+    void OnLButtonUp(CBrdEditView& pView, UINT nFlags, CPoint point) override;
+    void OnMouseMove(CBrdEditView& pView, UINT nFlags, CPoint point) override {}
+    void OnTimer(CBrdEditView& pView, uintptr_t nIDEvent) override {}
+    BOOL OnSetCursor(const CBrdEditView& pView, UINT nHitTest) const override;
 
 // Implementation
 public:
@@ -278,12 +282,12 @@ public:
 
 // Operations
 public:
-    virtual void OnLButtonDown(CBrdEditView* pView, UINT nFlags, CPoint point);
-    virtual void OnLButtonDblClk(CBrdEditView* pView, UINT nFlags, CPoint point) {}
-    virtual void OnLButtonUp(CBrdEditView* pView, UINT nFlags, CPoint point) {}
-    virtual void OnMouseMove(CBrdEditView* pView, UINT nFlags, CPoint point);
-    virtual void OnTimer(CBrdEditView* pView, uintptr_t nIDEvent) override {}
-    virtual BOOL OnSetCursor(CBrdEditView* pView, UINT nHitTest);
+    void OnLButtonDown(CBrdEditView& pView, UINT nFlags, CPoint point) override;
+    void OnLButtonDblClk(CBrdEditView& pView, UINT nFlags, CPoint point) override {}
+    void OnLButtonUp(CBrdEditView& pView, UINT nFlags, CPoint point) override {}
+    void OnMouseMove(CBrdEditView& pView, UINT nFlags, CPoint point) override;
+    void OnTimer(CBrdEditView& pView, uintptr_t nIDEvent) override {}
+    BOOL OnSetCursor(const CBrdEditView& pView, UINT nHitTest) const override;
 
 // Implementation
 public:
@@ -300,12 +304,12 @@ public:
 
 // Operations
 public:
-    virtual void OnLButtonDown(CBrdEditView* pView, UINT nFlags, CPoint point);
-    virtual void OnLButtonDblClk(CBrdEditView* pView, UINT nFlags, CPoint point) {}
-    virtual void OnLButtonUp(CBrdEditView* pView, UINT nFlags, CPoint point) {}
-    virtual void OnMouseMove(CBrdEditView* pView, UINT nFlags, CPoint point);
-    virtual void OnTimer(CBrdEditView* pView, uintptr_t nIDEvent) override {}
-    virtual BOOL OnSetCursor(CBrdEditView* pView, UINT nHitTest);
+    void OnLButtonDown(CBrdEditView& pView, UINT nFlags, CPoint point) override;
+    void OnLButtonDblClk(CBrdEditView& pView, UINT nFlags, CPoint point) override {}
+    void OnLButtonUp(CBrdEditView& pView, UINT nFlags, CPoint point) override {}
+    void OnMouseMove(CBrdEditView& pView, UINT nFlags, CPoint point) override;
+    void OnTimer(CBrdEditView& pView, uintptr_t nIDEvent) override {}
+    BOOL OnSetCursor(const CBrdEditView& pView, UINT nHitTest) const override;
 
 // Implementation
 public:
@@ -322,12 +326,12 @@ public:
 
 // Operations
 public:
-    virtual void OnLButtonDown(CBrdEditView* pView, UINT nFlags, CPoint point);
-    virtual void OnLButtonDblClk(CBrdEditView* pView, UINT nFlags, CPoint point) {}
-    virtual void OnLButtonUp(CBrdEditView* pView, UINT nFlags, CPoint point) {}
-    virtual void OnMouseMove(CBrdEditView* pView, UINT nFlags, CPoint point) {}
-    virtual void OnTimer(CBrdEditView* pView, uintptr_t nIDEvent) override {}
-    virtual BOOL OnSetCursor(CBrdEditView* pView, UINT nHitTest);
+    void OnLButtonDown(CBrdEditView& pView, UINT nFlags, CPoint point) override;
+    void OnLButtonDblClk(CBrdEditView& pView, UINT nFlags, CPoint point) override {}
+    void OnLButtonUp(CBrdEditView& pView, UINT nFlags, CPoint point) override {}
+    void OnMouseMove(CBrdEditView& pView, UINT nFlags, CPoint point) override {}
+    void OnTimer(CBrdEditView& pView, uintptr_t nIDEvent) override {}
+    BOOL OnSetCursor(const CBrdEditView& pView, UINT nHitTest) const override;
 
 // Implementation
 public:
@@ -344,12 +348,12 @@ public:
 
 // Operations
 public:
-    virtual void OnLButtonDown(CBrdEditView* pView, UINT nFlags, CPoint point);
-    virtual void OnLButtonDblClk(CBrdEditView* pView, UINT nFlags, CPoint point) {}
-    virtual void OnLButtonUp(CBrdEditView* pView, UINT nFlags, CPoint point) {}
-    virtual void OnMouseMove(CBrdEditView* pView, UINT nFlags, CPoint point);
-    virtual void OnTimer(CBrdEditView* pView, uintptr_t nIDEvent) override {}
-    virtual BOOL OnSetCursor(CBrdEditView* pView, UINT nHitTest);
+    void OnLButtonDown(CBrdEditView& pView, UINT nFlags, CPoint point) override;
+    void OnLButtonDblClk(CBrdEditView& pView, UINT nFlags, CPoint point) override {}
+    void OnLButtonUp(CBrdEditView& pView, UINT nFlags, CPoint point) override {}
+    void OnMouseMove(CBrdEditView& pView, UINT nFlags, CPoint point) override;
+    void OnTimer(CBrdEditView& pView, uintptr_t nIDEvent) override {}
+    BOOL OnSetCursor(const CBrdEditView& pView, UINT nHitTest) const override;
 
 // Implementation
 public:

--- a/GM/ToolObjs.h
+++ b/GM/ToolObjs.h
@@ -105,7 +105,6 @@ public:
     // ------- //
     void DrawSelectionRect(wxDC& pDC, const wxRect& pRct) const;
     void DrawNetRect(wxDC& pDC, CBrdEditView& pView) const;
-    BOOL AdjustPoint(const CBrdEditView& pView, wxPoint& point) const;
     void MoveSelections(CSelList& pSLst, wxPoint point);
     void StartDragTimer(CBrdEditView& pView);
     void KillDragTimer(CBrdEditView& pView);

--- a/GM/VwBitedt.cpp
+++ b/GM/VwBitedt.cpp
@@ -368,10 +368,8 @@ void CBitEditView::DrawImageEllipse(wxPoint startPt, wxPoint curPt, UINT nSize)
     {
         wxMemoryDC dc(m_bmView);
 
-        /* KLUDGE:  size - 1 due to
-                    https://groups.google.com/g/wx-dev/c/0HZLlbTB6do/m/JMQy61LqAQAJ */
         wxRect rct(wxPoint(std::min(startPt.x, curPt.x), std::min(startPt.y, curPt.y)),
-                    wxSize(std::abs(curPt.x - startPt.x) + 1 - 1, std::abs(curPt.y - startPt.y) + 1 - 1));
+                    wxSize(std::abs(curPt.x - startPt.x) + 1, std::abs(curPt.y - startPt.y) + 1));
         wxPen pen(CB::Convert(m_pTMgr->GetForeColor()), nSize);
         if (nSize == 0)
             dc.SetBrush(m_pTMgr->GetForeBrushWx());
@@ -379,7 +377,7 @@ void CBitEditView::DrawImageEllipse(wxPoint startPt, wxPoint curPt, UINT nSize)
             dc.SetBrush(*wxTRANSPARENT_BRUSH);
         dc.SetPen(pen);
 
-        dc.DrawEllipse(rct);
+        CB::DrawEllipse(dc, rct);
     }
 
     InvalidateViewImage(true);

--- a/GM/VwBitedt.cpp
+++ b/GM/VwBitedt.cpp
@@ -65,6 +65,7 @@ wxBEGIN_EVENT_TABLE(CBitEditView, wxScrolledCanvas)
     EVT_LEFT_DOWN(OnLButtonDown)
     EVT_LEFT_UP(OnLButtonUp)
     EVT_MOTION(OnMouseMove)
+    EVT_MOUSE_CAPTURE_LOST(OnMouseCaptureLost)
     EVT_SET_CURSOR(OnSetCursor)
     EVT_MENU(XRCID("ID_IMAGE_BOARDMASK"), OnImageBoardMask)
     EVT_MENU(wxID_ZOOM_IN, OnViewZoomIn)
@@ -901,6 +902,13 @@ void CBitEditView::OnLButtonUp(wxMouseEvent& event)
     CImageTool& pTool = CImageTool::GetTool(eToolType);
     wxPoint point = ClientToWorkspace(event.GetPosition());
     pTool.OnLButtonUp(*this, event.GetModifiers(), point);
+}
+
+void CBitEditView::OnMouseCaptureLost(wxMouseCaptureLostEvent& /*event*/)
+{
+    IToolType eToolType = MapToolType(m_nCurToolID);
+    CImageTool& pTool = CImageTool::GetTool(eToolType);
+    pTool.OnMouseCaptureLost(*this);
 }
 
 void CBitEditView::OnSetCursor(wxSetCursorEvent& event)

--- a/GM/VwBitedt.h
+++ b/GM/VwBitedt.h
@@ -205,6 +205,7 @@ protected:
     void OnLButtonDown(wxMouseEvent& event);
     void OnLButtonUp(wxMouseEvent& event);
     void OnMouseMove(wxMouseEvent& event);
+    void OnMouseCaptureLost(wxMouseCaptureLostEvent& event);
     void OnSetCursor(wxSetCursorEvent& event);
     void OnImageBoardMask(wxCommandEvent& event);
     void OnViewZoomIn(wxCommandEvent& event);

--- a/GM/VwEdtbrd.cpp
+++ b/GM/VwEdtbrd.cpp
@@ -287,7 +287,6 @@ BOOL CBrdEditView::OnEraseBkgnd(CDC* pDC)
 
 void CBrdEditView::PrepareScaledDC(wxDC& pDC) const
 {
-    wxASSERT(m_selList.empty() || !"needs testing");
     wxSize wsize, vsize;
     m_pBoard->GetBoardArray().GetBoardScaling(m_nZoom, wsize, vsize);
     pDC.SetUserScale(double(vsize.x)/wsize.x, double(vsize.y)/wsize.y);
@@ -309,16 +308,13 @@ void CBrdEditView::ClientToWorkspace(wxPoint& point) const
     ScalePoint(point, wsize, vsize);
 }
 
-#if 0
-void CBrdEditView::ClientToWorkspace(CRect& rect) const
+void CBrdEditView::ClientToWorkspace(wxRect& rect) const
 {
-    CPoint dpnt = GetDeviceScrollPosition();
-    rect += dpnt;
-    CSize wsize, vsize;
+    rect.SetTopLeft(CalcUnscrolledPosition(rect.GetTopLeft()));
+    wxSize wsize, vsize;
     m_pBoard->GetBoardArray().GetBoardScaling(m_nZoom, wsize, vsize);
     ScaleRect(rect, wsize, vsize);
 }
-#endif
 
 void CBrdEditView::WorkspaceToClient(wxPoint& point) const
 {
@@ -328,24 +324,23 @@ void CBrdEditView::WorkspaceToClient(wxPoint& point) const
     point = CalcScrolledPosition(point);
 }
 
-#if 0
-void CBrdEditView::WorkspaceToClient(CRect& rect) const
+void CBrdEditView::WorkspaceToClient(wxRect& rect) const
 {
-    CPoint dpnt = GetDeviceScrollPosition();
-    CSize wsize, vsize;
+    wxSize wsize, vsize;
     m_pBoard->GetBoardArray().GetBoardScaling(m_nZoom, wsize, vsize);
     ScaleRect(rect, vsize, wsize);
-    rect -= dpnt;
+    rect.SetLeftTop(CalcScrolledPosition(rect.GetTopLeft()));
 }
 
-void CBrdEditView::InvalidateWorkspaceRect(const CRect& pRect, BOOL bErase)
+void CBrdEditView::InvalidateWorkspaceRect(const wxRect& pRect, BOOL bErase)
 {
-    CRect rct(pRect);
+    wxRect rct(pRect);
     WorkspaceToClient(rct);
-    rct.InflateRect(1, 1);
-    InvalidateRect(&rct, bErase);
+    rct.Inflate(1, 1);
+    RefreshRect(rct, bErase);
 }
 
+#if 0
 CPoint CBrdEditView::GetWorkspaceDim() const
 {
     // First get MM_TEXT size of board for this scaling mode.
@@ -376,8 +371,9 @@ CDrawObj* CBrdEditView::ObjectHitTest(CPoint point)
     else
         return NULL;
 }
+#endif
 
-void CBrdEditView::SelectWithinRect(CRect rctNet, BOOL bInclIntersects)
+void CBrdEditView::SelectWithinRect(wxRect rctNet, BOOL bInclIntersects)
 {
     CDrawList* pDwg = GetDrawList(FALSE);
     if (pDwg == NULL)
@@ -393,9 +389,9 @@ void CBrdEditView::SelectWithinRect(CRect rctNet, BOOL bInclIntersects)
         if (!m_selList.IsObjectSelected(pObj))
         {
             if ((!bInclIntersects &&
-                ((pObj.GetEnclosingRect() | rctNet) == rctNet)) ||
+                ((CB::Convert(pObj.GetEnclosingRect()) + rctNet) == rctNet)) ||
                 (bInclIntersects &&
-                (!(pObj.GetEnclosingRect() & rctNet).IsRectEmpty())))
+                (!(CB::Convert(pObj.GetEnclosingRect()) * rctNet).IsEmpty())))
             {
                 m_selList.AddObject(pObj, TRUE);
             }
@@ -403,6 +399,7 @@ void CBrdEditView::SelectWithinRect(CRect rctNet, BOOL bInclIntersects)
     }
 }
 
+#if 0
 void CBrdEditView::SelectAllUnderPoint(CPoint point)
 {
     CDrawList* pDwg = GetDrawList(FALSE);
@@ -995,6 +992,7 @@ void CBrdEditView::SetBoardBackColor(COLORREF cr, BOOL bUpdate)
         Invalidate();
     GetDocument().SetModifiedFlag();
 }
+#endif
 
 CDrawList* CBrdEditView::GetDrawList(BOOL bCanCreateList)
 {
@@ -1008,6 +1006,7 @@ CDrawList* CBrdEditView::GetDrawList(BOOL bCanCreateList)
         return NULL;
 }
 
+#if 0
 void CBrdEditView::AddDrawObject(CDrawObj::OwnerPtr pObj)
 {
     CDrawList* pDwg = GetDrawList(TRUE);

--- a/GM/VwEdtbrd.cpp
+++ b/GM/VwEdtbrd.cpp
@@ -54,39 +54,44 @@ IMPLEMENT_DYNCREATE(CBrdEditViewContainer, CView)
 wxBEGIN_EVENT_TABLE(CBrdEditView, wxScrolledCanvas)
 #if 0
     ON_WM_MOUSEWHEEL()
-    ON_WM_LBUTTONDOWN()
-    ON_WM_LBUTTONUP()
-    ON_WM_MOUSEMOVE()
-    ON_WM_LBUTTONDBLCLK()
+#endif
+    EVT_LEFT_DOWN(OnLButtonDown)
+    EVT_LEFT_UP(OnLButtonUp)
+    EVT_MOTION(OnMouseMove)
+    EVT_LEFT_DCLICK(OnLButtonDblClk)
+    EVT_MOUSE_CAPTURE_LOST(OnMouseCaptureLost)
+#if 0
     ON_WM_TIMER()
     ON_WM_KEYDOWN()
     ON_WM_CHAR()
-    ON_WM_SETCURSOR()
+#endif
+    EVT_SET_CURSOR(OnSetCursor)
+#if 0
     ON_WM_ERASEBKGND()
 #endif
     EVT_DRAGDROP(OnDragTileItem)
+    EVT_SETCOLOR(OnSetColor)
+    EVT_SETCUSTOMCOLOR(OnSetCustomColors)
+    EVT_SETLINEWIDTH(OnSetLineWidth)
 #if 0
-    ON_MESSAGE(WM_SETCOLOR, OnSetColor)
-    ON_MESSAGE(WM_SETCUSTOMCOLOR, OnSetCustomColors)
-    ON_MESSAGE(WM_SETLINEWIDTH, OnSetLineWidth)
     ON_COMMAND(ID_OFFSCREEN, OnOffscreen)
     ON_COMMAND(ID_VIEW_GRIDLINES, OnViewGridLines)
     ON_COMMAND(ID_DWG_TOBACK, OnDwgToBack)
     ON_COMMAND(ID_DWG_TOFRONT, OnDwgToFront)
-    ON_COMMAND_EX(ID_TOOL_ARROW, OnToolPalette)
 #endif
+    EVT_MENU(XRCID("ID_TOOL_ARROW"), OnToolPalette)
     EVT_MENU(XRCID("ID_EDIT_LAYER_BASE"), OnEditLayer)
 #if 0
     ON_UPDATE_COMMAND_UI(ID_VIEW_GRIDLINES, OnUpdateViewGridLines)
     ON_UPDATE_COMMAND_UI(ID_OFFSCREEN, OnUpdateOffscreen)
 #endif
     EVT_UPDATE_UI(XRCID("ID_EDIT_LAYER_BASE"), OnUpdateEditLayer)
+    EVT_UPDATE_UI(XRCID("ID_COLOR_FOREGROUND"), OnUpdateColorForeground)
+    EVT_UPDATE_UI(XRCID("ID_COLOR_BACKGROUND"), OnUpdateColorBackground)
+    EVT_UPDATE_UI(XRCID("ID_COLOR_CUSTOM"), OnUpdateColorCustom)
+    EVT_UPDATE_UI(XRCID("ID_LINE_WIDTH"), OnUpdateLineWidth)
+    EVT_UPDATE_UI(XRCID("ID_TOOL_ARROW"), OnUpdateToolPalette)
 #if 0
-    ON_UPDATE_COMMAND_UI(ID_COLOR_FOREGROUND, OnUpdateColorForeground)
-    ON_UPDATE_COMMAND_UI(ID_COLOR_BACKGROUND, OnUpdateColorBackground)
-    ON_UPDATE_COMMAND_UI(ID_COLOR_CUSTOM, OnUpdateColorCustom)
-    ON_UPDATE_COMMAND_UI(ID_LINE_WIDTH, OnUpdateLineWidth)
-    ON_UPDATE_COMMAND_UI(ID_TOOL_ARROW, OnUpdateToolPalette)
     ON_UPDATE_COMMAND_UI(ID_DWG_TOFRONT, OnUpdateDwgToFrontOrBack)
 #endif
     EVT_UPDATE_UI(XRCID("ID_VIEW_FULLSCALE"), OnUpdateViewFullScale)
@@ -122,29 +127,27 @@ wxBEGIN_EVENT_TABLE(CBrdEditView, wxScrolledCanvas)
 #endif
     EVT_MENU(XRCID("ID_EDIT_LAYER_TILE"), OnEditLayer)
     EVT_MENU(XRCID("ID_EDIT_LAYER_TOP"), OnEditLayer)
-#if 0
-    ON_COMMAND_EX(ID_TOOL_ERASER, OnToolPalette)
-    ON_COMMAND_EX(ID_TOOL_TILE, OnToolPalette)
-    ON_COMMAND_EX(ID_TOOL_TEXT, OnToolPalette)
-    ON_COMMAND_EX(ID_TOOL_FILL, OnToolPalette)
-    ON_COMMAND_EX(ID_TOOL_DROPPER, OnToolPalette)
-    ON_COMMAND_EX(ID_TOOL_LINE, OnToolPalette)
-    ON_COMMAND_EX(ID_TOOL_POLYGON, OnToolPalette)
-    ON_COMMAND_EX(ID_TOOL_RECT, OnToolPalette)
-    ON_COMMAND_EX(ID_TOOL_OVAL, OnToolPalette)
-#endif
+    EVT_MENU(XRCID("ID_TOOL_ERASER"), OnToolPalette)
+    EVT_MENU(XRCID("ID_TOOL_TILE"), OnToolPalette)
+    EVT_MENU(XRCID("ID_TOOL_TEXT"), OnToolPalette)
+    EVT_MENU(XRCID("ID_TOOL_FILL"), OnToolPalette)
+    EVT_MENU(XRCID("ID_TOOL_DROPPER"), OnToolPalette)
+    EVT_MENU(XRCID("ID_TOOL_LINE"), OnToolPalette)
+    EVT_MENU(XRCID("ID_TOOL_POLYGON"), OnToolPalette)
+    EVT_MENU(XRCID("ID_TOOL_RECT"), OnToolPalette)
+    EVT_MENU(XRCID("ID_TOOL_OVAL"), OnToolPalette)
     EVT_UPDATE_UI(XRCID("ID_EDIT_LAYER_TOP"), OnUpdateEditLayer)
     EVT_UPDATE_UI(XRCID("ID_EDIT_LAYER_TILE"), OnUpdateEditLayer)
+    EVT_UPDATE_UI(XRCID("ID_TOOL_ERASER"), OnUpdateToolPalette)
+    EVT_UPDATE_UI(XRCID("ID_TOOL_TILE"), OnUpdateToolPalette)
+    EVT_UPDATE_UI(XRCID("ID_TOOL_TEXT"), OnUpdateToolPalette)
+    EVT_UPDATE_UI(XRCID("ID_TOOL_FILL"), OnUpdateToolPalette)
+    EVT_UPDATE_UI(XRCID("ID_TOOL_DROPPER"), OnUpdateToolPalette)
+    EVT_UPDATE_UI(XRCID("ID_TOOL_LINE"), OnUpdateToolPalette)
+    EVT_UPDATE_UI(XRCID("ID_TOOL_POLYGON"), OnUpdateToolPalette)
+    EVT_UPDATE_UI(XRCID("ID_TOOL_RECT"), OnUpdateToolPalette)
+    EVT_UPDATE_UI(XRCID("ID_TOOL_OVAL"), OnUpdateToolPalette)
 #if 0
-    ON_UPDATE_COMMAND_UI(ID_TOOL_ERASER, OnUpdateToolPalette)
-    ON_UPDATE_COMMAND_UI(ID_TOOL_TILE, OnUpdateToolPalette)
-    ON_UPDATE_COMMAND_UI(ID_TOOL_TEXT, OnUpdateToolPalette)
-    ON_UPDATE_COMMAND_UI(ID_TOOL_FILL, OnUpdateToolPalette)
-    ON_UPDATE_COMMAND_UI(ID_TOOL_DROPPER, OnUpdateToolPalette)
-    ON_UPDATE_COMMAND_UI(ID_TOOL_LINE, OnUpdateToolPalette)
-    ON_UPDATE_COMMAND_UI(ID_TOOL_POLYGON, OnUpdateToolPalette)
-    ON_UPDATE_COMMAND_UI(ID_TOOL_RECT, OnUpdateToolPalette)
-    ON_UPDATE_COMMAND_UI(ID_TOOL_OVAL, OnUpdateToolPalette)
     ON_UPDATE_COMMAND_UI(ID_DWG_TOBACK, OnUpdateDwgToFrontOrBack)
 #endif
     EVT_MENU(XRCID("ID_VIEW_TOGGLE_SCALE"), OnViewToggleScale)
@@ -168,8 +171,8 @@ CBrdEditView::CBrdEditView(CBrdEditViewContainer& p) :
     m_bOffScreen = TRUE;
     m_pBoard = NULL;
     m_pBMgr = NULL;
-    m_nCurToolID = ID_TOOL_ARROW;       // ID_TOOL_ARROW tool (select)
-    m_nLastToolID = ID_TOOL_ARROW;      // ID_TOOL_ARROW tool (select)
+    m_nCurToolID = XRCID("ID_TOOL_ARROW");       // ID_TOOL_ARROW tool (select)
+    m_nLastToolID = XRCID("ID_TOOL_ARROW");      // ID_TOOL_ARROW tool (select)
     m_nZoom = fullScale;
     // use sizers for scrolling
     wxSizer* sizer = new wxBoxSizer(wxVERTICAL);
@@ -333,8 +336,7 @@ void CBrdEditView::WorkspaceToClient(wxRect& rect) const
 
 void CBrdEditView::InvalidateWorkspaceRect(const wxRect& pRect, BOOL bErase)
 {
-    wxRect rct(pRect);
-    WorkspaceToClient(rct);
+    wxRect rct = WorkspaceToClient(pRect);
     rct.Inflate(1, 1);
     RefreshRect(rct, bErase);
 }
@@ -356,7 +358,7 @@ void CBrdEditView::ResetToDefaultTool()
 {
     if (!GetDocument().GetStickyDrawTools())
     {
-        m_nCurToolID = m_nLastToolID = ID_TOOL_ARROW;
+        m_nCurToolID = m_nLastToolID = XRCID("ID_TOOL_ARROW");
     }
 }
 
@@ -555,8 +557,8 @@ namespace
 
 void CBrdEditView::OnEditLayer(wxCommandEvent& event)
 {
-    m_nCurToolID = ID_TOOL_ARROW;       // Turn off tool with layer change
-    m_nLastToolID = ID_TOOL_ARROW;      // Turn off tool with layer change
+    m_nCurToolID = XRCID("ID_TOOL_ARROW");       // Turn off tool with layer change
+    m_nLastToolID = XRCID("ID_TOOL_ARROW");      // Turn off tool with layer change
     m_selList.PurgeList(TRUE);
 
     wxBusyCursor busyCursor;
@@ -599,83 +601,110 @@ void CBrdEditView::OnContextMenu(CWnd* pWnd, CPoint point)
         END_TRY
     }
 }
+#endif
 
 /////////////////////////////////////////////////////////////////////////////
 // CBrdEditView mouse and timer message handlers
 
-void CBrdEditView::OnLButtonDown(UINT nFlags, CPoint point)
+void CBrdEditView::OnLButtonDown(wxMouseEvent& event)
 {
     ToolType eToolType = MapToolType(m_nCurToolID);
     if (eToolType == ttypeUnknown)
     {
-        CScrollView::OnMouseMove(nFlags, point);
+        OwnerPtr<wxEvent> moveEvent = event.Clone();
+        moveEvent->SetEventType(wxEVT_MOTION);
+        ProcessWindowEvent(*moveEvent);
         return;
     }
     CTool& pTool = CTool::GetTool(eToolType);
-    ClientToWorkspace(point);
-    pTool.OnLButtonDown(*this, nFlags, point);
+    wxPoint point = ClientToWorkspace(event.GetPosition());
+    pTool.OnLButtonDown(*this, event.GetModifiers(), point);
 }
 
-void CBrdEditView::OnMouseMove(UINT nFlags, CPoint point)
+void CBrdEditView::OnMouseMove(wxMouseEvent& event)
 {
     ToolType eToolType = MapToolType(m_nCurToolID);
     if (eToolType == ttypeUnknown)
     {
-        CScrollView::OnMouseMove(nFlags, point);
+        event.Skip();
         return;
     }
     CTool& pTool = CTool::GetTool(eToolType);
-    ClientToWorkspace(point);
-    pTool.OnMouseMove(*this, nFlags, point);
+    wxPoint point = ClientToWorkspace(event.GetPosition());
+    pTool.OnMouseMove(*this, event.GetModifiers(), CB::GetMouseButtons(event), point);
 }
 
-void CBrdEditView::OnLButtonUp(UINT nFlags, CPoint point)
+void CBrdEditView::OnLButtonUp(wxMouseEvent& event)
 {
     ToolType eToolType = MapToolType(m_nCurToolID);
     if (eToolType == ttypeUnknown)
     {
-        CScrollView::OnMouseMove(nFlags, point);
+        OwnerPtr<wxEvent> moveEvent = event.Clone();
+        moveEvent->SetEventType(wxEVT_MOTION);
+        ProcessWindowEvent(*moveEvent);
         return;
     }
     CTool& pTool = CTool::GetTool(eToolType);
-    ClientToWorkspace(point);
-    pTool.OnLButtonUp(*this, nFlags, point);
+    wxPoint point = ClientToWorkspace(event.GetPosition());
+    pTool.OnLButtonUp(*this, event.GetModifiers(), point);
 }
 
-void CBrdEditView::OnLButtonDblClk(UINT nFlags, CPoint point)
+void CBrdEditView::OnLButtonDblClk(wxMouseEvent& event)
 {
     ToolType eToolType = MapToolType(m_nCurToolID);
     if (eToolType == ttypeUnknown)
     {
-        CScrollView::OnMouseMove(nFlags, point);
+        OwnerPtr<wxEvent> moveEvent = event.Clone();
+        moveEvent->SetEventType(wxEVT_MOTION);
+        ProcessWindowEvent(*moveEvent);
         return;
     }
     CTool& pTool = CTool::GetTool(eToolType);
-    ClientToWorkspace(point);
-    pTool.OnLButtonDblClk(*this, nFlags, point);
+    wxPoint point = ClientToWorkspace(event.GetPosition());
+    pTool.OnLButtonDblClk(*this, event.GetModifiers(), point);
 }
 
+void CBrdEditView::OnMouseCaptureLost(wxMouseCaptureLostEvent& event)
+{
+    ToolType eToolType = MapToolType(m_nCurToolID);
+    if (eToolType == ttypeUnknown)
+    {
+        return;
+    }
+    CTool& pTool = CTool::GetTool(eToolType);
+    pTool.OnMouseCaptureLost(*this);
+}
+
+#if 0
 void CBrdEditView::OnTimer(uintptr_t nIDEvent)
 {
     ToolType eToolType = MapToolType(m_nCurToolID);
     CTool& pTool = CTool::GetTool(eToolType);
     pTool.OnTimer(*this, nIDEvent);
 }
+#endif
 
-BOOL CBrdEditView::OnSetCursor(CWnd* pWnd, UINT nHitTest, UINT message)
+void CBrdEditView::OnSetCursor(wxSetCursorEvent& event)
 {
     ToolType eToolType = MapToolType(m_nCurToolID);
-    if (pWnd == this && eToolType != ttypeUnknown)
+    wxASSERT(event.GetEventObject() == this);
+    if (event.GetEventObject() == this && eToolType != ttypeUnknown)
     {
         CTool& pTool = CTool::GetTool(eToolType);
-        if(pTool.OnSetCursor(*this, nHitTest))
-            return TRUE;
+        wxPoint point = ClientToWorkspace(wxPoint(event.GetX(), event.GetY()));
+        wxCursor rc = pTool.OnSetCursor(*this, point);
+        if (rc.IsOk())
+        {
+            event.SetCursor(rc);
+            return;
+        }
     }
-    return CScrollView::OnSetCursor(pWnd, nHitTest, message);
+    event.Skip();
 }
 
 //////////////////////////////////////////////////////////////////////
 
+#if 0
 void CBrdEditView::OnChar(UINT nChar, UINT nRepCnt, UINT nFlags)
 {
     ToolType eToolType = MapToolType(m_nCurToolID);
@@ -809,44 +838,45 @@ void CBrdEditView::OnUpdateEditClear(CCmdUI* pCmdUI)
     pCmdUI->Enable(m_pBoard->GetMaxDrawLayer() != LAYER_GRID &&
         m_selList.IsAnySelects());
 }
+#endif
 
 //////////////////////////////////////////////////////////////////////
 
-static ToolType tblDrawTools[] =
+ToolType CBrdEditView::MapToolType(int nToolResID) const
 {
-    ttypeSelect,    // ID_TOOL_ARROW
-    ttypeUnknown,   // ID_TOOL_ERASER
-    ttypeTile,      // ID_TOOL_TILE
-    ttypeText,      // ID_TOOL_TEXT
-    ttypePaintBack, // ID_TOOL_FILL
-    ttypeColorPick, // ID_TOOL_DROPPER
-    ttypeLine,      // ID_TOOL_LINE
-    ttypePolygon,   // ID_TOOL_POLYGON
-    ttypeRect,      // ID_TOOL_RECT
-    ttypeEllipse,   // ID_TOOL_OVAL
-};
+    // wx doesn't guarantee XRCID() value order
+    static const std::unordered_map<int, ToolType> tblDrawTools
+    {
+        { XRCID("ID_TOOL_ARROW"), ttypeSelect },
+        { XRCID("ID_TOOL_ERASER"), ttypeUnknown },
+        { XRCID("ID_TOOL_TILE"), ttypeTile },
+        { XRCID("ID_TOOL_TEXT"), ttypeText },
+        { XRCID("ID_TOOL_FILL"), ttypePaintBack },
+        { XRCID("ID_TOOL_DROPPER"), ttypeColorPick },
+        { XRCID("ID_TOOL_LINE"), ttypeLine },
+        { XRCID("ID_TOOL_POLYGON"), ttypePolygon },
+        { XRCID("ID_TOOL_RECT"), ttypeRect },
+        { XRCID("ID_TOOL_OVAL"), ttypeEllipse },
+    };
 
-static ToolType tblGridTools[] =
-{
-    ttypeUnknown,   // ID_TOOL_ARROW
-    ttypeCellEraser,// ID_TOOL_ERASER
-    ttypeTile,      // ID_TOOL_TILE
-    ttypeUnknown,   // ID_TOOL_TEXT
-    ttypeCellPaint, // ID_TOOL_FILL
-    ttypeColorPick, // ID_TOOL_DROPPER
-    ttypeUnknown,   // ID_TOOL_LINE
-    ttypeUnknown,   // ID_TOOL_POLYGON
-    ttypeUnknown,   // ID_TOOL_RECT
-    ttypeUnknown,   // ID_TOOL_OVAL
-};
+    static const std::unordered_map<int, ToolType> tblGridTools
+    {
+        { XRCID("ID_TOOL_ARROW"), ttypeUnknown },
+        { XRCID("ID_TOOL_ERASER"), ttypeCellEraser },
+        { XRCID("ID_TOOL_TILE"), ttypeTile },
+        { XRCID("ID_TOOL_TEXT"), ttypeUnknown },
+        { XRCID("ID_TOOL_FILL"), ttypeCellPaint },
+        { XRCID("ID_TOOL_DROPPER"), ttypeColorPick },
+        { XRCID("ID_TOOL_LINE"), ttypeUnknown },
+        { XRCID("ID_TOOL_POLYGON"), ttypeUnknown },
+        { XRCID("ID_TOOL_RECT"), ttypeUnknown },
+        { XRCID("ID_TOOL_OVAL"), ttypeUnknown },
+    };
 
-ToolType CBrdEditView::MapToolType(UINT nToolResID) const
-{
     return m_pBoard->GetMaxDrawLayer() == LAYER_GRID ?
-        tblGridTools[nToolResID - ID_TOOL_ARROW] :
-        tblDrawTools[nToolResID - ID_TOOL_ARROW];
+        tblGridTools.at(nToolResID) :
+        tblDrawTools.at(nToolResID);
 }
-#endif
 
 //////////////////////////////////////////////////////////////////////
 // Tile drag and drop code.
@@ -857,8 +887,8 @@ void CBrdEditView::OnDragTileItem(DragDropEvent& event)
     {
         return;
     }
-    m_nCurToolID = ID_TOOL_ARROW;       // Not valid with drag over.
-    m_nLastToolID = ID_TOOL_ARROW;      // Not valid with drag over.
+    m_nCurToolID = XRCID("ID_TOOL_ARROW");       // Not valid with drag over.
+    m_nLastToolID = XRCID("ID_TOOL_ARROW");      // Not valid with drag over.
 
     const DragInfoWx& pdi = event.GetDragInfo();
 
@@ -1194,33 +1224,42 @@ void CBrdEditView::PixelToWorkspace(CPoint& point) const
     m_pBoard->GetBoardArray().GetBoardScaling(m_nZoom, wsize, vsize);
     ScalePoint(point, wsize, vsize);
 }
+#endif
 
 //////////////////////////////////////////////////////////////////////
 
-void CBrdEditView::OnUpdateColorForeground(CCmdUI* pCmdUI)
+void CBrdEditView::OnUpdateColorForeground(wxUpdateUIEvent& pCmdUI)
 {
-    static_cast<CColorCmdUI*>(pCmdUI)->SetColor(CB::Convert(m_pBMgr->GetForeColor()));
+    CCmdUI* cmdui = static_cast<CCmdUI*>(pCmdUI.GetClientData());
+    CColorCmdUI& colorCmdUI = CheckedDeref(dynamic_cast<CColorCmdUI*>(cmdui));
+    colorCmdUI.SetColor(CB::Convert(m_pBMgr->GetForeColor()));
 }
 
-void CBrdEditView::OnUpdateColorBackground(CCmdUI* pCmdUI)
+void CBrdEditView::OnUpdateColorBackground(wxUpdateUIEvent& pCmdUI)
 {
-    static_cast<CColorCmdUI*>(pCmdUI)->SetColor(CB::Convert(m_pBMgr->GetBackColor()));
+    CCmdUI* cmdui = static_cast<CCmdUI*>(pCmdUI.GetClientData());
+    CColorCmdUI& colorCmdUI = CheckedDeref(dynamic_cast<CColorCmdUI*>(cmdui));
+    colorCmdUI.SetColor(CB::Convert(m_pBMgr->GetBackColor()));
 }
 
-void CBrdEditView::OnUpdateColorCustom(CCmdUI* pCmdUI)
+void CBrdEditView::OnUpdateColorCustom(wxUpdateUIEvent& pCmdUI)
 {
-    static_cast<CColorCmdUI*>(pCmdUI)->SetCustomColors(GetDocument().GetCustomColors());
+    CCmdUI* cmdui = static_cast<CCmdUI*>(pCmdUI.GetClientData());
+    CColorCmdUI& colorCmdUI = CheckedDeref(dynamic_cast<CColorCmdUI*>(cmdui));
+    colorCmdUI.SetCustomColors(GetDocument().GetCustomColors());
 }
 
-void CBrdEditView::OnUpdateLineWidth(CCmdUI* pCmdUI)
+void CBrdEditView::OnUpdateLineWidth(wxUpdateUIEvent& pCmdUI)
 {
-    static_cast<CColorCmdUI*>(pCmdUI)->SetLineWidth(value_preserving_cast<UINT>(m_pBMgr->GetLineWidth()));
+    CCmdUI* cmdui = static_cast<CCmdUI*>(pCmdUI.GetClientData());
+    CColorCmdUI& colorCmdUI = CheckedDeref(dynamic_cast<CColorCmdUI*>(cmdui));
+    colorCmdUI.SetLineWidth(value_preserving_cast<UINT>(m_pBMgr->GetLineWidth()));
 }
 
 //////////////////////////////////////////////////////////////////////
 
 
-LRESULT CBrdEditView::OnSetColor(WPARAM wParam, LPARAM lParam)
+void CBrdEditView::OnSetColor(SetColorEvent& event)
 {
     struct ColorSetting
     {
@@ -1229,39 +1268,40 @@ LRESULT CBrdEditView::OnSetColor(WPARAM wParam, LPARAM lParam)
     };
     ColorSetting cset = { RGB(0,0,0), FALSE };
 
-    if ((UINT)wParam == ID_COLOR_FOREGROUND)
+    if (event.GetSubId() == XRCID("ID_COLOR_FOREGROUND"))
     {
-        m_pBMgr->SetForeColor((COLORREF)lParam);
+        m_pBMgr->SetForeColor(CB::Convert(event.GetColor()));
         cset.m_cr = m_pBMgr->GetForeColor();
         m_selList.ForAllSelections([&cset](CDrawObj& pObj) { cset.m_bColorAccepted |= pObj.SetForeColor(cset.m_cr); });
         m_selList.UpdateObjects();
     }
-    else if ((UINT)wParam == ID_COLOR_BACKGROUND)
+    else if (event.GetSubId() == XRCID("ID_COLOR_BACKGROUND"))
     {
-        m_pBMgr->SetBackColor((COLORREF)lParam);
+        m_pBMgr->SetBackColor(CB::Convert(event.GetColor()));
         cset.m_cr = m_pBMgr->GetBackColor();
         m_selList.ForAllSelections([&cset](CDrawObj& pObj) { cset.m_bColorAccepted |= pObj.SetBackColor(cset.m_cr); });
         m_selList.UpdateObjects();
     }
     else
-        return 0;
+    {
+        event.Skip();
+        return;
+    }
     if (cset.m_bColorAccepted)
         GetDocument().SetModifiedFlag();
-    return 1;
 }
 
 //////////////////////////////////////////////////////////////////////
 
-LRESULT CBrdEditView::OnSetCustomColors(WPARAM wParam, LPARAM lParam)
+void CBrdEditView::OnSetCustomColors(SetCustomColorEvent& event)
 {
-    const std::vector<wxColour>& pCustomColors = CheckedDeref(reinterpret_cast<const std::vector<wxColour>*>(wParam));
+    const std::vector<wxColour>& pCustomColors = event.GetColors();
     GetDocument().SetCustomColors(pCustomColors);
-    return (LRESULT)0;
 }
 
 //////////////////////////////////////////////////////////////////////
 
-LRESULT CBrdEditView::OnSetLineWidth(WPARAM wParam, LPARAM lParam)
+void CBrdEditView::OnSetLineWidth(SetLineWidthEvent& event)
 {
     struct WidthSetting
     {
@@ -1270,18 +1310,18 @@ LRESULT CBrdEditView::OnSetLineWidth(WPARAM wParam, LPARAM lParam)
     };
     WidthSetting wset = { 1, FALSE };
 
-    m_pBMgr->SetLineWidth((UINT)wParam);
+    m_pBMgr->SetLineWidth(event.GetWidth());
     m_selList.UpdateObjects();
     wset.m_nWidth = m_pBMgr->GetLineWidth();
     m_selList.ForAllSelections([&wset](CDrawObj& pObj) { wset.m_bWidthAccepted |= pObj.SetLineWidth(wset.m_nWidth); });
     m_selList.UpdateObjects(TRUE, FALSE);
     if (wset.m_bWidthAccepted)
         GetDocument().SetModifiedFlag();
-    return 1;
 }
 
 // ------------------------------------------------------ //
 
+#if 0
 void CBrdEditView::OnDwgFont()
 {
     if (m_pBMgr->DoBoardFontDialog())
@@ -1297,16 +1337,17 @@ void CBrdEditView::OnDwgFont()
         }
     }
 }
+#endif
 
 // ------------------------------------------------------ //
 
-BOOL CBrdEditView::OnToolPalette(UINT id)
+void CBrdEditView::OnToolPalette(wxCommandEvent& event)
 {
-    if (id != ID_TOOL_ARROW)
+    if (event.GetId() != XRCID("ID_TOOL_ARROW"))
         m_selList.PurgeList(TRUE);
-    if (id != m_nCurToolID)
+    if (event.GetId() != m_nCurToolID)
     {
-        if (m_nCurToolID == ID_TOOL_POLYGON)
+        if (m_nCurToolID == XRCID("ID_TOOL_POLYGON"))
         {
             // If we're changing away from the polygon tool
             // we need to act as if the escape key was hit.
@@ -1320,62 +1361,57 @@ BOOL CBrdEditView::OnToolPalette(UINT id)
             }
         }
         m_nLastToolID = m_nCurToolID;
-        m_nCurToolID = id;
+        m_nCurToolID = event.GetId();
     }
-    return TRUE;
 }
 
 // ---------------------------------------------------- //
 
-void CBrdEditView::OnUpdateToolPalette(CCmdUI* pCmdUI)
+void CBrdEditView::OnUpdateToolPalette(wxUpdateUIEvent& pCmdUI)
 {
     TileID tid;
     int iLayer = m_pBoard->GetMaxDrawLayer();
     BOOL bEnable;
 
-    switch (pCmdUI->m_nID)
+    if (pCmdUI.GetId() == XRCID("ID_TOOL_TILE"))
     {
-        case ID_TOOL_TILE:
-            tid = GetDocument().GetTilePalWnd()->GetCurrentTileID();
-            bEnable = tid != nullTid;
-            if (tid == nullTid && m_nCurToolID == ID_TOOL_TILE)
-            {
-                m_nCurToolID = ID_TOOL_ARROW;
-                m_nLastToolID = ID_TOOL_ARROW;
-            }
-            break;
-        case ID_TOOL_ARROW:
-        case ID_TOOL_DROPPER:
-            bEnable = TRUE;
-            break;
-        case ID_TOOL_FILL:
-        case ID_TOOL_ERASER:
-            bEnable = iLayer == LAYER_BASE || iLayer == LAYER_GRID;
-            break;
-        case ID_TOOL_TEXT:
-        case ID_TOOL_LINE:
-        case ID_TOOL_POLYGON:
-        case ID_TOOL_RECT:
-        case ID_TOOL_OVAL:
-            bEnable = iLayer == LAYER_BASE || iLayer == LAYER_TOP;
-            break;
-        default:
-            ASSERT(!"unexpected tool id");
-            bEnable = false;
+        tid = GetDocument().GetTilePalWnd()->GetCurrentTileID();
+        bEnable = tid != nullTid;
+        if (tid == nullTid && m_nCurToolID == XRCID("ID_TOOL_TILE"))
+        {
+            m_nCurToolID = XRCID("ID_TOOL_ARROW");
+            m_nLastToolID = XRCID("ID_TOOL_ARROW");
+        }
     }
-    if (pCmdUI->m_pSubMenu != NULL)
+    else if (pCmdUI.GetId() == XRCID("ID_TOOL_ARROW") ||
+            pCmdUI.GetId() == XRCID("ID_TOOL_DROPPER"))
     {
-        // Need to handle menu that the submenu is connected to.
-        pCmdUI->m_pMenu->EnableMenuItem(pCmdUI->m_nIndex,
-            MF_BYPOSITION | (bEnable ? MF_ENABLED : (MF_DISABLED | MF_GRAYED)));
+        bEnable = TRUE;
+    }
+    else if (pCmdUI.GetId() == XRCID("ID_TOOL_FILL") ||
+            pCmdUI.GetId() == XRCID("ID_TOOL_ERASER"))
+    {
+        bEnable = iLayer == LAYER_BASE || iLayer == LAYER_GRID;
+    }
+    else if (pCmdUI.GetId() == XRCID("ID_TOOL_TEXT") ||
+            pCmdUI.GetId() == XRCID("ID_TOOL_LINE") ||
+            pCmdUI.GetId() == XRCID("ID_TOOL_POLYGON") ||
+            pCmdUI.GetId() == XRCID("ID_TOOL_RECT") ||
+            pCmdUI.GetId() == XRCID("ID_TOOL_OVAL"))
+    {
+        bEnable = iLayer == LAYER_BASE || iLayer == LAYER_TOP;
+    }
+    else
+    {
+        ASSERT(!"unexpected tool id");
+        bEnable = false;
     }
 
-    pCmdUI->Enable(bEnable);
-    // NOTE!!: The control ID's are assumed to be consecutive and
-    // in the same order as the tool codes defined in MAINFRM.C
-    pCmdUI->SetCheck(pCmdUI->m_nID == m_nCurToolID);
+    pCmdUI.Enable(bEnable);
+    pCmdUI.Check(pCmdUI.GetId()  == m_nCurToolID);
 }
 
+#if 0
 void CBrdEditView::OnUpdateDwgToFrontOrBack(CCmdUI* pCmdUI)
 {
     pCmdUI->Enable(!m_selList.empty());
@@ -1514,7 +1550,7 @@ void CBrdEditView::OnUpdateIndicatorCellNum(CCmdUI* pCmdUI)
         GetClientRect(&rct);
         if (rct.PtInRect(point))
         {
-            point += (CSize)GetDeviceScrollPosition();
+            point = CalcUnscrolledPosition(point);
             CB::string str = pba.GetCellNumberStr(point, m_nZoom);
             pCmdUI->Enable();
             pCmdUI->SetText(str);

--- a/GM/VwEdtbrd.cpp
+++ b/GM/VwEdtbrd.cpp
@@ -111,9 +111,7 @@ wxBEGIN_EVENT_TABLE(CBrdEditView, wxScrolledCanvas)
     EVT_UPDATE_UI(XRCID("ID_EDIT_PASTEBITMAPFROMFILE"), OnUpdateEditPasteBitmapFromFile)
     EVT_MENU(wxID_CLEAR, OnEditClear)
     EVT_UPDATE_UI(wxID_CLEAR, OnUpdateEditClear)
-#if 0
-    ON_WM_CONTEXTMENU()
-#endif
+    EVT_CONTEXT_MENU(OnContextMenu)
     EVT_MENU(wxID_COPY, OnEditCopy)
     EVT_UPDATE_UI(wxID_COPY, OnUpdateEditCopy)
 #if 0
@@ -574,30 +572,26 @@ void CBrdEditView::OnUpdateEditLayer(wxUpdateUIEvent& pCmdUI)
 
 /////////////////////////////////////////////////////////////////////////////
 
-#if 0
-void CBrdEditView::OnContextMenu(CWnd* pWnd, CPoint point)
+void CBrdEditView::OnContextMenu(wxContextMenuEvent& event)
 {
-    // Make sure window is active.
-    GetParentFrame()->ActivateFrame();
-
-    CMenu bar;
-    if (bar.LoadMenuW(IDR_MENU_DESIGN_POPUPS))
+    std::unique_ptr<wxMenuBar> bar(wxXmlResource::Get()->LoadMenuBar("IDR_MENU_DESIGN_POPUPS"));
+    if (bar)
     {
-        CMenu& popup = *bar.GetSubMenu(MENU_BV_DRAWING);
-        ASSERT(popup.m_hMenu != NULL);
+        int index = bar->FindMenu("0=BV_EDIT");
+        wxASSERT(index != wxNOT_FOUND);
+        std::unique_ptr<wxMenu> popup(bar->Remove(value_preserving_cast<size_t>(index)));
 
         // Make sure we clean up even if exception is tossed.
-        TRY
+        try
         {
-            popup.TrackPopupMenu(TPM_RIGHTBUTTON, point.x, point.y,
-                AfxGetMainWnd()); // Route commands through main window
-            // Make sure command is dispatched BEFORE we clear m_bInRightMouse.
-            GetApp()->DispatchMessages();
+            PopupMenu(&*popup);
         }
-        END_TRY
+        catch (...)
+        {
+            wxASSERT(!"exception");
+        }
     }
 }
-#endif
 
 /////////////////////////////////////////////////////////////////////////////
 // CBrdEditView mouse and timer message handlers

--- a/GM/VwEdtbrd.cpp
+++ b/GM/VwEdtbrd.cpp
@@ -60,8 +60,8 @@ wxBEGIN_EVENT_TABLE(CBrdEditView, wxScrolledCanvas)
     EVT_MOTION(OnMouseMove)
     EVT_LEFT_DCLICK(OnLButtonDblClk)
     EVT_MOUSE_CAPTURE_LOST(OnMouseCaptureLost)
+    EVT_TIMER(wxID_ANY, OnTimer)
 #if 0
-    ON_WM_TIMER()
     ON_WM_KEYDOWN()
     ON_WM_CHAR()
 #endif
@@ -166,7 +166,8 @@ END_MESSAGE_MAP()
 CBrdEditView::CBrdEditView(CBrdEditViewContainer& p) :
     m_selList(*this),
     parent(&p),
-    document(dynamic_cast<CGamDoc*>(parent->GetDocument()))
+    document(dynamic_cast<CGamDoc*>(parent->GetDocument())),
+    timer(this)
 {
     m_bOffScreen = TRUE;
     m_pBoard = NULL;
@@ -675,14 +676,12 @@ void CBrdEditView::OnMouseCaptureLost(wxMouseCaptureLostEvent& event)
     pTool.OnMouseCaptureLost(*this);
 }
 
-#if 0
-void CBrdEditView::OnTimer(uintptr_t nIDEvent)
+void CBrdEditView::OnTimer(wxTimerEvent& event)
 {
     ToolType eToolType = MapToolType(m_nCurToolID);
     CTool& pTool = CTool::GetTool(eToolType);
-    pTool.OnTimer(*this, nIDEvent);
+    pTool.OnTimer(*this);
 }
-#endif
 
 void CBrdEditView::OnSetCursor(wxSetCursorEvent& event)
 {

--- a/GM/VwEdtbrd.cpp
+++ b/GM/VwEdtbrd.cpp
@@ -1052,6 +1052,7 @@ void CBrdEditView::DoCreateTextDrawingObject(CPoint point)
         }
     }
 }
+#endif
 
 void CBrdEditView::DoEditTextDrawingObject(CText& pDObj)
 {
@@ -1064,19 +1065,20 @@ void CBrdEditView::DoEditTextDrawingObject(CText& pDObj)
     {
         if (!dlg.m_strText.empty())
         {
-            CRect rct = pDObj.GetEnclosingRect();
-            InvalidateWorkspaceRect(&rct);
+            wxRect rct = CB::Convert(pDObj.GetEnclosingRect());
+            InvalidateWorkspaceRect(rct);
 
             pDObj.m_text = dlg.m_strText;
             pDObj.SetFont(dlg.m_fontID);   // Also resyncs the extent rect
 
-            rct = pDObj.GetEnclosingRect();
-            InvalidateWorkspaceRect(&rct);
+            rct = CB::Convert(pDObj.GetEnclosingRect());
+            InvalidateWorkspaceRect(rct);
             GetDocument().SetModifiedFlag();
         }
     }
 }
 
+#if 0
 void CBrdEditView::CreateTextDrawingObject(CPoint pnt, FontID fid,
     COLORREF crText, const CB::string& strText, BOOL bInvalidate /* = TRUE */)
 {

--- a/GM/VwEdtbrd.cpp
+++ b/GM/VwEdtbrd.cpp
@@ -591,7 +591,7 @@ void CBrdEditView::OnLButtonDown(UINT nFlags, CPoint point)
     }
     CTool& pTool = CTool::GetTool(eToolType);
     ClientToWorkspace(point);
-    pTool.OnLButtonDown(this, nFlags, point);
+    pTool.OnLButtonDown(*this, nFlags, point);
 }
 
 void CBrdEditView::OnMouseMove(UINT nFlags, CPoint point)
@@ -604,7 +604,7 @@ void CBrdEditView::OnMouseMove(UINT nFlags, CPoint point)
     }
     CTool& pTool = CTool::GetTool(eToolType);
     ClientToWorkspace(point);
-    pTool.OnMouseMove(this, nFlags, point);
+    pTool.OnMouseMove(*this, nFlags, point);
 }
 
 void CBrdEditView::OnLButtonUp(UINT nFlags, CPoint point)
@@ -617,7 +617,7 @@ void CBrdEditView::OnLButtonUp(UINT nFlags, CPoint point)
     }
     CTool& pTool = CTool::GetTool(eToolType);
     ClientToWorkspace(point);
-    pTool.OnLButtonUp(this, nFlags, point);
+    pTool.OnLButtonUp(*this, nFlags, point);
 }
 
 void CBrdEditView::OnLButtonDblClk(UINT nFlags, CPoint point)
@@ -630,14 +630,14 @@ void CBrdEditView::OnLButtonDblClk(UINT nFlags, CPoint point)
     }
     CTool& pTool = CTool::GetTool(eToolType);
     ClientToWorkspace(point);
-    pTool.OnLButtonDblClk(this, nFlags, point);
+    pTool.OnLButtonDblClk(*this, nFlags, point);
 }
 
 void CBrdEditView::OnTimer(uintptr_t nIDEvent)
 {
     ToolType eToolType = MapToolType(m_nCurToolID);
     CTool& pTool = CTool::GetTool(eToolType);
-    pTool.OnTimer(this, nIDEvent);
+    pTool.OnTimer(*this, nIDEvent);
 }
 
 BOOL CBrdEditView::OnSetCursor(CWnd* pWnd, UINT nHitTest, UINT message)
@@ -646,7 +646,7 @@ BOOL CBrdEditView::OnSetCursor(CWnd* pWnd, UINT nHitTest, UINT message)
     if (pWnd == this && eToolType != ttypeUnknown)
     {
         CTool& pTool = CTool::GetTool(eToolType);
-        if(pTool.OnSetCursor(this, nHitTest))
+        if(pTool.OnSetCursor(*this, nHitTest))
             return TRUE;
     }
     return CScrollView::OnSetCursor(pWnd, nHitTest, message);
@@ -663,13 +663,13 @@ void CBrdEditView::OnChar(UINT nChar, UINT nRepCnt, UINT nFlags)
         CPolyTool& pPolyTool = static_cast<CPolyTool&>(pTool);
         if (nChar == VK_ESCAPE)
         {
-            pPolyTool.RemoveRubberBand(this);
-            pPolyTool.FinalizePolygon(this, TRUE);
+            pPolyTool.RemoveRubberBand(*this);
+            pPolyTool.FinalizePolygon(*this, TRUE);
         }
         else if (nChar == VK_RETURN)
         {
-            pPolyTool.RemoveRubberBand(this);
-            pPolyTool.FinalizePolygon(this, FALSE);
+            pPolyTool.RemoveRubberBand(*this);
+            pPolyTool.FinalizePolygon(*this, FALSE);
         }
     }
     CScrollView::OnChar(nChar, nRepCnt, nFlags);
@@ -1292,8 +1292,8 @@ BOOL CBrdEditView::OnToolPalette(UINT id)
             if (pTool.m_eToolType == ttypePolygon)
             {
                 CPolyTool& pPolyTool = static_cast<CPolyTool&>(pTool);
-                pPolyTool.RemoveRubberBand(this);
-                pPolyTool.FinalizePolygon(this, TRUE);
+                pPolyTool.RemoveRubberBand(*this);
+                pPolyTool.FinalizePolygon(*this, TRUE);
             }
         }
         m_nLastToolID = m_nCurToolID;

--- a/GM/VwEdtbrd.cpp
+++ b/GM/VwEdtbrd.cpp
@@ -75,14 +75,14 @@ wxBEGIN_EVENT_TABLE(CBrdEditView, wxScrolledCanvas)
     EVT_SETLINEWIDTH(OnSetLineWidth)
 #if 0
     ON_COMMAND(ID_OFFSCREEN, OnOffscreen)
-    ON_COMMAND(ID_VIEW_GRIDLINES, OnViewGridLines)
-    ON_COMMAND(ID_DWG_TOBACK, OnDwgToBack)
-    ON_COMMAND(ID_DWG_TOFRONT, OnDwgToFront)
 #endif
+    EVT_MENU(XRCID("ID_VIEW_GRIDLINES"), OnViewGridLines)
+    EVT_MENU(XRCID("ID_DWG_TOBACK"), OnDwgToBack)
+    EVT_MENU(XRCID("ID_DWG_TOFRONT"), OnDwgToFront)
     EVT_MENU(XRCID("ID_TOOL_ARROW"), OnToolPalette)
     EVT_MENU(XRCID("ID_EDIT_LAYER_BASE"), OnEditLayer)
+    EVT_UPDATE_UI(XRCID("ID_VIEW_GRIDLINES"), OnUpdateViewGridLines)
 #if 0
-    ON_UPDATE_COMMAND_UI(ID_VIEW_GRIDLINES, OnUpdateViewGridLines)
     ON_UPDATE_COMMAND_UI(ID_OFFSCREEN, OnUpdateOffscreen)
 #endif
     EVT_UPDATE_UI(XRCID("ID_EDIT_LAYER_BASE"), OnUpdateEditLayer)
@@ -91,40 +91,38 @@ wxBEGIN_EVENT_TABLE(CBrdEditView, wxScrolledCanvas)
     EVT_UPDATE_UI(XRCID("ID_COLOR_CUSTOM"), OnUpdateColorCustom)
     EVT_UPDATE_UI(XRCID("ID_LINE_WIDTH"), OnUpdateLineWidth)
     EVT_UPDATE_UI(XRCID("ID_TOOL_ARROW"), OnUpdateToolPalette)
-#if 0
-    ON_UPDATE_COMMAND_UI(ID_DWG_TOFRONT, OnUpdateDwgToFrontOrBack)
-#endif
+    EVT_UPDATE_UI(XRCID("ID_DWG_TOFRONT"), OnUpdateDwgToFrontOrBack)
     EVT_UPDATE_UI(XRCID("ID_VIEW_FULLSCALE"), OnUpdateViewFullScale)
     EVT_UPDATE_UI(XRCID("ID_VIEW_HALFSCALE"), OnUpdateViewHalfScale)
-#if 0
-    ON_COMMAND(ID_DWG_FONT, OnDwgFont)
-#endif
+    EVT_MENU(XRCID("ID_DWG_FONT"), OnDwgFont)
     EVT_MENU(XRCID("ID_VIEW_FULLSCALE"), OnViewFullScale)
     EVT_MENU(XRCID("ID_VIEW_HALFSCALE"), OnViewHalfScale)
     EVT_MENU(XRCID("ID_VIEW_SMALLSCALE"), OnViewSmallScale)
     EVT_UPDATE_UI(XRCID("ID_VIEW_SMALLSCALE"), OnUpdateViewSmallScale)
+    EVT_UPDATE_UI(XRCID("ID_INDICATOR_CELLNUM"), OnUpdateIndicatorCellNum)
+    EVT_MENU(XRCID("ID_TOOLS_BRDSNAPGRID"), OnToolsBrdSnapGrid)
+    EVT_UPDATE_UI(XRCID("ID_TOOLS_BRDSNAPGRID"), OnUpdateToolsBrdSnapGrid)
+    EVT_MENU(XRCID("ID_TOOLS_BRDPROPS"), OnToolsBrdProps)
+    EVT_MENU(XRCID("ID_TOOL_SETVISIBLESCALE"), OnToolSetVisibleScale)
+    EVT_UPDATE_UI(XRCID("ID_TOOL_SETVISIBLESCALE"), OnUpdateToolSetVisibleScale)
+    EVT_MENU(XRCID("ID_TOOL_SUSPENDSCALEVISIBILITY"), OnToolSuspendScaleVisibility)
+    EVT_UPDATE_UI(XRCID("ID_TOOL_SUSPENDSCALEVISIBILITY"), OnUpdateToolSuspendScaleVsibility)
+    EVT_MENU(wxID_PASTE, OnEditPaste)
+    EVT_UPDATE_UI(wxID_PASTE, OnUpdateEditPaste)
+    EVT_MENU(XRCID("ID_EDIT_PASTEBITMAPFROMFILE"), OnEditPasteBitmapFromFile)
+    EVT_UPDATE_UI(XRCID("ID_EDIT_PASTEBITMAPFROMFILE"), OnUpdateEditPasteBitmapFromFile)
+    EVT_MENU(wxID_CLEAR, OnEditClear)
+    EVT_UPDATE_UI(wxID_CLEAR, OnUpdateEditClear)
 #if 0
-    ON_UPDATE_COMMAND_UI(ID_INDICATOR_CELLNUM, OnUpdateIndicatorCellNum)
-    ON_COMMAND(ID_TOOLS_BRDSNAPGRID, OnToolsBrdSnapGrid)
-    ON_UPDATE_COMMAND_UI(ID_TOOLS_BRDSNAPGRID, OnUpdateToolsBrdSnapGrid)
-    ON_COMMAND(ID_TOOLS_BRDPROPS, OnToolsBrdProps)
-    ON_COMMAND(ID_TOOL_SETVISIBLESCALE, OnToolSetVisibleScale)
-    ON_UPDATE_COMMAND_UI(ID_TOOL_SETVISIBLESCALE, OnUpdateToolSetVisibleScale)
-    ON_COMMAND(ID_TOOL_SUSPENDSCALEVISIBILITY, OnToolSuspendScaleVisibility)
-    ON_UPDATE_COMMAND_UI(ID_TOOL_SUSPENDSCALEVISIBILITY, OnUpdateToolSuspendScaleVsibility)
-    ON_COMMAND(ID_EDIT_PASTE, OnEditPaste)
-    ON_UPDATE_COMMAND_UI(ID_EDIT_PASTE, OnUpdateEditPaste)
-    ON_COMMAND(ID_EDIT_PASTEBITMAPFROMFILE, OnEditPasteBitmapFromFile)
-    ON_UPDATE_COMMAND_UI(ID_EDIT_PASTEBITMAPFROMFILE, OnUpdateEditPasteBitmapFromFile)
-    ON_COMMAND(ID_EDIT_CLEAR, OnEditClear)
-    ON_UPDATE_COMMAND_UI(ID_EDIT_CLEAR, OnUpdateEditClear)
     ON_WM_CONTEXTMENU()
-    ON_COMMAND(ID_EDIT_COPY, OnEditCopy)
-    ON_UPDATE_COMMAND_UI(ID_EDIT_COPY, OnUpdateEditCopy)
-    ON_WM_SYSKEYDOWN()
-    ON_COMMAND(ID_DWG_DRAWABOVEGRID, OnDwgDrawAboveGrid)
-    ON_UPDATE_COMMAND_UI(ID_DWG_DRAWABOVEGRID, OnUpdateDwgDrawAboveGrid)
 #endif
+    EVT_MENU(wxID_COPY, OnEditCopy)
+    EVT_UPDATE_UI(wxID_COPY, OnUpdateEditCopy)
+#if 0
+    ON_WM_SYSKEYDOWN()
+#endif
+    EVT_MENU(XRCID("ID_DWG_DRAWABOVEGRID"), OnDwgDrawAboveGrid)
+    EVT_UPDATE_UI(XRCID("ID_DWG_DRAWABOVEGRID"), OnUpdateDwgDrawAboveGrid)
     EVT_MENU(XRCID("ID_EDIT_LAYER_TILE"), OnEditLayer)
     EVT_MENU(XRCID("ID_EDIT_LAYER_TOP"), OnEditLayer)
     EVT_MENU(XRCID("ID_TOOL_ERASER"), OnToolPalette)
@@ -147,10 +145,10 @@ wxBEGIN_EVENT_TABLE(CBrdEditView, wxScrolledCanvas)
     EVT_UPDATE_UI(XRCID("ID_TOOL_POLYGON"), OnUpdateToolPalette)
     EVT_UPDATE_UI(XRCID("ID_TOOL_RECT"), OnUpdateToolPalette)
     EVT_UPDATE_UI(XRCID("ID_TOOL_OVAL"), OnUpdateToolPalette)
-#if 0
-    ON_UPDATE_COMMAND_UI(ID_DWG_TOBACK, OnUpdateDwgToFrontOrBack)
-#endif
+    EVT_UPDATE_UI(XRCID("ID_DWG_TOBACK"), OnUpdateDwgToFrontOrBack)
     EVT_MENU(XRCID("ID_VIEW_TOGGLE_SCALE"), OnViewToggleScale)
+    EVT_UPDATE_UI(XRCID("ID_DWG_FONT"), OnUpdateEnable)
+    EVT_UPDATE_UI(XRCID("ID_TOOLS_BRDPROPS"), OnUpdateEnable)
     EVT_UPDATE_UI(XRCID("ID_VIEW_TOGGLE_SCALE"), OnUpdateEnable)
     EVT_SCROLLWIN_LINEDOWN(OnScrollWinLine)
     EVT_SCROLLWIN_LINEUP(OnScrollWinLine)
@@ -418,7 +416,6 @@ void CBrdEditView::SelectAllUnderPoint(wxPoint point)
     }
 }
 
-#if 0
 void CBrdEditView::DeleteObjsInSelectList(BOOL bInvalidate)
 {
     CDrawList* pDwg = GetDrawList(FALSE);
@@ -428,7 +425,6 @@ void CBrdEditView::DeleteObjsInSelectList(BOOL bInvalidate)
     if (bInvalidate)
         m_selList.InvalidateListHandles();
 
-    CRect rct;
     while (!m_selList.empty())
     {
         OwnerPtr<CSelection> pSel = std::move(m_selList.front());
@@ -482,6 +478,7 @@ void CBrdEditView::MoveObjsInSelectList(BOOL bToFront, BOOL bInvalidate)
 /////////////////////////////////////////////////////////////////////////////
 // CBrdEditView printing
 
+#if 0
 void CBrdEditView::OnPrepareDC(CDC* pDC, CPrintInfo* pInfo)
 {
     CScrollView::OnPrepareDC(pDC, pInfo);
@@ -523,25 +520,24 @@ void CBrdEditView::OnUpdateOffscreen(CCmdUI* pCmdUI)
 {
     pCmdUI->SetCheck(m_bOffScreen);
 }
+#endif
 
-void CBrdEditView::OnViewGridLines()
+void CBrdEditView::OnViewGridLines(wxCommandEvent& event)
 {
-    BeginWaitCursor();
+    wxBusyCursor busyCursor;
     m_pBoard->SetCellBorder(!m_pBoard->GetCellBorder());
-    Invalidate(FALSE);
-    UpdateWindow();
-    EndWaitCursor();
+    Refresh(FALSE);
+    Update();
 
     CGmBoxHint hint;
     hint.GetArgs<HINT_BOARDPROPCHANGE>().m_pBoard = &*m_pBoard;
-    GetDocument().UpdateAllViews(this, HINT_BOARDPROPCHANGE, &hint);
+    GetDocument().UpdateAllViews(&*parent, HINT_BOARDPROPCHANGE, &hint);
 }
 
-void CBrdEditView::OnUpdateViewGridLines(CCmdUI* pCmdUI)
+void CBrdEditView::OnUpdateViewGridLines(wxUpdateUIEvent& pCmdUI)
 {
-    pCmdUI->SetCheck(m_pBoard->GetCellBorder());
+    pCmdUI.Check(m_pBoard->GetCellBorder());
 }
-#endif
 
 namespace
 {
@@ -822,22 +818,22 @@ void CBrdEditView::OnKeyDown(UINT nChar, UINT nRepCnt, UINT nFlags)
     }
     //...DFM19991118
 }
+#endif
 
 //////////////////////////////////////////////////////////////////////
 
-void CBrdEditView::OnEditClear()
+void CBrdEditView::OnEditClear(wxCommandEvent& /*event*/)
 {
-    ASSERT(m_pBoard->GetMaxDrawLayer() != LAYER_GRID &&
+    wxASSERT(m_pBoard->GetMaxDrawLayer() != LAYER_GRID &&
         m_selList.IsAnySelects());
     DeleteObjsInSelectList(TRUE);
 }
 
-void CBrdEditView::OnUpdateEditClear(CCmdUI* pCmdUI)
+void CBrdEditView::OnUpdateEditClear(wxUpdateUIEvent& pCmdUI)
 {
-    pCmdUI->Enable(m_pBoard->GetMaxDrawLayer() != LAYER_GRID &&
+    pCmdUI.Enable(m_pBoard->GetMaxDrawLayer() != LAYER_GRID &&
         m_selList.IsAnySelects());
 }
-#endif
 
 //////////////////////////////////////////////////////////////////////
 
@@ -1320,8 +1316,7 @@ void CBrdEditView::OnSetLineWidth(SetLineWidthEvent& event)
 
 // ------------------------------------------------------ //
 
-#if 0
-void CBrdEditView::OnDwgFont()
+void CBrdEditView::OnDwgFont(wxCommandEvent& /*event*/)
 {
     if (m_pBMgr->DoBoardFontDialog())
     {
@@ -1336,7 +1331,6 @@ void CBrdEditView::OnDwgFont()
         }
     }
 }
-#endif
 
 // ------------------------------------------------------ //
 
@@ -1410,52 +1404,49 @@ void CBrdEditView::OnUpdateToolPalette(wxUpdateUIEvent& pCmdUI)
     pCmdUI.Check(pCmdUI.GetId()  == m_nCurToolID);
 }
 
-#if 0
-void CBrdEditView::OnUpdateDwgToFrontOrBack(CCmdUI* pCmdUI)
+void CBrdEditView::OnUpdateDwgToFrontOrBack(wxUpdateUIEvent& pCmdUI)
 {
-    pCmdUI->Enable(!m_selList.empty());
+    pCmdUI.Enable(!m_selList.empty());
 }
 
-void CBrdEditView::OnDwgToBack()
+void CBrdEditView::OnDwgToBack(wxCommandEvent& /*event*/)
 {
     MoveObjsInSelectList(FALSE, TRUE);
 }
 
-void CBrdEditView::OnDwgToFront()
+void CBrdEditView::OnDwgToFront(wxCommandEvent& /*event*/)
 {
     MoveObjsInSelectList(TRUE, TRUE);
 }
 
-void CBrdEditView::OnUpdateDwgDrawAboveGrid(CCmdUI* pCmdUI)
+void CBrdEditView::OnUpdateDwgDrawAboveGrid(wxUpdateUIEvent& pCmdUI)
 {
     if (m_pBoard->GetMaxDrawLayer() == LAYER_TOP && !m_selList.empty())
     {
-        pCmdUI->Enable(TRUE);
+        pCmdUI.Enable(TRUE);
         if (m_selList.IsDObjFlagSetInAllSelectedObjects(dobjFlgDrawPass2))
-            pCmdUI->SetCheck(1);
+            pCmdUI.Check(true);
         else if (m_selList.IsDObjFlagSetInSomeSelectedObjects(dobjFlgDrawPass2))
-            pCmdUI->SetCheck(2);
+            pCmdUI.Set3StateValue(pCmdUI.Is3State() ?  wxCHK_UNDETERMINED : wxCHK_CHECKED);
         else
-            pCmdUI->SetCheck(0);
+            pCmdUI.Check(false);
     }
     else
     {
-        pCmdUI->Enable(FALSE);
-        pCmdUI->SetCheck(0);
+        pCmdUI.Enable(FALSE);
+        pCmdUI.Check(false);
     }
-
 }
 
-void CBrdEditView::OnDwgDrawAboveGrid()
+void CBrdEditView::OnDwgDrawAboveGrid(wxCommandEvent& /*event*/)
 {
-    ASSERT(!m_selList.empty());
+    wxASSERT(!m_selList.empty());
     if (m_selList.IsDObjFlagSetInAllSelectedObjects(dobjFlgDrawPass2))
         m_selList.ClearDObjFlagInAllSelectedObjects(dobjFlgDrawPass2);
     else
         m_selList.SetDObjFlagInAllSelectedObjects(dobjFlgDrawPass2);
     m_selList.InvalidateList(TRUE);
 }
-#endif
 
 void CBrdEditView::CenterViewOnWorkspacePoint(wxPoint point)
 {
@@ -1536,44 +1527,41 @@ void CBrdEditView::OnUpdateEnable(wxUpdateUIEvent& pCmdUI)
     pCmdUI.Enable(true);
 }
 
-#if 0
-void CBrdEditView::OnUpdateIndicatorCellNum(CCmdUI* pCmdUI)
+void CBrdEditView::OnUpdateIndicatorCellNum(wxUpdateUIEvent& pCmdUI)
 {
     CBoardArray& pba = m_pBoard->GetBoardArray();
     if (pba.GetCellNumTracking())
     {
-        CPoint point;
-        GetCursorPos(&point);
-        ScreenToClient(&point);
-        CRect rct;
-        GetClientRect(&rct);
-        if (rct.PtInRect(point))
+        wxPoint point = wxGetMouseState().GetPosition();
+        point = ScreenToClient(point);
+        wxRect rct = GetClientRect();
+        if (rct.Contains(point))
         {
             point = CalcUnscrolledPosition(point);
-            CB::string str = pba.GetCellNumberStr(point, m_nZoom);
-            pCmdUI->Enable();
-            pCmdUI->SetText(str);
+            CB::string str = pba.GetCellNumberStr(CB::Convert(point), m_nZoom);
+            pCmdUI.Enable(true);
+            pCmdUI.SetText(str);
         }
     }
 }
 
-void CBrdEditView::OnToolsBrdSnapGrid()
+void CBrdEditView::OnToolsBrdSnapGrid(wxCommandEvent& /*event*/)
 {
     m_pBoard->m_bGridSnap = !m_pBoard->m_bGridSnap;
 }
 
-void CBrdEditView::OnUpdateToolsBrdSnapGrid(CCmdUI* pCmdUI)
+void CBrdEditView::OnUpdateToolsBrdSnapGrid(wxUpdateUIEvent& pCmdUI)
 {
-    pCmdUI->Enable(TRUE);
-    pCmdUI->SetCheck(m_pBoard->m_bGridSnap);
+    pCmdUI.Enable(TRUE);
+    pCmdUI.Check(m_pBoard->m_bGridSnap);
 }
 
-void CBrdEditView::OnToolsBrdProps()
+void CBrdEditView::OnToolsBrdProps(wxCommandEvent& /*event*/)
 {
     GetDocument().DoBoardPropertyDialog(*m_pBoard);
 }
 
-void CBrdEditView::OnToolSetVisibleScale()
+void CBrdEditView::OnToolSetVisibleScale(wxCommandEvent& /*event*/)
 {
     CSetScaleVisibilityDialog dlg;
     dlg.m_bFullScale = TRUE;
@@ -1598,57 +1586,57 @@ void CBrdEditView::OnToolSetVisibleScale()
     }
 }
 
-void CBrdEditView::OnUpdateToolSetVisibleScale(CCmdUI* pCmdUI)
+void CBrdEditView::OnUpdateToolSetVisibleScale(wxUpdateUIEvent& pCmdUI)
 {
-    pCmdUI->Enable(m_selList.IsAnySelects());
+    pCmdUI.Enable(m_selList.IsAnySelects());
 }
 
-void CBrdEditView::OnToolSuspendScaleVisibility()
+void CBrdEditView::OnToolSuspendScaleVisibility(wxCommandEvent& /*event*/)
 {
     m_pBoard->SetApplyVisible(!m_pBoard->GetApplyVisible());
-    Invalidate(FALSE);
+    Refresh(FALSE);
 }
 
-void CBrdEditView::OnUpdateToolSuspendScaleVsibility(CCmdUI* pCmdUI)
+void CBrdEditView::OnUpdateToolSuspendScaleVsibility(wxUpdateUIEvent& pCmdUI)
 {
-    pCmdUI->SetCheck(!m_pBoard->GetApplyVisible());
+    pCmdUI.Check(!m_pBoard->GetApplyVisible());
 }
 
-void CBrdEditView::OnEditPaste()
+void CBrdEditView::OnEditPaste(wxCommandEvent& /*event*/)
 {
-    OwnerPtr<CBitmap> pBMap = GetClipboardBitmap(this);
+    wxBitmap pBMap = GetClipboardBitmap();
 
     {
         OwnerPtr<CBitmapImage> pDObj = MakeOwner<CBitmapImage>();
-        pDObj->SetBitmap(0, 0, (HBITMAP)pBMap->Detach(), fullScale);
+        pDObj->SetBitmap(0, 0, static_cast<HBITMAP>(CB::Convert(pBMap)->Detach()), fullScale);
 
         GetSelectList().PurgeList(TRUE);           // Clear current select list
         AddDrawObject(std::move(pDObj));
     }
     CDrawObj& pDObj = GetDrawList(FALSE)->Front();
     GetSelectList().AddObject(pDObj, TRUE);
-    CRect rct = pDObj.GetEnclosingRect();
+    wxRect rct = CB::Convert(pDObj.GetEnclosingRect());
     InvalidateWorkspaceRect(rct);
 }
 
-void CBrdEditView::OnUpdateEditPaste(CCmdUI* pCmdUI)
+void CBrdEditView::OnUpdateEditPaste(wxUpdateUIEvent& pCmdUI)
 {
     int nMaxLayer = m_pBoard->GetMaxDrawLayer();
-    pCmdUI->Enable(IsClipboardBitmap() &&
+    pCmdUI.Enable(IsClipboardBitmap() &&
         (nMaxLayer < 0 || nMaxLayer == LAYER_BASE || nMaxLayer == LAYER_TOP));
 }
 
-void CBrdEditView::OnEditCopy()
+void CBrdEditView::OnEditCopy(wxCommandEvent& /*event*/)
 {
     GetSelectList().CopyToClipboard();
 }
 
-void CBrdEditView::OnUpdateEditCopy(CCmdUI* pCmdUI)
+void CBrdEditView::OnUpdateEditCopy(wxUpdateUIEvent& pCmdUI)
 {
-    pCmdUI->Enable(GetSelectList().IsCopyToClipboardPossible());
+    pCmdUI.Enable(GetSelectList().IsCopyToClipboardPossible());
 }
 
-void CBrdEditView::OnEditPasteBitmapFromFile()
+void CBrdEditView::OnEditPasteBitmapFromFile(wxCommandEvent& /*event*/)
 {
     CB::string strFilter = CB::string::LoadString(IDS_BMP_FILTER);
     CB::string strTitle = CB::string::LoadString(IDS_SEL_BITMAPFILE);
@@ -1663,10 +1651,10 @@ void CBrdEditView::OnEditPasteBitmapFromFile()
     try
     {
         wxImage img(CB::string(dlg.GetPathName()));
-        OwnerPtr<CBitmap> pBMap = ToBitmap(img);
+        wxBitmap pBMap = img;
 
         OwnerPtr<CBitmapImage> pDObj = MakeOwner<CBitmapImage>();
-        pDObj->SetBitmap(0, 0, (HBITMAP)pBMap->Detach(), fullScale);
+        pDObj->SetBitmap(0, 0, (HBITMAP)CB::Convert(pBMap)->Detach(), fullScale);
 
         GetSelectList().PurgeList(TRUE);           // Clear current select list
         AddDrawObject(std::move(pDObj));
@@ -1678,17 +1666,18 @@ void CBrdEditView::OnEditPasteBitmapFromFile()
     }
     CDrawObj& pDObj = GetDrawList(FALSE)->Front();
     GetSelectList().AddObject(pDObj, TRUE);
-    CRect rct = pDObj.GetEnclosingRect();
-    InvalidateWorkspaceRect(&rct);
+    wxRect rct = CB::Convert(pDObj.GetEnclosingRect());
+    InvalidateWorkspaceRect(rct);
 }
 
-void CBrdEditView::OnUpdateEditPasteBitmapFromFile(CCmdUI* pCmdUI)
+void CBrdEditView::OnUpdateEditPasteBitmapFromFile(wxUpdateUIEvent& pCmdUI)
 {
     int nMaxLayer = m_pBoard->GetMaxDrawLayer();
-    pCmdUI->Enable(nMaxLayer < 0 || nMaxLayer == LAYER_BASE ||
+    pCmdUI.Enable(nMaxLayer < 0 || nMaxLayer == LAYER_BASE ||
         nMaxLayer == LAYER_TOP);
 }
 
+#if 0
 //DFM 19991014...
 //GetKeyState()
 static const short KEY_STATE_VALUE = static_cast<short>(static_cast<unsigned short>(0x8000));

--- a/GM/VwEdtbrd.cpp
+++ b/GM/VwEdtbrd.cpp
@@ -74,23 +74,31 @@ wxBEGIN_EVENT_TABLE(CBrdEditView, wxScrolledCanvas)
     ON_COMMAND(ID_DWG_TOBACK, OnDwgToBack)
     ON_COMMAND(ID_DWG_TOFRONT, OnDwgToFront)
     ON_COMMAND_EX(ID_TOOL_ARROW, OnToolPalette)
-    ON_COMMAND_EX(ID_EDIT_LAYER_BASE, OnEditLayer)
+#endif
+    EVT_MENU(XRCID("ID_EDIT_LAYER_BASE"), OnEditLayer)
+#if 0
     ON_UPDATE_COMMAND_UI(ID_VIEW_GRIDLINES, OnUpdateViewGridLines)
     ON_UPDATE_COMMAND_UI(ID_OFFSCREEN, OnUpdateOffscreen)
-    ON_UPDATE_COMMAND_UI(ID_EDIT_LAYER_BASE, OnUpdateEditLayer)
+#endif
+    EVT_UPDATE_UI(XRCID("ID_EDIT_LAYER_BASE"), OnUpdateEditLayer)
+#if 0
     ON_UPDATE_COMMAND_UI(ID_COLOR_FOREGROUND, OnUpdateColorForeground)
     ON_UPDATE_COMMAND_UI(ID_COLOR_BACKGROUND, OnUpdateColorBackground)
     ON_UPDATE_COMMAND_UI(ID_COLOR_CUSTOM, OnUpdateColorCustom)
     ON_UPDATE_COMMAND_UI(ID_LINE_WIDTH, OnUpdateLineWidth)
     ON_UPDATE_COMMAND_UI(ID_TOOL_ARROW, OnUpdateToolPalette)
     ON_UPDATE_COMMAND_UI(ID_DWG_TOFRONT, OnUpdateDwgToFrontOrBack)
-    ON_UPDATE_COMMAND_UI(ID_VIEW_FULLSCALE, OnUpdateViewFullScale)
-    ON_UPDATE_COMMAND_UI(ID_VIEW_HALFSCALE, OnUpdateViewHalfScale)
+#endif
+    EVT_UPDATE_UI(XRCID("ID_VIEW_FULLSCALE"), OnUpdateViewFullScale)
+    EVT_UPDATE_UI(XRCID("ID_VIEW_HALFSCALE"), OnUpdateViewHalfScale)
+#if 0
     ON_COMMAND(ID_DWG_FONT, OnDwgFont)
-    ON_COMMAND(ID_VIEW_FULLSCALE, OnViewFullScale)
-    ON_COMMAND(ID_VIEW_HALFSCALE, OnViewHalfScale)
-    ON_COMMAND(ID_VIEW_SMALLSCALE, OnViewSmallScale)
-    ON_UPDATE_COMMAND_UI(ID_VIEW_SMALLSCALE, OnUpdateViewSmallScale)
+#endif
+    EVT_MENU(XRCID("ID_VIEW_FULLSCALE"), OnViewFullScale)
+    EVT_MENU(XRCID("ID_VIEW_HALFSCALE"), OnViewHalfScale)
+    EVT_MENU(XRCID("ID_VIEW_SMALLSCALE"), OnViewSmallScale)
+    EVT_UPDATE_UI(XRCID("ID_VIEW_SMALLSCALE"), OnUpdateViewSmallScale)
+#if 0
     ON_UPDATE_COMMAND_UI(ID_INDICATOR_CELLNUM, OnUpdateIndicatorCellNum)
     ON_COMMAND(ID_TOOLS_BRDSNAPGRID, OnToolsBrdSnapGrid)
     ON_UPDATE_COMMAND_UI(ID_TOOLS_BRDSNAPGRID, OnUpdateToolsBrdSnapGrid)
@@ -111,8 +119,10 @@ wxBEGIN_EVENT_TABLE(CBrdEditView, wxScrolledCanvas)
     ON_WM_SYSKEYDOWN()
     ON_COMMAND(ID_DWG_DRAWABOVEGRID, OnDwgDrawAboveGrid)
     ON_UPDATE_COMMAND_UI(ID_DWG_DRAWABOVEGRID, OnUpdateDwgDrawAboveGrid)
-    ON_COMMAND_EX(ID_EDIT_LAYER_TILE, OnEditLayer)
-    ON_COMMAND_EX(ID_EDIT_LAYER_TOP, OnEditLayer)
+#endif
+    EVT_MENU(XRCID("ID_EDIT_LAYER_TILE"), OnEditLayer)
+    EVT_MENU(XRCID("ID_EDIT_LAYER_TOP"), OnEditLayer)
+#if 0
     ON_COMMAND_EX(ID_TOOL_ERASER, OnToolPalette)
     ON_COMMAND_EX(ID_TOOL_TILE, OnToolPalette)
     ON_COMMAND_EX(ID_TOOL_TEXT, OnToolPalette)
@@ -122,8 +132,10 @@ wxBEGIN_EVENT_TABLE(CBrdEditView, wxScrolledCanvas)
     ON_COMMAND_EX(ID_TOOL_POLYGON, OnToolPalette)
     ON_COMMAND_EX(ID_TOOL_RECT, OnToolPalette)
     ON_COMMAND_EX(ID_TOOL_OVAL, OnToolPalette)
-    ON_UPDATE_COMMAND_UI(ID_EDIT_LAYER_TOP, OnUpdateEditLayer)
-    ON_UPDATE_COMMAND_UI(ID_EDIT_LAYER_TILE, OnUpdateEditLayer)
+#endif
+    EVT_UPDATE_UI(XRCID("ID_EDIT_LAYER_TOP"), OnUpdateEditLayer)
+    EVT_UPDATE_UI(XRCID("ID_EDIT_LAYER_TILE"), OnUpdateEditLayer)
+#if 0
     ON_UPDATE_COMMAND_UI(ID_TOOL_ERASER, OnUpdateToolPalette)
     ON_UPDATE_COMMAND_UI(ID_TOOL_TILE, OnUpdateToolPalette)
     ON_UPDATE_COMMAND_UI(ID_TOOL_TEXT, OnUpdateToolPalette)
@@ -134,8 +146,9 @@ wxBEGIN_EVENT_TABLE(CBrdEditView, wxScrolledCanvas)
     ON_UPDATE_COMMAND_UI(ID_TOOL_RECT, OnUpdateToolPalette)
     ON_UPDATE_COMMAND_UI(ID_TOOL_OVAL, OnUpdateToolPalette)
     ON_UPDATE_COMMAND_UI(ID_DWG_TOBACK, OnUpdateDwgToFrontOrBack)
-    ON_COMMAND(ID_VIEW_TOGGLE_SCALE, OnViewToggleScale)
 #endif
+    EVT_MENU(XRCID("ID_VIEW_TOGGLE_SCALE"), OnViewToggleScale)
+    EVT_UPDATE_UI(XRCID("ID_VIEW_TOGGLE_SCALE"), OnUpdateEnable)
     EVT_SCROLLWIN_LINEDOWN(OnScrollWinLine)
     EVT_SCROLLWIN_LINEUP(OnScrollWinLine)
 wxEND_EVENT_TABLE()
@@ -226,26 +239,24 @@ void CBrdEditView::OnUpdate(CView* pSender, LPARAM lHint, CObject* pHint)
 /////////////////////////////////////////////////////////////////////////////
 // CBrdEditView drawing
 
-#if 0
-void CBrdEditView::OnDraw(CDC* pDC)
+void CBrdEditView::OnDraw(wxDC& pDC)
 {
-    CDC dcMem;
-    CRect oRct;
-    CDC* pDrawDC = pDC;
-    CBitmap* pPrvBMap = nullptr;
+    wxMemoryDC dcMem;
+    wxRect oRct;
+    wxDC* pDrawDC = &pDC;
 
-    pDC->GetClipBox(&oRct);
-    if (oRct.IsRectEmpty())
+    CB_VERIFY(pDC.GetClippingBox(oRct));
+    if (oRct.IsEmpty())
+    {
         return;                 // Nothing to do
+    }
 
     if (m_bOffScreen)
     {
-        OwnerPtr<CBitmap> bmMem = CDib::CreateDIBSection(
-            oRct.Width(), oRct.Height());
-        dcMem.CreateCompatibleDC(pDC);
-        pPrvBMap = dcMem.SelectObject(&*bmMem);
-        dcMem.SetViewportOrg(-oRct.left, -oRct.top);
-        dcMem.SetStretchBltMode(COLORONCOLOR);
+        wxBitmap bmMem = wxBitmap(
+            oRct.GetWidth(), oRct.GetHeight(), pDC);
+        dcMem.SelectObject(bmMem);
+        dcMem.SetDeviceOrigin(-oRct.GetLeft(), -oRct.GetTop());
         pDrawDC = &dcMem;
     }
 
@@ -253,50 +264,52 @@ void CBrdEditView::OnDraw(CDC* pDC)
 
     if (m_bOffScreen)
     {
-        pDC->BitBlt(oRct.left, oRct.top, oRct.Width(), oRct.Height(),
-            &dcMem, oRct.left, oRct.top, SRCCOPY);
-        dcMem.SelectObject(pPrvBMap);
+        pDC.Blit(oRct.GetLeftTop(), oRct.GetSize(),
+            &dcMem, oRct.GetLeftTop(), wxCOPY);
     }
-    wxASSERT(!pDC->IsPrinting());
-    if (!pDC->IsPrinting())
+    wxASSERT(!dynamic_cast<wxPrinterDC*>(&pDC));
+    if (!dynamic_cast<wxPrinterDC*>(&pDC))
     {
-        PrepareScaledDC(*pDC);
-        m_selList.OnDraw(*pDC);
+        PrepareScaledDC(pDC);
+        m_selList.OnDraw(pDC);
     }
 }
 
+#if 0
 BOOL CBrdEditView::OnEraseBkgnd(CDC* pDC)
 {
     return CScrollView::OnEraseBkgnd(pDC);
 }
+#endif
 
 /////////////////////////////////////////////////////////////////////////////
 // Coordinate space mappings
 
-void CBrdEditView::PrepareScaledDC(CDC& pDC) const
+void CBrdEditView::PrepareScaledDC(wxDC& pDC) const
 {
-    CSize wsize, vsize;
+    wxASSERT(m_selList.empty() || !"needs testing");
+    wxSize wsize, vsize;
     m_pBoard->GetBoardArray().GetBoardScaling(m_nZoom, wsize, vsize);
-    pDC.SetMapMode(MM_ANISOTROPIC);
-    pDC.SetWindowExt(wsize);
-    pDC.SetViewportExt(vsize);
+    pDC.SetUserScale(double(vsize.x)/wsize.x, double(vsize.y)/wsize.y);
 }
 
+#if 0
 void CBrdEditView::OnPrepareScaledDC(CDC& pDC)
 {
     OnPrepareDC(&pDC, NULL);
     PrepareScaledDC(pDC);
 }
+#endif
 
-void CBrdEditView::ClientToWorkspace(CPoint& point) const
+void CBrdEditView::ClientToWorkspace(wxPoint& point) const
 {
-    CPoint dpnt = GetDeviceScrollPosition();
-    point += (CSize)dpnt;
-    CSize wsize, vsize;
+    point = CalcUnscrolledPosition(point);
+    wxSize wsize, vsize;
     m_pBoard->GetBoardArray().GetBoardScaling(m_nZoom, wsize, vsize);
     ScalePoint(point, wsize, vsize);
 }
 
+#if 0
 void CBrdEditView::ClientToWorkspace(CRect& rect) const
 {
     CPoint dpnt = GetDeviceScrollPosition();
@@ -305,16 +318,17 @@ void CBrdEditView::ClientToWorkspace(CRect& rect) const
     m_pBoard->GetBoardArray().GetBoardScaling(m_nZoom, wsize, vsize);
     ScaleRect(rect, wsize, vsize);
 }
+#endif
 
-void CBrdEditView::WorkspaceToClient(CPoint& point) const
+void CBrdEditView::WorkspaceToClient(wxPoint& point) const
 {
-    CPoint dpnt = GetDeviceScrollPosition();
-    CSize wsize, vsize;
+    wxSize wsize, vsize;
     m_pBoard->GetBoardArray().GetBoardScaling(m_nZoom, wsize, vsize);
     ScalePoint(point, vsize, wsize);
-    point -= (CSize)dpnt;
+    point = CalcScrolledPosition(point);
 }
 
+#if 0
 void CBrdEditView::WorkspaceToClient(CRect& rect) const
 {
     CPoint dpnt = GetDeviceScrollPosition();
@@ -529,34 +543,45 @@ void CBrdEditView::OnUpdateViewGridLines(CCmdUI* pCmdUI)
 {
     pCmdUI->SetCheck(m_pBoard->GetCellBorder());
 }
+#endif
 
-BOOL CBrdEditView::OnEditLayer(UINT id)
+namespace
+{
+    int IdToLayer(int id)
+    {
+        static const std::map<int, int> map = {
+            { XRCID("ID_EDIT_LAYER_BASE"), LAYER_BASE },
+            { XRCID("ID_EDIT_LAYER_TILE"), LAYER_GRID },
+            { XRCID("ID_EDIT_LAYER_TOP"), LAYER_TOP },
+        };
+        return map.at(id);
+    }
+}
+
+void CBrdEditView::OnEditLayer(wxCommandEvent& event)
 {
     m_nCurToolID = ID_TOOL_ARROW;       // Turn off tool with layer change
     m_nLastToolID = ID_TOOL_ARROW;      // Turn off tool with layer change
     m_selList.PurgeList(TRUE);
 
-    BeginWaitCursor();
-    m_pBoard->SetMaxDrawLayer((int)((UINT)id - ID_EDIT_LAYER_BASE + 1));
-    Invalidate(FALSE);
-    UpdateWindow();
-    EndWaitCursor();
-    return TRUE;
+    wxBusyCursor busyCursor;
+    m_pBoard->SetMaxDrawLayer(IdToLayer(event.GetId()));
+    Refresh(false);
+    Update();
 }
 
-void CBrdEditView::OnUpdateEditLayer(CCmdUI* pCmdUI)
+void CBrdEditView::OnUpdateEditLayer(wxUpdateUIEvent& pCmdUI)
 {
-    // NOTE!!: The control ID's are assumed to be consecutive and
-    // in the same order as the tool codes defined in MAINFRM.CPP
-    pCmdUI->Enable(TRUE);
-    pCmdUI->SetCheck(m_pBoard->GetMaxDrawLayer() == -1 ?
-        pCmdUI->m_nID == ID_EDIT_LAYER_TOP :
-        pCmdUI->m_nID - ID_EDIT_LAYER_BASE + 1 ==
-            (unsigned)m_pBoard->GetMaxDrawLayer());
+    pCmdUI.Enable(TRUE);
+    pCmdUI.Check(m_pBoard->GetMaxDrawLayer() == -1 ?
+        pCmdUI.GetId() == XRCID("ID_EDIT_LAYER_TOP") :
+        IdToLayer(pCmdUI.GetId()) ==
+            m_pBoard->GetMaxDrawLayer());
 }
 
 /////////////////////////////////////////////////////////////////////////////
 
+#if 0
 void CBrdEditView::OnContextMenu(CWnd* pWnd, CPoint point)
 {
     // Make sure window is active.
@@ -1403,75 +1428,73 @@ void CBrdEditView::OnDwgDrawAboveGrid()
         m_selList.SetDObjFlagInAllSelectedObjects(dobjFlgDrawPass2);
     m_selList.InvalidateList(TRUE);
 }
+#endif
 
-void CBrdEditView::CenterViewOnWorkspacePoint(CPoint point)
+void CBrdEditView::CenterViewOnWorkspacePoint(wxPoint point)
 {
     WorkspaceToClient(point);
-    CRect rct;
-    GetClientRect(&rct);
-    CPoint pt = GetMidRect(rct);
-    CSize size = point - pt;
-    CPoint newUpLeft = GetDeviceScrollPosition() + size;
+    wxRect rct = GetClientRect();
+    wxPoint pt = GetMidRect(rct);
+    wxPoint size = point - pt;
+    wxPoint newUpLeft = CalcUnscrolledPosition(size);
     // If the axis being scrolled is entirely visible then set
     // that scroll position to zero.
-    CSize sizeTotal = GetTotalSize();   // Logical is in device units for us
-    if (rct.Width() >= sizeTotal.cx)
+    wxSize sizeTotal = GetVirtualSize();   // Logical is in device units for us
+    if (rct.GetWidth() >= sizeTotal.x)
         newUpLeft.x = 0;
-    if (rct.Height() >= sizeTotal.cy)
+    if (rct.GetHeight() >= sizeTotal.y)
         newUpLeft.y = 0;
-    ScrollToPosition(newUpLeft);
-    UpdateWindow();
+    Scroll(newUpLeft);
+    Update();
 }
 
 void CBrdEditView::DoViewScale(TileScale nZoom)
 {
-    CRect rctClient;
-    GetClientRect(&rctClient);
-    CPoint pntMid = rctClient.CenterPoint();
+    wxRect rctClient = GetClientRect();
+    wxPoint pntMid = GetMidRect(rctClient);
     ClientToWorkspace(pntMid);
 
     m_nZoom = nZoom;
     RecalcScrollLimits();
-    BeginWaitCursor();
-    Invalidate(FALSE);
+    wxBusyCursor busyCursor;
+    Refresh(false);
     CenterViewOnWorkspacePoint(pntMid);
-    EndWaitCursor();
 }
 
-void CBrdEditView::OnViewFullScale()
+void CBrdEditView::OnViewFullScale(wxCommandEvent& /*event*/)
 {
     DoViewScale(fullScale);
 }
 
-void CBrdEditView::OnUpdateViewFullScale(CCmdUI* pCmdUI)
+void CBrdEditView::OnUpdateViewFullScale(wxUpdateUIEvent& pCmdUI)
 {
-    pCmdUI->Enable();
-    pCmdUI->SetCheck(m_nZoom == fullScale);
+    pCmdUI.Enable(true);
+    pCmdUI.Check(m_nZoom == fullScale);
 }
 
-void CBrdEditView::OnViewHalfScale()
+void CBrdEditView::OnViewHalfScale(wxCommandEvent& /*event*/)
 {
     DoViewScale(halfScale);
 }
 
-void CBrdEditView::OnUpdateViewHalfScale(CCmdUI* pCmdUI)
+void CBrdEditView::OnUpdateViewHalfScale(wxUpdateUIEvent& pCmdUI)
 {
-    pCmdUI->Enable();
-    pCmdUI->SetCheck(m_nZoom == halfScale);
+    pCmdUI.Enable(true);
+    pCmdUI.Check(m_nZoom == halfScale);
 }
 
-void CBrdEditView::OnViewSmallScale()
+void CBrdEditView::OnViewSmallScale(wxCommandEvent& /*event*/)
 {
     DoViewScale(smallScale);
 }
 
-void CBrdEditView::OnUpdateViewSmallScale(CCmdUI* pCmdUI)
+void CBrdEditView::OnUpdateViewSmallScale(wxUpdateUIEvent& pCmdUI)
 {
-    pCmdUI->Enable();
-    pCmdUI->SetCheck(m_nZoom == smallScale);
+    pCmdUI.Enable(true);
+    pCmdUI.Check(m_nZoom == smallScale);
 }
 
-void CBrdEditView::OnViewToggleScale()
+void CBrdEditView::OnViewToggleScale(wxCommandEvent& /*event*/)
 {
     if (m_nZoom == fullScale)
          DoViewScale(halfScale);
@@ -1481,6 +1504,12 @@ void CBrdEditView::OnViewToggleScale()
          DoViewScale(fullScale);
 }
 
+void CBrdEditView::OnUpdateEnable(wxUpdateUIEvent& pCmdUI)
+{
+    pCmdUI.Enable(true);
+}
+
+#if 0
 void CBrdEditView::OnUpdateIndicatorCellNum(CCmdUI* pCmdUI)
 {
     CBoardArray& pba = m_pBoard->GetBoardArray();

--- a/GM/VwEdtbrd.h
+++ b/GM/VwEdtbrd.h
@@ -34,7 +34,7 @@
 
 class CBrdEditViewContainer;
 
-class CBrdEditView : public wxScrolledCanvas
+class CBrdEditView : public CB::ProcessEventOverride<wxScrolledCanvas>
 {
 protected: // create from serialization only
     CBrdEditView(CBrdEditViewContainer& p);
@@ -283,9 +283,7 @@ protected:
     void OnUpdateEditPasteBitmapFromFile(wxUpdateUIEvent& pCmdUI);
     void OnEditClear(wxCommandEvent& event);
     void OnUpdateEditClear(wxUpdateUIEvent& pCmdUI);
-#if 0
-    afx_msg void OnContextMenu(CWnd* pWnd, CPoint point);
-#endif
+    void OnContextMenu(wxContextMenuEvent& event);
     void OnEditCopy(wxCommandEvent& event);
     void OnUpdateEditCopy(wxUpdateUIEvent& pCmdUI);
 #if 0
@@ -299,6 +297,12 @@ protected:
     wxDECLARE_EVENT_TABLE();
 
 private:
+    // IGetCmdTarget
+    CCmdTarget& Get() override
+    {
+        return CheckedDeref(AfxGetMainWnd());
+    }
+
     void RecalcScrollLimits();
 
     RefPtr<CBrdEditViewContainer> parent;

--- a/GM/VwEdtbrd.h
+++ b/GM/VwEdtbrd.h
@@ -46,8 +46,8 @@ protected: // create from serialization only
     BOOL        m_bOffScreen;
     TileScale   m_nZoom;
     // --------------- //
-    UINT        m_nCurToolID;   // Current tool ID
-    UINT        m_nLastToolID;  // Previous tool ID
+    int         m_nCurToolID;   // Current tool ID
+    int         m_nLastToolID;  // Previous tool ID
 
 // Attributes
 public:
@@ -95,6 +95,12 @@ public:
     }
 
     void ClientToWorkspace(wxPoint& point) const;
+    [[nodiscard]] wxPoint ClientToWorkspace(const wxPoint& pnt) const
+    {
+        wxPoint retval = pnt;
+        ClientToWorkspace(retval);
+        return retval;
+    }
     void ClientToWorkspace(wxRect& rect) const;
     void WorkspaceToClient(wxPoint& point) const;
     [[nodiscard]] wxPoint WorkspaceToClient(const wxPoint& pnt) const
@@ -104,6 +110,12 @@ public:
         return retval;
     }
     void WorkspaceToClient(wxRect& rect) const;
+    [[nodiscard]] wxRect WorkspaceToClient(const wxRect& rect) const
+    {
+        wxRect retval = rect;
+        WorkspaceToClient(retval);
+        return retval;
+    }
     void InvalidateWorkspaceRect(const wxRect& pRect, BOOL bErase = FALSE);
     wxPoint GetWorkspaceDim() const;
     void OnPrepareScaledDC(wxDC& pDC);
@@ -162,10 +174,10 @@ public:
     void OnUpdate(CView* pSender, LPARAM lHint, CObject* pHint);
 
 protected:
-#if 0
     // ------------ //
-    ToolType MapToolType(UINT nToolResID) const;
+    ToolType MapToolType(int nToolResID) const;
 
+#if 0
     // Nudge and scroll functions
     void HandleKeyDown ();
     void HandleKeyUp ();
@@ -217,39 +229,44 @@ protected:
 #if 0
     //{{AFX_MSG(CBrdEditView)
     afx_msg BOOL OnMouseWheel(UINT nFlags, short zDelta, CPoint pt);
-    afx_msg void OnLButtonDown(UINT nFlags, CPoint point);
-    afx_msg void OnLButtonUp(UINT nFlags, CPoint point);
-    afx_msg void OnMouseMove(UINT nFlags, CPoint point);
-    afx_msg void OnLButtonDblClk(UINT nFlags, CPoint point);
+#endif
+    void OnLButtonDown(wxMouseEvent& event);
+    void OnLButtonUp(wxMouseEvent& event);
+    void OnMouseMove(wxMouseEvent& event);
+    void OnLButtonDblClk(wxMouseEvent& event);
+    void OnMouseCaptureLost(wxMouseCaptureLostEvent& event);
+#if 0
     afx_msg void OnTimer(uintptr_t nIDEvent);
     afx_msg void OnKeyDown(UINT nChar, UINT nRepCnt, UINT nFlags);
     afx_msg void OnChar(UINT nChar, UINT nRepCnt, UINT nFlags);
-    afx_msg BOOL OnSetCursor(CWnd* pWnd, UINT nHitTest, UINT message);
+#endif
+    void OnSetCursor(wxSetCursorEvent& event);
+#if 0
     afx_msg BOOL OnEraseBkgnd(CDC* pDC);
 #endif
     void OnDragTileItem(DragDropEvent& event);
+    void OnSetColor(SetColorEvent& event);
+    void OnSetCustomColors(SetCustomColorEvent& event);
+    void OnSetLineWidth(SetLineWidthEvent& event);
 #if 0
-    afx_msg LRESULT OnSetColor(WPARAM wParam, LPARAM lParam);
-    afx_msg LRESULT OnSetCustomColors(WPARAM wParam, LPARAM lParam);
-    afx_msg LRESULT OnSetLineWidth(WPARAM wParam, LPARAM lParam);
     afx_msg void OnOffscreen();
     afx_msg void OnViewGridLines();
     afx_msg void OnDwgToBack();
     afx_msg void OnDwgToFront();
-    afx_msg BOOL OnToolPalette(UINT id);
 #endif
+    void OnToolPalette(wxCommandEvent& event);
     void OnEditLayer(wxCommandEvent& event);
 #if 0
     afx_msg void OnUpdateViewGridLines(CCmdUI* pCmdUI);
     afx_msg void OnUpdateOffscreen(CCmdUI* pCmdUI);
 #endif
     void OnUpdateEditLayer(wxUpdateUIEvent& pCmdUI);
+    void OnUpdateColorForeground(wxUpdateUIEvent& pCmdUI);
+    void OnUpdateColorBackground(wxUpdateUIEvent& pCmdUI);
+    void OnUpdateColorCustom(wxUpdateUIEvent& pCmdUI);
+    void OnUpdateLineWidth(wxUpdateUIEvent& pCmdUI);
+    void OnUpdateToolPalette(wxUpdateUIEvent& pCmdUI);
 #if 0
-    afx_msg void OnUpdateColorForeground(CCmdUI* pCmdUI);
-    afx_msg void OnUpdateColorBackground(CCmdUI* pCmdUI);
-    afx_msg void OnUpdateColorCustom(CCmdUI* pCmdUI);
-    afx_msg void OnUpdateLineWidth(CCmdUI* pCmdUI);
-    afx_msg void OnUpdateToolPalette(CCmdUI* pCmdUI);
     afx_msg void OnUpdateDwgToFrontOrBack(CCmdUI* pCmdUI);
 #endif
     void OnUpdateViewFullScale(wxUpdateUIEvent& pCmdUI);

--- a/GM/VwEdtbrd.h
+++ b/GM/VwEdtbrd.h
@@ -1,6 +1,6 @@
 // VwEdtbrd.h : interface of the CBrdEditView class
 //
-// Copyright (c) 1994-2020 By Dale L. Larson, All Rights Reserved.
+// Copyright (c) 1994-2024 By Dale L. Larson & William Su, All Rights Reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining
 // a copy of this software and associated documentation files (the
@@ -37,7 +37,8 @@ class CBrdEditView : public CScrollView,
 {
 protected: // create from serialization only
     CBrdEditView();
-    DECLARE_DYNCREATE(CBrdEditView)
+    DECLARE_DYNAMIC(CBrdEditView)
+
 
     void GetCellDrawBounds(CRect &oRct, CRect &oLim);
     void FillMapCells(CDC* pDC, CRect &oLim);
@@ -77,7 +78,7 @@ public:
     void RestoreLastTool() { m_nCurToolID = m_nLastToolID; }
     void ResetToDefaultTool();
 
-    virtual void OnPrepareDC(CDC* pDC, CPrintInfo* pInfo);
+    void OnPrepareDC(CDC* pDC, CPrintInfo* pInfo) override;
     void PrepareScaledDC(CDC *pDC);
 
 // Tools and Selection support
@@ -128,16 +129,16 @@ protected:
     BOOL DoMouseWheelFix(UINT fFlags, short zDelta, CPoint point);
 
 public:
-    virtual ~CBrdEditView();
-    virtual void OnDraw(CDC* pDC);      // overridden to draw this view
+    ~CBrdEditView() override;
+    void OnDraw(CDC* pDC) override;      // overridden to draw this view
 
 #ifdef _DEBUG
-    virtual void AssertValid() const;
-    virtual void Dump(CDumpContext& dc) const;
+    void AssertValid() const override;
+    void Dump(CDumpContext& dc) const override;
 #endif
-    virtual BOOL PreCreateWindow(CREATESTRUCT& cs);
-    virtual void OnInitialUpdate();
-    virtual void OnUpdate(CView* pSender, LPARAM lHint, CObject* pHint);
+    BOOL PreCreateWindow(CREATESTRUCT& cs) override;
+    void OnInitialUpdate() override;
+    void OnUpdate(CView* pSender, LPARAM lHint, CObject* pHint) override;
 
 protected:
     // ------------ //
@@ -250,6 +251,9 @@ protected:
     afx_msg void OnViewToggleScale();
     //}}AFX_MSG
     DECLARE_MESSAGE_MAP()
+
+private:
+    friend class CBrdEditViewContainer;
 };
 
 #ifndef _DEBUG  // debug version in gmview.cpp
@@ -257,3 +261,29 @@ inline CGamDoc* CBrdEditView::GetDocument()
    { return (CGamDoc*) m_pDocument; }
 #endif
 
+class CBrdEditViewContainer : public CView
+{
+public:
+    const CBrdEditView& GetChild() const { return *child; }
+    CBrdEditView& GetChild()
+    {
+        return const_cast<CBrdEditView&>(std::as_const(*this).GetChild());
+    }
+    void OnDraw(CDC* pDC) override;
+
+protected:
+    void OnActivateView(BOOL bActivate,
+                        CView *pActivateView,
+                        CView* pDeactivateView) override;
+
+private:
+    CBrdEditViewContainer();         // used by dynamic creation
+    DECLARE_DYNCREATE(CBrdEditViewContainer)
+
+    afx_msg int OnCreate(LPCREATESTRUCT lpCreateStruct);
+    afx_msg void OnSize(UINT nType, int cx, int cy);
+    DECLARE_MESSAGE_MAP()
+
+    // owned by MFC
+    RefPtr<CBrdEditView> child;
+};

--- a/GM/VwEdtbrd.h
+++ b/GM/VwEdtbrd.h
@@ -133,9 +133,7 @@ public:
     // --- Misc Draw object manipulations
     void DeleteObjsInSelectList(BOOL bInvalidate = TRUE);
     void MoveObjsInSelectList(BOOL bToFront, BOOL bInvalidate = TRUE);
-#if 0
     void NudgeObjsInSelectList(int dX, int dY, BOOL forceScroll = FALSE); //DFM19991014
-#endif
     CDrawList* GetDrawList(BOOL bCanCreateList = TRUE);
 
 // Implementation
@@ -178,16 +176,15 @@ protected:
     // ------------ //
     ToolType MapToolType(int nToolResID) const;
 
-#if 0
     // Nudge and scroll functions
-    void HandleKeyDown ();
-    void HandleKeyUp ();
-    void HandleKeyLeft ();
-    void HandleKeyRight ();
-    void HandleKeyPageUp ();
-    void HandleKeyPageDown ();
-    void HandleKeyTop ();
-    void HandleKeyBottom ();
+    void HandleKeyDown (const wxKeyEvent& event);
+    void HandleKeyUp (const wxKeyEvent& event);
+    void HandleKeyLeft (const wxKeyEvent& event);
+    void HandleKeyRight (const wxKeyEvent& event);
+    void HandleKeyPageUp (const wxKeyEvent& event);
+    void HandleKeyPageDown (const wxKeyEvent& event);
+    void HandleKeyTop (const wxKeyEvent& event);
+    void HandleKeyBottom (const wxKeyEvent& event);
 
     void ScrollDown();
     void ScrollUp();
@@ -223,7 +220,6 @@ protected:
     void PageBottom();
     void PageFarLeft();
     void PageFarRight();
-#endif
 
     // Generated message map functions
 protected:
@@ -237,10 +233,8 @@ protected:
     void OnLButtonDblClk(wxMouseEvent& event);
     void OnMouseCaptureLost(wxMouseCaptureLostEvent& event);
     void OnTimer(wxTimerEvent& event);
-#if 0
-    afx_msg void OnKeyDown(UINT nChar, UINT nRepCnt, UINT nFlags);
-    afx_msg void OnChar(UINT nChar, UINT nRepCnt, UINT nFlags);
-#endif
+    void OnKeyDown(wxKeyEvent& event);
+    void OnChar(wxKeyEvent& event);
     void OnSetCursor(wxSetCursorEvent& event);
 #if 0
     afx_msg BOOL OnEraseBkgnd(CDC* pDC);
@@ -339,6 +333,7 @@ private:
     DECLARE_DYNCREATE(CBrdEditViewContainer)
 
     afx_msg int OnCreate(LPCREATESTRUCT lpCreateStruct);
+    afx_msg void OnSetFocus(CWnd* pOldWnd);
     DECLARE_MESSAGE_MAP()
 
     // IGetEvtHandler

--- a/GM/VwEdtbrd.h
+++ b/GM/VwEdtbrd.h
@@ -94,13 +94,11 @@ public:
     }
 
     void ClientToWorkspace(wxPoint& point) const;
-#if 0
-    void ClientToWorkspace(CRect& rect) const;
-#endif
+    void ClientToWorkspace(wxRect& rect) const;
     void WorkspaceToClient(wxPoint& point) const;
+    void WorkspaceToClient(wxRect& rect) const;
+    void InvalidateWorkspaceRect(const wxRect& pRect, BOOL bErase = FALSE);
 #if 0
-    void WorkspaceToClient(CRect& rect) const;
-    void InvalidateWorkspaceRect(const CRect& pRect, BOOL bErase = FALSE);
     CPoint GetWorkspaceDim() const;
     void OnPrepareScaledDC(CDC& pDC);
 
@@ -112,15 +110,17 @@ public:
 #if 0
     void AddDrawObject(CDrawObj::OwnerPtr pObj);         // Add to active layer
     void DeleteDrawObject(CDrawObj::OwnerPtr pObj);      // Delete from active layer
-    void SelectWithinRect(CRect rctNet, BOOL bInclIntersects = FALSE);
+#endif
+    void SelectWithinRect(wxRect rctNet, BOOL bInclIntersects = FALSE);
+#if 0
     void SelectAllUnderPoint(CPoint point);
 
     // --- Misc Draw object manipulations
     void DeleteObjsInSelectList(BOOL bInvalidate = TRUE);
     void MoveObjsInSelectList(BOOL bToFront, BOOL bInvalidate = TRUE);
     void NudgeObjsInSelectList(int dX, int dY, BOOL forceScroll = FALSE); //DFM19991014
-    CDrawList* GetDrawList(BOOL bCanCreateList = TRUE);
 #endif
+    CDrawList* GetDrawList(BOOL bCanCreateList = TRUE);
 
 // Implementation
 protected:

--- a/GM/VwEdtbrd.h
+++ b/GM/VwEdtbrd.h
@@ -74,7 +74,9 @@ public:
     void SetBoardBackColor(COLORREF cr, BOOL bUpdate);
     void SetDrawingTile(CDrawList& pDwg, TileID tid, CPoint pnt, BOOL bUpdate);
     void DoCreateTextDrawingObject(CPoint point);
+#endif
     void DoEditTextDrawingObject(CText& pDObj);
+#if 0
     void RestoreLastTool() { m_nCurToolID = m_nLastToolID; }
     void ResetToDefaultTool();
 

--- a/GM/VwEdtbrd.h
+++ b/GM/VwEdtbrd.h
@@ -130,10 +130,10 @@ public:
     void SelectWithinRect(wxRect rctNet, BOOL bInclIntersects = FALSE);
     void SelectAllUnderPoint(wxPoint point);
 
-#if 0
     // --- Misc Draw object manipulations
     void DeleteObjsInSelectList(BOOL bInvalidate = TRUE);
     void MoveObjsInSelectList(BOOL bToFront, BOOL bInvalidate = TRUE);
+#if 0
     void NudgeObjsInSelectList(int dX, int dY, BOOL forceScroll = FALSE); //DFM19991014
 #endif
     CDrawList* GetDrawList(BOOL bCanCreateList = TRUE);
@@ -251,14 +251,14 @@ protected:
     void OnSetLineWidth(SetLineWidthEvent& event);
 #if 0
     afx_msg void OnOffscreen();
-    afx_msg void OnViewGridLines();
-    afx_msg void OnDwgToBack();
-    afx_msg void OnDwgToFront();
 #endif
+    void OnViewGridLines(wxCommandEvent& event);
+    void OnDwgToBack(wxCommandEvent& event);
+    void OnDwgToFront(wxCommandEvent& event);
     void OnToolPalette(wxCommandEvent& event);
     void OnEditLayer(wxCommandEvent& event);
+    void OnUpdateViewGridLines(wxUpdateUIEvent& pCmdUI);
 #if 0
-    afx_msg void OnUpdateViewGridLines(CCmdUI* pCmdUI);
     afx_msg void OnUpdateOffscreen(CCmdUI* pCmdUI);
 #endif
     void OnUpdateEditLayer(wxUpdateUIEvent& pCmdUI);
@@ -267,40 +267,38 @@ protected:
     void OnUpdateColorCustom(wxUpdateUIEvent& pCmdUI);
     void OnUpdateLineWidth(wxUpdateUIEvent& pCmdUI);
     void OnUpdateToolPalette(wxUpdateUIEvent& pCmdUI);
-#if 0
-    afx_msg void OnUpdateDwgToFrontOrBack(CCmdUI* pCmdUI);
-#endif
+    void OnUpdateDwgToFrontOrBack(wxUpdateUIEvent& pCmdUI);
     void OnUpdateViewFullScale(wxUpdateUIEvent& pCmdUI);
     void OnUpdateViewHalfScale(wxUpdateUIEvent& pCmdUI);
-#if 0
-    afx_msg void OnDwgFont();
-#endif
+    void OnDwgFont(wxCommandEvent& event);
     void OnViewFullScale(wxCommandEvent& event);
     void OnViewHalfScale(wxCommandEvent& event);
     void OnViewSmallScale(wxCommandEvent& event);
     void OnUpdateViewSmallScale(wxUpdateUIEvent& pCmdUI);
+    void OnUpdateIndicatorCellNum(wxUpdateUIEvent& pCmdUI);
+    void OnToolsBrdSnapGrid(wxCommandEvent& event);
+    void OnUpdateToolsBrdSnapGrid(wxUpdateUIEvent& pCmdUI);
+    void OnToolsBrdProps(wxCommandEvent& event);
+    void OnToolSetVisibleScale(wxCommandEvent& event);
+    void OnUpdateToolSetVisibleScale(wxUpdateUIEvent& pCmdUI);
+    void OnToolSuspendScaleVisibility(wxCommandEvent& event);
+    void OnUpdateToolSuspendScaleVsibility(wxUpdateUIEvent& pCmdUI);
+    void OnEditPaste(wxCommandEvent& event);
+    void OnUpdateEditPaste(wxUpdateUIEvent& pCmdUI);
+    void OnEditPasteBitmapFromFile(wxCommandEvent& event);
+    void OnUpdateEditPasteBitmapFromFile(wxUpdateUIEvent& pCmdUI);
+    void OnEditClear(wxCommandEvent& event);
+    void OnUpdateEditClear(wxUpdateUIEvent& pCmdUI);
 #if 0
-    afx_msg void OnUpdateIndicatorCellNum(CCmdUI* pCmdUI);
-    afx_msg void OnToolsBrdSnapGrid();
-    afx_msg void OnUpdateToolsBrdSnapGrid(CCmdUI* pCmdUI);
-    afx_msg void OnToolsBrdProps();
-    afx_msg void OnToolSetVisibleScale();
-    afx_msg void OnUpdateToolSetVisibleScale(CCmdUI* pCmdUI);
-    afx_msg void OnToolSuspendScaleVisibility();
-    afx_msg void OnUpdateToolSuspendScaleVsibility(CCmdUI* pCmdUI);
-    afx_msg void OnEditPaste();
-    afx_msg void OnUpdateEditPaste(CCmdUI* pCmdUI);
-    afx_msg void OnEditPasteBitmapFromFile();
-    afx_msg void OnUpdateEditPasteBitmapFromFile(CCmdUI* pCmdUI);
-    afx_msg void OnEditClear();
-    afx_msg void OnUpdateEditClear(CCmdUI* pCmdUI);
     afx_msg void OnContextMenu(CWnd* pWnd, CPoint point);
-    afx_msg void OnEditCopy();
-    afx_msg void OnUpdateEditCopy(CCmdUI* pCmdUI);
-    afx_msg void OnSysKeyDown(UINT nChar, UINT nRepCnt, UINT nFlags);
-    afx_msg void OnDwgDrawAboveGrid();
-    afx_msg void OnUpdateDwgDrawAboveGrid(CCmdUI* pCmdUI);
 #endif
+    void OnEditCopy(wxCommandEvent& event);
+    void OnUpdateEditCopy(wxUpdateUIEvent& pCmdUI);
+#if 0
+    afx_msg void OnSysKeyDown(UINT nChar, UINT nRepCnt, UINT nFlags);
+#endif
+    void OnDwgDrawAboveGrid(wxCommandEvent& event);
+    void OnUpdateDwgDrawAboveGrid(wxUpdateUIEvent& pCmdUI);
     void OnViewToggleScale(wxCommandEvent& event);
     void OnUpdateEnable(wxUpdateUIEvent& pCmdUI);
     void OnScrollWinLine(wxScrollWinEvent& event);

--- a/GM/VwEdtbrd.h
+++ b/GM/VwEdtbrd.h
@@ -79,8 +79,8 @@ public:
     void ResetToDefaultTool();
 
     void OnPrepareDC(CDC* pDC, CPrintInfo* pInfo) override;
-    void PrepareScaledDC(CDC& pDC) const;
 #endif
+    void PrepareScaledDC(wxDC& pDC) const;
 
 // Tools and Selection support
 private:
@@ -93,10 +93,12 @@ public:
         return const_cast<CSelList&>(std::as_const(*this).GetSelectList());
     }
 
+    void ClientToWorkspace(wxPoint& point) const;
 #if 0
-    void ClientToWorkspace(CPoint& point) const;
     void ClientToWorkspace(CRect& rect) const;
-    void WorkspaceToClient(CPoint& point) const;
+#endif
+    void WorkspaceToClient(wxPoint& point) const;
+#if 0
     void WorkspaceToClient(CRect& rect) const;
     void InvalidateWorkspaceRect(const CRect& pRect, BOOL bErase = FALSE);
     CPoint GetWorkspaceDim() const;
@@ -133,18 +135,20 @@ protected:
 
     void CreateTextDrawingObject(CPoint pnt, FontID fid, COLORREF crText,
         const CB::string& m_strText, BOOL bInvalidate = TRUE);
+#endif
 
     void DoViewScale(TileScale nZoom);
-    void CenterViewOnWorkspacePoint(CPoint point);
+    void CenterViewOnWorkspacePoint(wxPoint point);
 
+#if 0
     BOOL DoMouseWheelFix(UINT fFlags, short zDelta, CPoint point);
 #endif
 
 public:
     ~CBrdEditView() override;
-#if 0
-    void OnDraw(CDC* pDC) override;      // overridden to draw this view
+    void OnDraw(wxDC& pDC) override;      // overridden to draw this view
 
+#if 0
 #ifdef _DEBUG
     void AssertValid() const override;
     void Dump(CDumpContext& dc) const override;
@@ -230,23 +234,31 @@ protected:
     afx_msg void OnDwgToBack();
     afx_msg void OnDwgToFront();
     afx_msg BOOL OnToolPalette(UINT id);
-    afx_msg BOOL OnEditLayer(UINT id);
+#endif
+    void OnEditLayer(wxCommandEvent& event);
+#if 0
     afx_msg void OnUpdateViewGridLines(CCmdUI* pCmdUI);
     afx_msg void OnUpdateOffscreen(CCmdUI* pCmdUI);
-    afx_msg void OnUpdateEditLayer(CCmdUI* pCmdUI);
+#endif
+    void OnUpdateEditLayer(wxUpdateUIEvent& pCmdUI);
+#if 0
     afx_msg void OnUpdateColorForeground(CCmdUI* pCmdUI);
     afx_msg void OnUpdateColorBackground(CCmdUI* pCmdUI);
     afx_msg void OnUpdateColorCustom(CCmdUI* pCmdUI);
     afx_msg void OnUpdateLineWidth(CCmdUI* pCmdUI);
     afx_msg void OnUpdateToolPalette(CCmdUI* pCmdUI);
     afx_msg void OnUpdateDwgToFrontOrBack(CCmdUI* pCmdUI);
-    afx_msg void OnUpdateViewFullScale(CCmdUI* pCmdUI);
-    afx_msg void OnUpdateViewHalfScale(CCmdUI* pCmdUI);
+#endif
+    void OnUpdateViewFullScale(wxUpdateUIEvent& pCmdUI);
+    void OnUpdateViewHalfScale(wxUpdateUIEvent& pCmdUI);
+#if 0
     afx_msg void OnDwgFont();
-    afx_msg void OnViewFullScale();
-    afx_msg void OnViewHalfScale();
-    afx_msg void OnViewSmallScale();
-    afx_msg void OnUpdateViewSmallScale(CCmdUI* pCmdUI);
+#endif
+    void OnViewFullScale(wxCommandEvent& event);
+    void OnViewHalfScale(wxCommandEvent& event);
+    void OnViewSmallScale(wxCommandEvent& event);
+    void OnUpdateViewSmallScale(wxUpdateUIEvent& pCmdUI);
+#if 0
     afx_msg void OnUpdateIndicatorCellNum(CCmdUI* pCmdUI);
     afx_msg void OnToolsBrdSnapGrid();
     afx_msg void OnUpdateToolsBrdSnapGrid(CCmdUI* pCmdUI);
@@ -267,9 +279,9 @@ protected:
     afx_msg void OnSysKeyDown(UINT nChar, UINT nRepCnt, UINT nFlags);
     afx_msg void OnDwgDrawAboveGrid();
     afx_msg void OnUpdateDwgDrawAboveGrid(CCmdUI* pCmdUI);
-    afx_msg void OnViewToggleScale();
-    //}}AFX_MSG
 #endif
+    void OnViewToggleScale(wxCommandEvent& event);
+    void OnUpdateEnable(wxUpdateUIEvent& pCmdUI);
     void OnScrollWinLine(wxScrollWinEvent& event);
     wxDECLARE_EVENT_TABLE();
 

--- a/GM/VwEdtbrd.h
+++ b/GM/VwEdtbrd.h
@@ -51,6 +51,7 @@ protected: // create from serialization only
 
 // Attributes
 public:
+    wxOverlay& GetOverlay() { return overlay; }
     const CGamDoc& GetDocument() const { return *document; }
     CGamDoc& GetDocument()
     {
@@ -68,18 +69,16 @@ public:
 
 // Operations
 public:
-#if 0
-    void SetCellTile(TileID tid, CPoint pnt, BOOL bUpdate);
-    void SetCellColor(COLORREF crCell, CPoint pnt, BOOL bUpdate);
-    void SetBoardBackColor(COLORREF cr, BOOL bUpdate);
-    void SetDrawingTile(CDrawList& pDwg, TileID tid, CPoint pnt, BOOL bUpdate);
-    void DoCreateTextDrawingObject(CPoint point);
-#endif
+    void SetCellTile(TileID tid, wxPoint pnt, BOOL bUpdate);
+    void SetCellColor(wxColour crCell, wxPoint pnt, BOOL bUpdate);
+    void SetBoardBackColor(wxColour cr, BOOL bUpdate);
+    void SetDrawingTile(CDrawList& pDwg, TileID tid, wxPoint pnt, BOOL bUpdate);
+    void DoCreateTextDrawingObject(wxPoint point);
     void DoEditTextDrawingObject(CText& pDObj);
-#if 0
     void RestoreLastTool() { m_nCurToolID = m_nLastToolID; }
     void ResetToDefaultTool();
 
+#if 0
     void OnPrepareDC(CDC* pDC, CPrintInfo* pInfo) override;
 #endif
     void PrepareScaledDC(wxDC& pDC) const;
@@ -98,25 +97,27 @@ public:
     void ClientToWorkspace(wxPoint& point) const;
     void ClientToWorkspace(wxRect& rect) const;
     void WorkspaceToClient(wxPoint& point) const;
+    [[nodiscard]] wxPoint WorkspaceToClient(const wxPoint& pnt) const
+    {
+        wxPoint retval = pnt;
+        WorkspaceToClient(retval);
+        return retval;
+    }
     void WorkspaceToClient(wxRect& rect) const;
     void InvalidateWorkspaceRect(const wxRect& pRect, BOOL bErase = FALSE);
-#if 0
-    CPoint GetWorkspaceDim() const;
-    void OnPrepareScaledDC(CDC& pDC);
+    wxPoint GetWorkspaceDim() const;
+    void OnPrepareScaledDC(wxDC& pDC);
 
-    void AdjustPoint(CPoint& pnt) const;              // Limit and grid processing
-    void AdjustRect(CRect& rct) const;
-#endif
+    void AdjustPoint(wxPoint& pnt) const;              // Limit and grid processing
+    void AdjustRect(wxRect& rct) const;
 
     CDrawObj* ObjectHitTest(wxPoint point);
-#if 0
     void AddDrawObject(CDrawObj::OwnerPtr pObj);         // Add to active layer
     void DeleteDrawObject(CDrawObj::OwnerPtr pObj);      // Delete from active layer
-#endif
     void SelectWithinRect(wxRect rctNet, BOOL bInclIntersects = FALSE);
-#if 0
-    void SelectAllUnderPoint(CPoint point);
+    void SelectAllUnderPoint(wxPoint point);
 
+#if 0
     // --- Misc Draw object manipulations
     void DeleteObjsInSelectList(BOOL bInvalidate = TRUE);
     void MoveObjsInSelectList(BOOL bToFront, BOOL bInvalidate = TRUE);
@@ -127,17 +128,17 @@ public:
 // Implementation
 protected:
     // Grid and limiting support
-#if 0
     BOOL IsGridizeActive() const;
-    void GridizeX(long& xPos) const;
-    void GridizeY(long& yPos) const;
-    void LimitPoint(POINT& pPnt) const;
-    void LimitRect(RECT& pRct) const;
+    void GridizeX(decltype(wxPoint::x)& xPos) const;
+    void GridizeY(decltype(wxPoint::y)& yPos) const;
+    void LimitPoint(wxPoint& pPnt) const;
+    void LimitRect(wxRect& pRct) const;
+#if 0
     void PixelToWorkspace(CPoint& point) const;
-
-    void CreateTextDrawingObject(CPoint pnt, FontID fid, COLORREF crText,
-        const CB::string& m_strText, BOOL bInvalidate = TRUE);
 #endif
+
+    void CreateTextDrawingObject(wxPoint pnt, FontID fid, wxColour crText,
+        const CB::string& m_strText, BOOL bInvalidate = TRUE);
 
     void DoViewScale(TileScale nZoom);
     void CenterViewOnWorkspacePoint(wxPoint point);
@@ -292,6 +293,7 @@ private:
 
     RefPtr<CBrdEditViewContainer> parent;
     RefPtr<CGamDoc> document;
+    wxOverlay overlay;
 
     /* This view should support scrolling by individual pixels,
         but don't make the line-up and line-down scrolling that

--- a/GM/VwEdtbrd.h
+++ b/GM/VwEdtbrd.h
@@ -51,6 +51,7 @@ protected: // create from serialization only
 
 // Attributes
 public:
+    wxTimer& GetTimer() { return timer; }
     wxOverlay& GetOverlay() { return overlay; }
     const CGamDoc& GetDocument() const { return *document; }
     CGamDoc& GetDocument()
@@ -235,8 +236,8 @@ protected:
     void OnMouseMove(wxMouseEvent& event);
     void OnLButtonDblClk(wxMouseEvent& event);
     void OnMouseCaptureLost(wxMouseCaptureLostEvent& event);
+    void OnTimer(wxTimerEvent& event);
 #if 0
-    afx_msg void OnTimer(uintptr_t nIDEvent);
     afx_msg void OnKeyDown(UINT nChar, UINT nRepCnt, UINT nFlags);
     afx_msg void OnChar(UINT nChar, UINT nRepCnt, UINT nFlags);
 #endif
@@ -310,6 +311,7 @@ private:
 
     RefPtr<CBrdEditViewContainer> parent;
     RefPtr<CGamDoc> document;
+    wxTimer timer;
     wxOverlay overlay;
 
     /* This view should support scrolling by individual pixels,

--- a/GShr/Board.h
+++ b/GShr/Board.h
@@ -99,7 +99,10 @@ public:
 // Operations
 public:
     void DrawBackground(CDC& pDC, const CRect& pDrawRct) const;
+    void DrawBackground(wxDC& pDC, const wxRect& pDrawRct) const;
     static void DrawDrawingList(CDrawList* pDwg, CDC& pDC, const CRect& pDrawRct,
+        TileScale eScale, BOOL bApplyVisible, BOOL bDrawPass2Objects = FALSE);
+    static void DrawDrawingList(CDrawList* pDwg, wxDC& pDC, const wxRect& pDrawRct,
         TileScale eScale, BOOL bApplyVisible, BOOL bDrawPass2Objects = FALSE);
 #ifndef GPLAY
     BOOL PurgeMissingTileIDs();
@@ -107,6 +110,8 @@ public:
 #endif
     // ------- //
     virtual void Draw(CDC& pDC, const CRect& pDrawRct, TileScale eScale,
+        int nApplyVisible = -1);
+    virtual void Draw(wxDC& pDC, const wxRect& pDrawRct, TileScale eScale,
         int nApplyVisible = -1);
     // ------- //
     void Serialize(CArchive& ar);
@@ -181,7 +186,9 @@ public:
 // Operations
 public:
     void DrawCellLines(CDC& pDC, const CRect& pCellRct, TileScale eScale) const;
+    void DrawCellLines(wxDC& pDC, const wxRect& pCellRct, TileScale eScale) const;
     void DrawCells(CDC& pDC, const CRect& pCellRct, TileScale eScale) const;
+    void DrawCells(wxDC& pDC, const wxRect& pCellRct, TileScale eScale) const;
 #ifndef GPLAY
     BOOL PurgeMissingTileIDs();
     BOOL IsTileInUse(TileID tid) const;
@@ -190,6 +197,8 @@ public:
 #endif
     // ------- //
     virtual void Draw(CDC& pDC, const CRect& pDrawRct, TileScale eScale,
+        int nCellBorder = -1, int nApplyVisible = -1);// -1 means use internal
+    virtual void Draw(wxDC& pDC, const wxRect& pDrawRct, TileScale eScale,
         int nCellBorder = -1, int nApplyVisible = -1);// -1 means use internal
     // ------- //
     void Serialize(CArchive& ar);

--- a/GShr/BrdCell.h
+++ b/GShr/BrdCell.h
@@ -1,6 +1,6 @@
 // BrdCell.h
 //
-// Copyright (c) 1994-2020 By Dale L. Larson, All Rights Reserved.
+// Copyright (c) 1994-2024 By Dale L. Larson & William Su, All Rights Reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining
 // a copy of this software and associated documentation files (the
@@ -138,9 +138,13 @@ public:
         CellStagger nStagger, CCellForm& cfFull, CCellForm& cfHalf, CCellForm& cfSmall);
     // ------- //
     void DrawCells(CDC& pDC, const CRect& pCellRct, TileScale eScale) const;
+    void DrawCells(wxDC& pDC, const wxRect& pCellRct, TileScale eScale) const;
     void DrawCellLines(CDC& pDC, const CRect& pCellRct, TileScale eScale) const;
+    void DrawCellLines(wxDC& pDC, const wxRect& pCellRct, TileScale eScale) const;
     void FillCell(CDC& pDC, size_t row, size_t col, TileScale eScale) const;
+    void FillCell(wxDC& pDC, size_t row, size_t col, TileScale eScale) const;
     void FrameCell(CDC& pDC, size_t row, size_t col, TileScale eScale) const;
+    void FrameCell(wxDC& pDC, size_t row, size_t col, TileScale eScale) const;
     // ------- //
     void SetCellTile(size_t row, size_t col, TileID tid);
     void SetCellColor(size_t row, size_t col, COLORREF cr);
@@ -148,10 +152,26 @@ public:
         size_t colEnd, COLORREF cr);
     // ------- //
     void GetBoardScaling(TileScale eScale, CSize& worldsize, CSize& viewSize) const;
+    void GetBoardScaling(TileScale eScale, wxSize& worldsize, wxSize& viewSize) const
+    {
+        CSize w, v;
+        GetBoardScaling(eScale, w, v);
+        worldsize = CB::Convert(w);
+        viewSize = CB::Convert(v);
+    }
     BOOL FindCell(long x, long y, size_t& rRow, size_t& rCol, TileScale eScale) const;
     CRect GetCellRect(size_t row, size_t col, TileScale eScale) const;
     BOOL MapPixelsToCellBounds(const CRect& pPxlRct, CRect& pCellRct,
         TileScale eScale) const;
+    BOOL MapPixelsToCellBounds(const wxRect& pPxlRct, wxRect& pCellRct,
+        TileScale eScale) const
+    {
+        CRect in = CB::Convert(pPxlRct);
+        CRect out;
+        BOOL rc = MapPixelsToCellBounds(in, out, eScale);
+        pCellRct = CB::Convert(out);
+        return rc;
+    }
     // ------- //
     BOOL PurgeMissingTileIDs();
     BOOL IsTileInUse(TileID tid) const;
@@ -182,6 +202,7 @@ protected:
     std::vector<BoardCell> m_pMap;
     // -------- //
     CPen    m_pnCellFrame;      // Cell frame color pen.
+    wxPen   m_pnCellFrameWx;    // Cell frame color pen.
     // -------- //
     RefPtr<CTileManager> m_pTsa;
     // -------- //

--- a/GShr/CellForm.cpp
+++ b/GShr/CellForm.cpp
@@ -329,6 +329,14 @@ void CCellForm::FrameCell(CDC& pDC, int xPos, int yPos) const
     pDC.Polyline(m_pWrk.data(), value_preserving_cast<int>(m_pWrk.size()));
 }
 
+void CCellForm::FrameCell(wxDC& pDC, int xPos, int yPos) const
+{
+    m_pWrk = m_pPoly;
+    OffsetPoly(m_pWrk, xPos, yPos);
+    std::vector<wxPoint> pts = CB::Convert(m_pWrk);
+    pDC.DrawLines(value_preserving_cast<int>(pts.size()), pts.data());
+}
+
 void CCellForm::FillCell(CDC& pDC, int xPos, int yPos) const
 {
     CPen* pPrvPen = (CPen *)pDC.SelectStockObject(NULL_PEN);
@@ -347,6 +355,28 @@ void CCellForm::FillCell(CDC& pDC, int xPos, int yPos) const
         m_pWrk = m_pPoly;
         OffsetPoly(m_pWrk, xPos, yPos);
         pDC.Polygon(m_pWrk.data(), value_preserving_cast<int>(m_pWrk.size()));
+    }
+}
+
+void CCellForm::FillCell(wxDC& pDC, int xPos, int yPos) const
+{
+    wxDCPenChanger setPen(pDC, *wxTRANSPARENT_PEN);
+    if (m_eType == cformRect || m_eType == cformBrickHorz ||
+        m_eType == cformBrickVert)
+    {
+        wxRect rct = CB::Convert(m_rct);
+        rct.Offset(xPos, yPos);
+        rct.SetWidth(rct.GetWidth() + 1);            // Adjust to include start of next rect
+        rct.SetHeight(rct.GetHeight() + 1);
+        pDC.DrawRectangle(rct);
+    }
+    else
+    {
+        // Hexagonal shapes
+        m_pWrk = m_pPoly;
+        OffsetPoly(m_pWrk, xPos, yPos);
+        std::vector<wxPoint> pts = CB::Convert(m_pWrk);
+        pDC.DrawPolygon(value_preserving_cast<int>(pts.size()), pts.data());
     }
 }
 

--- a/GShr/CellForm.h
+++ b/GShr/CellForm.h
@@ -152,7 +152,9 @@ public:
         CellStagger nStagger = CellStagger::Invalid);
     void FindCell(long x, long y, CB::ssize_t& row, CB::ssize_t& col) const;
     void FillCell(CDC& pDC, int xPos, int yPos) const;
+    void FillCell(wxDC& pDC, int xPos, int yPos) const;
     void FrameCell(CDC& pDC, int xPos, int yPos) const;
+    void FrameCell(wxDC& pDC, int xPos, int yPos) const;
     CSize CalcBoardSize(size_t nRows, size_t nCols) const;
     BOOL CalcTrialBoardSize(size_t nRows, size_t nCols) const;
 

--- a/GShr/CyberBoard.h
+++ b/GShr/CyberBoard.h
@@ -72,6 +72,7 @@
 #include <wx/dc.h>
 #include <wx/dcclient.h>
 #include <wx/dcmemory.h>
+#include "wx/dcprint.h"
 #include <wx/dialog.h>
 #include <wx/fontdlg.h>
 #include <wx/fontutil.h>
@@ -2258,6 +2259,101 @@ namespace CB
                 return RelayProcessEvent(*this, event);
             }
         }
+    };
+}
+
+namespace CB
+{
+    class DCUserScaleChanger
+    {
+    public:
+        DCUserScaleChanger() = default;
+        DCUserScaleChanger(wxDC& d, double xScale, double yScale) :
+            dc(&d)
+        {
+            dc->GetUserScale(&oldXScale, &oldYScale);
+            dc->SetUserScale(xScale, yScale);
+        }
+        DCUserScaleChanger(const DCUserScaleChanger&) = delete;
+        DCUserScaleChanger(DCUserScaleChanger&& other) noexcept
+        {
+            *this = std::move(other);
+        }
+        DCUserScaleChanger& operator=(const DCUserScaleChanger&) = delete;
+        DCUserScaleChanger& operator=(DCUserScaleChanger&& other) noexcept
+        {
+            if (this != &other)
+            {
+                Reset();
+                dc = other.dc;
+                other.dc = nullptr;
+                oldXScale = other.oldXScale;
+                oldYScale = other.oldYScale;
+            }
+            return *this;
+        }
+        ~DCUserScaleChanger()
+        {
+            Reset();
+        }
+
+    private:
+        void Reset()
+        {
+            if (dc)
+            {
+                dc->SetUserScale(oldXScale, oldYScale);
+            }
+        }
+
+        wxDC* dc = nullptr;
+        double oldXScale;
+        double oldYScale;
+    };
+
+    class DCLogicalFunctionChanger
+    {
+    public:
+        DCLogicalFunctionChanger() = default;
+        DCLogicalFunctionChanger(wxDC& d, wxRasterOperationMode rop) :
+            dc(&d)
+        {
+            oldRop = dc->GetLogicalFunction();
+            dc->SetLogicalFunction(rop);
+        }
+        DCLogicalFunctionChanger(const DCLogicalFunctionChanger&) = delete;
+        DCLogicalFunctionChanger(DCLogicalFunctionChanger&& other) noexcept
+        {
+            *this = std::move(other);
+        }
+        DCLogicalFunctionChanger& operator=(const DCLogicalFunctionChanger&) = delete;
+        DCLogicalFunctionChanger& operator=(DCLogicalFunctionChanger&& other) noexcept
+        {
+            if (this != &other)
+            {
+                Reset();
+                dc = other.dc;
+                other.dc = nullptr;
+                oldRop = other.oldRop;
+            }
+            return *this;
+        }
+        ~DCLogicalFunctionChanger()
+        {
+            Reset();
+        }
+
+    private:
+        void Reset()
+        {
+            if (dc)
+            {
+                dc->SetLogicalFunction(oldRop);
+            }
+        }
+
+        wxDC* dc = nullptr;
+        wxRasterOperationMode oldRop;
     };
 }
 #endif

--- a/GShr/CyberBoard.h
+++ b/GShr/CyberBoard.h
@@ -2390,4 +2390,16 @@ namespace CB
 {
     int GetMouseButtons(const wxMouseState& event);
 }
+
+// replacement for wxDC::DrawEllipse()
+namespace CB
+{
+    /* KLUDGE:  size - 1 due to
+                https://groups.google.com/g/wx-dev/c/0HZLlbTB6do/m/JMQy61LqAQAJ */
+    inline void DrawEllipse(wxDC& dc, const wxRect& rect)
+    {
+        wxRect temp(rect.GetLeftTop(), wxSize(rect.GetWidth() - 1, rect.GetHeight() - 1));
+        dc.DrawEllipse(temp);
+    }
+}
 #endif

--- a/GShr/CyberBoard.h
+++ b/GShr/CyberBoard.h
@@ -344,6 +344,27 @@ public:
     }
 };
 
+template<typename CharT>
+struct std::formatter<wxColour, CharT> : private std::formatter<decltype(std::declval<wxColour>().Red()), CharT>
+{
+private:
+    using BASE = formatter<decltype(std::declval<wxColour>().Red()), CharT>;
+public:
+    using BASE::parse;
+
+    template<typename FormatContext>
+    FormatContext::iterator format(const wxColour& c, FormatContext& ctx) const
+    {
+        std::format_to(ctx.out(), "RGB(");
+        BASE::format(c.Red(), ctx);
+        std::format_to(ctx.out(), ",");
+        BASE::format(c.Green(), ctx);
+        std::format_to(ctx.out(), ",");
+        BASE::format(c.Blue(), ctx);
+        return std::format_to(ctx.out(), ")");
+    }
+};
+
 /////////////////////////////////////////////////////////////////////////////
 
 // emulate c++20 std::remove_cvref_t

--- a/GShr/CyberBoard.h
+++ b/GShr/CyberBoard.h
@@ -2073,6 +2073,17 @@ namespace CB
         return CRect(r.GetLeft(), r.GetTop(), r.GetRight() + 1, r.GetBottom() + 1);
     }
 
+    inline std::vector<POINT> Convert(const std::vector<wxPoint>& v)
+    {
+        std::vector<POINT> retval;
+        retval.reserve(v.size());
+        for (const wxPoint& p : v)
+        {
+            retval.emplace_back(CB::Convert(p));
+        }
+        return retval;
+    }
+
     inline std::vector<wxPoint> Convert(const std::vector<POINT>& v)
     {
         std::vector<wxPoint> retval;
@@ -2093,6 +2104,17 @@ namespace CB
         wxRect rctClip;
         dc.GetClippingBox(rctClip);
         return rctClip.Intersects(r);
+    }
+
+    inline void Normalize(wxRect& rect)
+    {
+        typedef decltype(std::declval<wxRect>().GetLeft()) Coord;
+        Coord x1 = rect.GetLeft();
+        Coord x2 = rect.GetRight() + 1;
+        Coord y1 = rect.GetTop();
+        Coord y2 = rect.GetBottom() + 1;
+        rect = wxRect(wxPoint(std::min(x1, x2), std::min(y1, y2)),
+                        wxSize(abs(x2 - x1), abs(y2 - y1)));
     }
 
     class ToolTip : private wxTimer
@@ -2178,6 +2200,12 @@ namespace CB
         State state = sNoTool;
 
     };
+
+    /* emulate CRect::Inflate() and CRect::Normalize() sequence
+        because (contrary to MFC) wxRect::Inflate() doesn't
+        allow negative size, so there's no way to normalize
+        the Inflate() result */
+    void InflateAndNormalize(wxRect& rect, int dx, int dy);
 }
 
 // use these to translate and relay MFC messages to a wx target
@@ -2355,5 +2383,11 @@ namespace CB
         wxDC* dc = nullptr;
         wxRasterOperationMode oldRop;
     };
+}
+
+// provide wxMouseState equivalent of wxKeyboardState::GetModifiers()
+namespace CB
+{
+    int GetMouseButtons(const wxMouseState& event);
 }
 #endif

--- a/GShr/CyberBoard.h
+++ b/GShr/CyberBoard.h
@@ -80,6 +80,7 @@
 #include "wx/menu.h"
 #include <wx/msgdlg.h>
 #include <wx/nativewin.h>
+#include <wx/overlay.h>
 #include <wx/radiobut.h>
 #include <wx/rawbmp.h>
 #include <wx/stattext.h>

--- a/GShr/DrawObj.h
+++ b/GShr/DrawObj.h
@@ -105,6 +105,7 @@ public:
     virtual void SetRect(const CRect& rct) /* override */ = 0;
 
     virtual CRect GetEnclosingRect() const /* override */ { return GetRect(); }
+    // non-const due to CBitmapImage::Draw()
     virtual BOOL HitTest(CPoint pt) /* override */ { return FALSE; }
 #ifdef GPLAY
     virtual ObjectID GetObjectID() const /* override */;
@@ -128,6 +129,7 @@ public:
 
 // Operations
 public:
+    // non-const due to CBitmapImage::Draw()
     virtual void Draw(CDC& pDC, TileScale eScale) /* override */ = 0;
     // Support required by selection objects
 #ifdef GPLAY
@@ -1073,6 +1075,7 @@ public:
     void Draw(CDC& pDC, const CRect& pDrawRct, TileScale eScale,
         BOOL bApplyVisibility = TRUE, BOOL bDrawPass2Objects = FALSE,
         BOOL bHideUnlocked = FALSE, BOOL bDrawLockedFirst = FALSE);
+    // non-const due to CBitmapImage::Draw()
     CDrawObj* HitTest(CPoint pt, TileScale eScale = (TileScale)AllTileScales,
         BOOL bApplyVisibility = TRUE);
     void DrillDownHitTest(CPoint point, std::vector<CB::not_null<CDrawObj*>>& selLst,

--- a/GShr/DrawObj.h
+++ b/GShr/DrawObj.h
@@ -689,9 +689,19 @@ public:
     UINT     m_nLineWidth;
 
     void SetLine(int xBeg, int yBeg, int xEnd, int yEnd);
-    void GetLine(CRect& rct)
+    void GetLine(CRect& rct) const
         { rct.left =m_ptBeg.x; rct.top = m_ptBeg.y;
             rct.right = m_ptEnd.x; rct.bottom = m_ptEnd.y; }
+    wxRect GetLine() const
+    {
+        wxRect retval(wxPoint(m_ptBeg.x, m_ptBeg.y),
+                        wxSize(m_ptEnd.x - m_ptBeg.x, m_ptEnd.y - m_ptBeg.y));
+        CRect check;
+        GetLine(check);
+        wxASSERT(retval == CB::Convert(check));
+        return retval;
+    }
+
     void GetLine(long& xBeg, long& yBeg, long& xEnd, long& yEnd)
         { xBeg = m_ptBeg.x; yBeg = m_ptBeg.y; xEnd = m_ptEnd.x; yEnd = m_ptEnd.y; }
     void GetLine(POINT& ptBeg, POINT& ptEnd)

--- a/GShr/DrawObj.h
+++ b/GShr/DrawObj.h
@@ -1,6 +1,6 @@
 // DrawObj.h
 //
-// Copyright (c) 1994-2023 By Dale L. Larson & William Su, All Rights Reserved.
+// Copyright (c) 1994-2024 By Dale L. Larson & William Su, All Rights Reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining
 // a copy of this software and associated documentation files (the
@@ -131,6 +131,7 @@ public:
 public:
     // non-const due to CBitmapImage::Draw()
     virtual void Draw(CDC& pDC, TileScale eScale) /* override */ = 0;
+    virtual void Draw(wxDC& pDC, TileScale eScale) /* override */ = 0;
     // Support required by selection objects
 #ifdef GPLAY
     virtual ::OwnerPtr<CSelection> CreateSelectProxy(CPlayBoardView& pView) /* override */ { AfxThrowInvalidArgException(); }
@@ -154,6 +155,12 @@ protected:
     BOOL IsExtentOutOfZone(const CRect& pRctZone, CPoint& pntOffset) const;
     // ------- //
     virtual void SetUpDraw(CDC& pDC, CPen& pPen, CBrush& pBrush) const /* override */;
+    struct SetUpDrawResult
+    {
+        wxDCPenChanger setPen;
+        wxDCBrushChanger setBrush;
+    };
+    virtual SetUpDrawResult SetUpDraw(wxDC& pDC) const /* override */;
     virtual void CleanUpDraw(CDC& pDC) const /* override */;
     virtual BOOL BitBlockHitTest(CPoint pt) /* override */;
     virtual UINT GetLineWidth() const /* override */ { return 0; }
@@ -616,6 +623,7 @@ public:
 // Operations
 public:
     virtual void Draw(CDC& pDC, TileScale eScale) override;
+    virtual void Draw(wxDC& pDC, TileScale eScale) override;
 
     // Support required by selection processing.
     virtual BOOL HitTest(CPoint pt) override;
@@ -658,6 +666,7 @@ public:
 // Operations
 public:
     virtual void Draw(CDC& pDC, TileScale eScale) override;
+    virtual void Draw(wxDC& pDC, TileScale eScale) override;
 #ifndef GPLAY
     virtual ::OwnerPtr<CSelection> CreateSelectProxy(CBrdEditView& pView) override;
 #endif
@@ -698,6 +707,7 @@ public:
 // Operations
 public:
     virtual void Draw(CDC& pDC, TileScale eScale) override;
+    virtual void Draw(wxDC& pDC, TileScale eScale) override;
     // Support required by selection processing.
     virtual BOOL HitTest(CPoint pt) override;
 #ifdef GPLAY
@@ -757,6 +767,7 @@ public:
 // Overrides
 public:
     virtual void Draw(CDC& pDC, TileScale eScale) override;
+    virtual void Draw(wxDC& pDC, TileScale eScale) override;
 
     // Support required by selection processing.
     virtual BOOL HitTest(CPoint pt) override;
@@ -811,6 +822,7 @@ public:
 // Operations
 public:
     virtual void Draw(CDC& pDC, TileScale eScale) override;
+    virtual void Draw(wxDC& pDC, TileScale eScale) override;
     // Support required by selection processing.
     virtual BOOL HitTest(CPoint pt) override;
 #ifndef GPLAY
@@ -853,6 +865,7 @@ public:
 public:
 
     virtual void Draw(CDC& pDC, TileScale eScale) override;
+    virtual void Draw(wxDC& pDC, TileScale eScale) override;
     // Support required by selection processing.
     virtual BOOL HitTest(CPoint pt) override;
 #ifndef GPLAY
@@ -873,6 +886,14 @@ public:
 
 protected:
     void SynchronizeExtentRect(CSize sizeWorld, CSize sizeView);
+    void SynchronizeExtentRect(const wxDC& dc)
+    {
+        double xScale, yScale;
+        dc.GetUserScale(&xScale, &yScale);
+        wxSize sizeWorld(10000, 10000);
+        wxSize sizeView(static_cast<int>(10000 * xScale), static_cast<int>(10000 * yScale));
+        SynchronizeExtentRect(CB::Convert(sizeWorld), CB::Convert(sizeView));
+    }
 };
 
 ///////////////////////////////////////////////////////////////////////
@@ -893,6 +914,7 @@ public:
 // Operations
 public:
     virtual void Draw(CDC& pDC, TileScale eScale) override;
+    virtual void Draw(wxDC& pDC, TileScale eScale) override;
     // Support required by selection processing.
     virtual BOOL HitTest(CPoint pt) override;
 #ifndef GPLAY
@@ -952,6 +974,7 @@ private:
 
 public:
     virtual void Draw(CDC& pDC, TileScale eScale) override;
+    virtual void Draw(wxDC& pDC, TileScale eScale) override;
     // Support required by selection processing.
     virtual BOOL HitTest(CPoint pt) override;
     virtual ::OwnerPtr<CSelection> CreateSelectProxy(CPlayBoardView& pView) override;
@@ -1020,6 +1043,7 @@ public:
     TileID GetCurrentTileID();
     // ------- //
     virtual void Draw(CDC& pDC, TileScale eScale) override;
+    virtual void Draw(wxDC& pDC, TileScale eScale) override;
     // Support required by selection processing.
     virtual BOOL HitTest(CPoint pt) override;
     virtual ::OwnerPtr<CSelection> CreateSelectProxy(CPlayBoardView& pView) override;
@@ -1073,6 +1097,9 @@ public:
     CDrawObj& Front() { return *back(); }
     CDrawObj& Back() { return *front(); }
     void Draw(CDC& pDC, const CRect& pDrawRct, TileScale eScale,
+        BOOL bApplyVisibility = TRUE, BOOL bDrawPass2Objects = FALSE,
+        BOOL bHideUnlocked = FALSE, BOOL bDrawLockedFirst = FALSE);
+    void Draw(wxDC& pDC, const wxRect& pDrawRct, TileScale eScale,
         BOOL bApplyVisibility = TRUE, BOOL bDrawPass2Objects = FALSE,
         BOOL bHideUnlocked = FALSE, BOOL bDrawLockedFirst = FALSE);
     // non-const due to CBitmapImage::Draw()

--- a/GShr/GMisc.h
+++ b/GShr/GMisc.h
@@ -1,6 +1,6 @@
 // GMisc.h
 //
-// Copyright (c) 1994-2023 By Dale L. Larson & William Su, All Rights Reserved.
+// Copyright (c) 1994-2024 By Dale L. Larson & William Su, All Rights Reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining
 // a copy of this software and associated documentation files (the
@@ -63,13 +63,37 @@ std::vector<size_t> AllocateAndCalcRandomIndexVector(size_t nNumIndices, size_t 
 
 inline int MidPnt(int a, int b) { return a+(b-a)/2; }
 CPoint GetMidRect(const CRect& rct);
+inline wxPoint GetMidRect(const wxRect& rct)
+{
+    return CB::Convert(GetMidRect(CB::Convert(rct)));
+}
 CPoint RotatePointAroundPoint(CPoint pntOrigin, CPoint pntXlate, int nAngleDeg);
 
 int32_t GridizeClosest1000(int32_t nVal, int32_t nMultiple, int32_t nOffset);
 int32_t GridizeClosest(int32_t nVal, int32_t nMultiple, int32_t nOffset);
 size_t CalcAllocSize(size_t uiDesired, size_t uiBaseSize, size_t uiExtendSize);
 void ScalePoint(POINT& pnt, const CSize& numSize, const CSize& denSize);
+inline void ScalePoint(wxPoint& pnt, const wxSize& numSize, const wxSize& denSize)
+{
+    CPoint temp = CB::Convert(pnt);
+    ScalePoint(temp, CB::Convert(numSize), CB::Convert(denSize));
+    pnt = CB::Convert(temp);
+}
+inline void ScalePoint(wxPoint& pnt, const wxDC& dc)
+{
+    double xScale, yScale;
+    dc.GetUserScale(&xScale, &yScale);
+    wxSize sizeWorld(10000, 10000);
+    wxSize sizeView(static_cast<int>(10000 * xScale), static_cast<int>(10000 * yScale));
+    ScalePoint(pnt, sizeView, sizeWorld);
+}
 void ScaleRect(RECT& rct, const CSize& numSize, const CSize& denSize);
+inline void ScaleRect(wxRect& rct, const wxSize& numSize, const wxSize& denSize)
+{
+    CRect temp = CB::Convert(rct);
+    ScaleRect(temp, CB::Convert(numSize), CB::Convert(denSize));
+    rct = CB::Convert(temp);
+}
 int NumInWordArray(CWordArray& array, int val);
 WORD GetTimeBasedRandomNumber(BOOL bZeroAllowed = TRUE);
 WORD GetStringBasedRandomNumber(const CB::string& str);

--- a/GShr/LibMfc.cpp
+++ b/GShr/LibMfc.cpp
@@ -1168,6 +1168,12 @@ namespace CB
                         return XRCID("ID_COLOR_CUSTOM");
                     case ID_DWG_FONT:
                         return XRCID("ID_DWG_FONT");
+                    case ID_EDIT_LAYER_BASE:
+                        return XRCID("ID_EDIT_LAYER_BASE");
+                    case ID_EDIT_LAYER_TILE:
+                        return XRCID("ID_EDIT_LAYER_TILE");
+                    case ID_EDIT_LAYER_TOP:
+                        return XRCID("ID_EDIT_LAYER_TOP");
                     case ID_IMAGE_BOARDMASK:
                         return XRCID("ID_IMAGE_BOARDMASK");
                     case ID_IMAGE_GRIDLINES:
@@ -1200,6 +1206,12 @@ namespace CB
                         return XRCID("ID_ITOOL_COLORCHANGE");
                     case ID_LINE_WIDTH:
                         return XRCID("ID_LINE_WIDTH");
+                    case ID_VIEW_FULLSCALE:
+                        return XRCID("ID_VIEW_FULLSCALE");
+                    case ID_VIEW_HALFSCALE:
+                        return XRCID("ID_VIEW_HALFSCALE");
+                    case ID_VIEW_SMALLSCALE:
+                        return XRCID("ID_VIEW_SMALLSCALE");
                     case ID_VIEW_TOGGLE_SCALE:
                         return XRCID("ID_VIEW_TOGGLE_SCALE");
                     case ID_VIEW_ZOOMIN:

--- a/GShr/LibMfc.cpp
+++ b/GShr/LibMfc.cpp
@@ -1145,6 +1145,8 @@ namespace CB
     {
         switch (id)
         {
+            case ID_EDIT_CLEAR:
+                return wxID_CLEAR;
             case ID_EDIT_COPY:
                 return wxID_COPY;
             case ID_EDIT_PASTE:
@@ -1166,14 +1168,22 @@ namespace CB
                         return XRCID("ID_COLOR_TRANSPARENT");
                     case ID_COLOR_CUSTOM:
                         return XRCID("ID_COLOR_CUSTOM");
+                    case ID_DWG_DRAWABOVEGRID:
+                        return XRCID("ID_DWG_DRAWABOVEGRID");
                     case ID_DWG_FONT:
                         return XRCID("ID_DWG_FONT");
+                    case ID_DWG_TOBACK:
+                        return XRCID("ID_DWG_TOBACK");
+                    case ID_DWG_TOFRONT:
+                        return XRCID("ID_DWG_TOFRONT");
                     case ID_EDIT_LAYER_BASE:
                         return XRCID("ID_EDIT_LAYER_BASE");
                     case ID_EDIT_LAYER_TILE:
                         return XRCID("ID_EDIT_LAYER_TILE");
                     case ID_EDIT_LAYER_TOP:
                         return XRCID("ID_EDIT_LAYER_TOP");
+                    case ID_EDIT_PASTEBITMAPFROMFILE:
+                        return XRCID("ID_EDIT_PASTEBITMAPFROMFILE");
                     case ID_IMAGE_BOARDMASK:
                         return XRCID("ID_IMAGE_BOARDMASK");
                     case ID_IMAGE_GRIDLINES:
@@ -1222,12 +1232,22 @@ namespace CB
                         return XRCID("ID_TOOL_POLYGON");
                     case ID_TOOL_RECT:
                         return XRCID("ID_TOOL_RECT");
+                    case ID_TOOL_SETVISIBLESCALE:
+                        return XRCID("ID_TOOL_SETVISIBLESCALE");
+                    case ID_TOOL_SUSPENDSCALEVISIBILITY:
+                        return XRCID("ID_TOOL_SUSPENDSCALEVISIBILITY");
                     case ID_TOOL_TEXT:
                         return XRCID("ID_TOOL_TEXT");
                     case ID_TOOL_TILE:
                         return XRCID("ID_TOOL_TILE");
+                    case ID_TOOLS_BRDPROPS:
+                        return XRCID("ID_TOOLS_BRDPROPS");
+                    case ID_TOOLS_BRDSNAPGRID:
+                        return XRCID("ID_TOOLS_BRDSNAPGRID");
                     case ID_VIEW_FULLSCALE:
                         return XRCID("ID_VIEW_FULLSCALE");
+                    case ID_VIEW_GRIDLINES:
+                        return XRCID("ID_VIEW_GRIDLINES");
                     case ID_VIEW_HALFSCALE:
                         return XRCID("ID_VIEW_HALFSCALE");
                     case ID_VIEW_SMALLSCALE:
@@ -1261,7 +1281,11 @@ BOOL CB::RelayOnCmdMsg(wxEvtHandler& dest,
                 not possible in wx
                 (see https://groups.google.com/g/wx-dev/c/DD9CYFAjbdM/m/ndNP3TZXBgAJ),
                 so approximate this way */
-                CCmdUI dummy;
+                class CDummyCmdUI : public CCmdUI
+                {
+                    void SetCheck(int nCheck = 1) override {}   // 0, 1 or 2 (indeterminate)
+                };
+                CDummyCmdUI dummy;
                 return RelayOnCmdMsg(dest, nID, CN_UPDATE_COMMAND_UI, &dummy, nullptr);
             }
             wxCommandEvent event(wxEVT_MENU, CB::ToWxID(nID));
@@ -1371,8 +1395,12 @@ bool CB::RelayProcessEvent(CCmdTarget& dest,
                         case 1:
                             wxUUIEvent.Check(true);
                             break;
+                        case 2:
+                            wxASSERT(!"untested code");
+                            wxUUIEvent.Set3StateValue(wxCHK_UNDETERMINED);
+                            break;
                         default:
-                            wxASSERT(!"not implemented");
+                            wxASSERT(!"unknown value");
                     }
                 }
                 void SetRadio(BOOL bOn = TRUE) override

--- a/GShr/LibMfc.cpp
+++ b/GShr/LibMfc.cpp
@@ -1206,6 +1206,26 @@ namespace CB
                         return XRCID("ID_ITOOL_COLORCHANGE");
                     case ID_LINE_WIDTH:
                         return XRCID("ID_LINE_WIDTH");
+                    case ID_TOOL_ARROW:
+                        return XRCID("ID_TOOL_ARROW");
+                    case ID_TOOL_DROPPER:
+                        return XRCID("ID_TOOL_DROPPER");
+                    case ID_TOOL_ERASER:
+                        return XRCID("ID_TOOL_ERASER");
+                    case ID_TOOL_FILL:
+                        return XRCID("ID_TOOL_FILL");
+                    case ID_TOOL_LINE:
+                        return XRCID("ID_TOOL_LINE");
+                    case ID_TOOL_OVAL:
+                        return XRCID("ID_TOOL_OVAL");
+                    case ID_TOOL_POLYGON:
+                        return XRCID("ID_TOOL_POLYGON");
+                    case ID_TOOL_RECT:
+                        return XRCID("ID_TOOL_RECT");
+                    case ID_TOOL_TEXT:
+                        return XRCID("ID_TOOL_TEXT");
+                    case ID_TOOL_TILE:
+                        return XRCID("ID_TOOL_TILE");
                     case ID_VIEW_FULLSCALE:
                         return XRCID("ID_VIEW_FULLSCALE");
                     case ID_VIEW_HALFSCALE:

--- a/GShr/LibMfc.cpp
+++ b/GShr/LibMfc.cpp
@@ -1108,6 +1108,37 @@ CB::ToolTip::ToolInfo::ToolInfo(wxWindow& w, std::optional<wxRect>&& r, wxString
 {
 }
 
+void CB::InflateAndNormalize(wxRect& rect, int dx, int dy)
+{
+    if (dx < 0 && abs(2*dx) > rect.GetWidth())
+    {
+        wxASSERT(!"needs testing");
+        /* the sides will move so far that
+            left and right will swap
+        newleft = oldright + dx
+                === oldleft + width + dx
+                === oldleft + -1*-width + -1*-dx
+                === oldleft + -1*(-width + -dx)
+                === oldleft - (-width + -dx)
+                === oldleft - (-width + abs(dx))
+                === oldleft - (abs(dx) - width)
+        newright = oldleft - dx
+                === oldright - width - dx
+                === oldright + (- width - dx)
+                === oldright + (-width + -dx)
+                === oldright + (-width + abs(dx))
+                === oldright + (abs(dx) - width)
+        */
+        dx = abs(dx) - rect.GetWidth();
+    }
+    if (dy < 0 && abs(2*dy) > rect.GetHeight())
+    {
+        wxASSERT(!"needs testing");
+        dy = abs(dy) - rect.GetHeight();
+    }
+    rect.Inflate(dx, dy);
+}
+
 namespace CB
 {
     int ToWxID(int id)
@@ -1332,4 +1363,15 @@ bool CB::RelayProcessEvent(CCmdTarget& dest,
     }
 
     return false;
+}
+
+int CB::GetMouseButtons(const wxMouseState& event)
+{
+    int retval = 0;
+    retval |= event.LeftIsDown() ? wxMOUSE_BTN_LEFT : 0;
+    retval |= event.MiddleIsDown() ? wxMOUSE_BTN_MIDDLE : 0;
+    retval |= event.RightIsDown() ? wxMOUSE_BTN_RIGHT : 0;
+    retval |= event.Aux1IsDown() ? wxMOUSE_BTN_AUX1 : 0;
+    retval |= event.Aux2IsDown() ? wxMOUSE_BTN_AUX2 : 0;
+    return retval;
 }

--- a/GShr/ResTbl.cpp
+++ b/GShr/ResTbl.cpp
@@ -75,6 +75,7 @@ void ResourceTable::LoadCursors(HINSTANCE hInst)
     hcrDropper = LoadCursor(hInst, MAKEINTRESOURCE(IDC_DROPPER));
     hcrDropperWx.SetHCURSOR(reinterpret_cast<WXHCURSOR>(LoadCursor(hInst, MAKEINTRESOURCE(IDC_DROPPER))));
     hcrEraser = LoadCursor(hInst, MAKEINTRESOURCE(IDC_ERASER));
+    hcrEraserWx.SetHCURSOR(reinterpret_cast<WXHCURSOR>(LoadCursor(hInst, MAKEINTRESOURCE(IDC_ERASER))));
     hcrPencil = LoadCursor(hInst, MAKEINTRESOURCE(IDC_PENCIL));
     hcrPencilWx.SetHCURSOR(reinterpret_cast<WXHCURSOR>(LoadCursor(hInst, MAKEINTRESOURCE(IDC_PENCIL))));
     hcrBrush = LoadCursor(hInst, MAKEINTRESOURCE(IDC_BRUSH));

--- a/GShr/ResTbl.h
+++ b/GShr/ResTbl.h
@@ -52,6 +52,7 @@ struct ResourceTable
     HCURSOR     hcrDropper;
     wxCursor    hcrDropperWx;
     HCURSOR     hcrEraser;
+    wxCursor    hcrEraserWx;
     HCURSOR     hcrPencil;
     wxCursor    hcrPencilWx;
     HCURSOR     hcrBrush;

--- a/GShr/Tile.cpp
+++ b/GShr/Tile.cpp
@@ -1,6 +1,6 @@
 // Tile.h
 //
-// Copyright (c) 1994-2020 By Dale L. Larson, All Rights Reserved.
+// Copyright (c) 1994-2024 By Dale L. Larson & William Su, All Rights Reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining
 // a copy of this software and associated documentation files (the
@@ -124,6 +124,33 @@ void CTile::TransBlt(CDC& pDC, int x, int y, const BITMAP* pMaskBMapInfo /* = NU
         CBrush* pPrvBrsh = pDC.SelectObject(&oBrsh);
         pDC.PatBlt(x, y, m_size.cx, m_size.cy, PATCOPY);
         pDC.SelectObject(pPrvBrsh);
+    }
+}
+
+void CTile::TransBlt(wxDC& pDC, int x, int y, const wxBitmap& pMaskBMapInfo) const
+{
+    if (m_pTS != NULL)
+    {
+        if (m_crTrans != noColor)
+        {
+            if (pMaskBMapInfo.IsOk())
+            {
+                m_pTS->TransBltThruDIBSectMonoMask(pDC, x, y, m_yLoc,
+                    CB::Convert(m_crTrans), pMaskBMapInfo);
+            }
+            else
+                m_pTS->TransBlt(pDC, x, y, m_yLoc, CB::Convert(m_crTrans));
+        }
+        else
+            m_pTS->TileBlt(pDC, x, y, m_yLoc, wxCOPY);
+    }
+    else if (m_crTrans != m_crSmall)
+    {
+        // Only draw color patch if not the transparent color.
+        wxBrush oBrsh(CB::Convert(m_crSmall));
+        wxDCPenChanger setPen(pDC, *wxTRANSPARENT_PEN);
+        wxDCBrushChanger setBrush(pDC, oBrsh);
+        pDC.DrawRectangle(wxPoint(x, y), wxSize(m_size.cx, m_size.cy));
     }
 }
 

--- a/GShr/Tile.h
+++ b/GShr/Tile.h
@@ -141,8 +141,11 @@ protected:
     void StretchBlt(CDC& pDC, int xDst, int yDst, int xWid, int yWid,
         int ySrc, DWORD dwRop) const;
     void TransBlt(CDC& pDC, int xDst, int yDst, int ySrc, COLORREF crTrans) const;
+    void TransBlt(wxDC& pDC, int xDst, int yDst, int ySrc, wxColour crTrans) const;
     void TransBltThruDIBSectMonoMask(CDC& pDC, int xDst, int yDst, int ySrc,
         COLORREF crTrans, const BITMAP& pMaskBMapInfo) const;
+    void TransBltThruDIBSectMonoMask(wxDC& pDC, int xDst, int yDst, int ySrc,
+        wxColour crTrans, const wxBitmap& pMaskBMapInfo) const;
 
 // Implementation - vars...
 protected:
@@ -356,6 +359,7 @@ public:
     void BitBlt(wxDC& pDC, wxCoord x, wxCoord y, wxRasterOperationMode dwRop = wxCOPY) const;
     void StretchBlt(CDC& pDC, int x, int y, int cx, int cy, DWORD dwRop = SRCCOPY) const;
     void TransBlt(CDC& pDC, int x, int y, const BITMAP* pMaskBMapInfo = NULL) const;
+    void TransBlt(wxDC& pDC, int x, int y, const wxBitmap& pMaskBMapInfo = wxBitmap()) const;
     OwnerPtr<CBitmap> CreateBitmapOfTile() const;
 
 // Implementation


### PR DESCRIPTION
The MFC doc/view framework is not being replaced yet, but, other than that, convert as much as is feasible of VwEdtbrd from MFC to wxWidgets .