### PR TITLE
reduce unnecessary repaint

### DIFF
--- a/GM/FrmMain.cpp
+++ b/GM/FrmMain.cpp
@@ -122,7 +122,8 @@ static const wxClassInfo *tblBrd[] = {
 CMainFrame::CMainFrame() :
     wxDocParentFrameAny<wxAuiMDIParentFrame>(wxDocManager::GetDocumentManager(),
                                             nullptr, wxID_ANY,
-                                            wxTheApp->GetAppDisplayName())
+                                            wxTheApp->GetAppDisplayName()),
+    CB::FreezeUntilIdleMixin(static_cast<wxWindow&>(*this))
 {
     auiManager.SetManagedWindow(this);
     SetIcon(wxIcon(std::format("#{}", IDR_MAINFRAME)));
@@ -653,6 +654,8 @@ void CMainFrame::OnIdle()
         auiMgrScheduleUpdate = false;
         auiManager.Update();
     }
+
+    CB::FreezeUntilIdleMixin::OnIdle();
 }
 
 namespace {

--- a/GM/FrmMain.h
+++ b/GM/FrmMain.h
@@ -42,7 +42,8 @@
 #include    "frmdocktile.h"
 #endif
 
-class CMainFrame : public wxDocParentFrameAny<CB::wxAuiMDIParentFrame>
+class CMainFrame : public wxDocParentFrameAny<CB::wxAuiMDIParentFrame>,
+                    public CB::FreezeUntilIdleMixin
 {
 public:
     CMainFrame();

--- a/GShr/CyberBoard.h
+++ b/GShr/CyberBoard.h
@@ -2037,6 +2037,9 @@ namespace CB
     public:
         virtual wxWindow& GetWindow() = 0;
 
+        void OnActivateView(bool activate,
+                                ::wxView *activeView,
+                                ::wxView *deactiveView) override;
         void OnDraw(wxDC* dc) override;
 
     protected:
@@ -2070,6 +2073,23 @@ namespace CB
 {
     wxWindow* pGetMainWndWx();
     inline wxWindow& GetMainWndWx() { return CheckedDeref(pGetMainWndWx()); }
+
+    /* call wxWindow::Freeze() to block repaint until after idle
+        processing shows/hides palettes */
+    class FreezeUntilIdleMixin
+    {
+    public:
+        FreezeUntilIdleMixin(wxWindow& inw);
+        // avoid compiler preferring copy ctor to above ctor
+        FreezeUntilIdleMixin(const FreezeUntilIdleMixin&) = delete;
+        void FreezeUntilIdle();
+    protected:
+        void OnIdle();
+    private:
+        wxWindow& w;
+        bool scheduleThaw = false;
+    };
+
     string GetAppName();
 }
 

--- a/GShr/LibMfc.cpp
+++ b/GShr/LibMfc.cpp
@@ -903,6 +903,22 @@ const std::type_info& CB::GetPublicTypeid(const wxWindow& w)
     return mfcWnd ? typeid(*mfcWnd) : typeid(w);
 }
 
+void CB::wxView::OnActivateView(bool activate,
+                        ::wxView *activeView,
+                        ::wxView *deactiveView)
+{
+    if (activate)
+    {
+        wxWindow& mainWnd = GetMainWndWx();
+        CB::FreezeUntilIdleMixin* freezer = dynamic_cast<CB::FreezeUntilIdleMixin*>(&mainWnd);
+        if (freezer)
+        {
+            freezer->FreezeUntilIdle();
+        }
+    }
+    ::wxView::OnActivateView(activate, activeView, deactiveView);
+}
+
 void CB::wxView::OnDraw(wxDC * dc)
 {
     CPP20_TRACE("{}({})\n", __func__, *this);
@@ -1010,6 +1026,29 @@ void CB::wxView::FileHistoryRemoveMenu()
     wxMenu& menuFile = CheckedDeref(menubar.GetMenu(size_t(0)));
     wxDocManager& docMgr = CheckedDeref(wxDocManager::GetDocumentManager());
     docMgr.FileHistoryRemoveMenu(&menuFile);
+}
+
+CB::FreezeUntilIdleMixin::FreezeUntilIdleMixin(wxWindow& inw) :
+    w(inw)
+{
+}
+
+void CB::FreezeUntilIdleMixin::FreezeUntilIdle()
+{
+    if (!scheduleThaw)
+    {
+        w.Freeze();
+        scheduleThaw = true;
+    }
+}
+
+void CB::FreezeUntilIdleMixin::OnIdle()
+{
+    if (scheduleThaw)
+    {
+        w.Thaw();
+        scheduleThaw = false;
+    }
 }
 
 CB::ToolTip::~ToolTip()


### PR DESCRIPTION
wxAUI invalidates windows that changed size when the idle processing shows/hides palettes, so defer painting a newly-activated tab until idle processing has finished with the palettes